### PR TITLE
Character cells count perf

### DIFF
--- a/src/Spectre.Console/Internal/Cell.cs
+++ b/src/Spectre.Console/Internal/Cell.cs
@@ -4,11 +4,14 @@ namespace Spectre.Console
 {
     internal static class Cell
     {
+        private static readonly int?[] _runeWidthCache = new int?[char.MaxValue];
+
         public static int GetCellLength(string text)
         {
             var sum = 0;
-            foreach (var rune in text)
+            for (var index = 0; index < text.Length; index++)
             {
+                var rune = text[index];
                 sum += GetCellLength(rune);
             }
 
@@ -28,7 +31,7 @@ namespace Spectre.Console
                 return 1;
             }
 
-            return UnicodeCalculator.GetWidth(rune);
+            return _runeWidthCache[rune] ??= UnicodeCalculator.GetWidth(rune);
         }
     }
 }


### PR DESCRIPTION
I noticed that we spend a lot of time calculating widths of strings and their rune size. E.g. to render the progress demo, it is over 1,000,000 measurements. This is a proposal to cache those values for quick access.

Because there are a limited number of runes this adds a static array to cache them that we can then just go right to their memory spot without needing to hit WcWidth for these values. Being able to quickly grab these values drops rendering time significantly, especially if we are rendering something repeatably like a progress bar.

# Simple example using the tables demo.

Before
![image](https://user-images.githubusercontent.com/2447331/113515954-9e891c80-9545-11eb-9e0c-7b158900aa59.png)

After
![image](https://user-images.githubusercontent.com/2447331/113515964-a8128480-9545-11eb-9691-1713747904f4.png)


# More Complex

Here's one rendering a tree. Nearly an entire second was spent counting characters

Before
![image](https://user-images.githubusercontent.com/2447331/113516012-f9bb0f00-9545-11eb-948e-9ee3763defb7.png)

After
![image](https://user-images.githubusercontent.com/2447331/113515997-de500400-9545-11eb-956d-b33485dd4e81.png)

# Even More Complex.

Running the progress demo shows even more improvements. shaves 3 seconds off of the millions of calculations we do.

Before
![image](https://user-images.githubusercontent.com/2447331/113516502-98486f80-9548-11eb-871d-73842af6756d.png)

After
![image](https://user-images.githubusercontent.com/2447331/113516526-b0b88a00-9548-11eb-89c3-32d72bf0e5e4.png)

Downside, of course, is we are eating up 65kb to store this data but that's a pretty fair tradeoff. Might make sense to looking at reducing the calls to the method to begin long term.