### PR TITLE
Fix AnsiConsoleBackend.Clear

### DIFF
--- a/src/Spectre.Console.Tests/Unit/AnsiConsoleTests.cs
+++ b/src/Spectre.Console.Tests/Unit/AnsiConsoleTests.cs
@@ -8,8 +8,8 @@ namespace Spectre.Console.Tests.Unit
     public partial class AnsiConsoleTests
     {
         [Theory]
-        [InlineData(false, "Hello[2JWorld")]
-        [InlineData(true, "Hello[2J[0;0HWorld")]
+        [InlineData(false, "Hello[2J[3JWorld")]
+        [InlineData(true, "Hello[2J[3J[1;1HWorld")]
         public void Should_Clear_Screen(bool home, string expected)
         {
             // Given

--- a/src/Spectre.Console/Internal/Backends/Ansi/AnsiConsoleBackend.cs
+++ b/src/Spectre.Console/Internal/Backends/Ansi/AnsiConsoleBackend.cs
@@ -23,10 +23,11 @@ namespace Spectre.Console
         public void Clear(bool home)
         {
             Write(new ControlSequence(ED(2)));
+            Write(new ControlSequence(ED(3)));
 
             if (home)
             {
-                Write(new ControlSequence(CUP(0, 0)));
+                Write(new ControlSequence(CUP(1, 1)));
             }
         }
 


### PR DESCRIPTION
## Add an ED3 command to clear the scroll buffer.

This command is not in the original ANSI terminal control sequences but
was added later to XTerm to account for the fact that most modern
terminals have a scroll-buffer.

https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h4-Functions-using-CSI-_-ordered-by-the-final-character-lparen-s-rparen:CSI-Ps-J.1C8A

This command is now awailable in basically
all terminals with scroll-buffers

## Change CUP coordinates to 1, 1

The coordinates 0, 0 also worked, but strictly speaking they are outside
the available screen area and are capped to 1, 1 anyways.

This commit fixes #337