### PR TITLE
Remove redundant Style constructor.

### DIFF
--- a/src/Spectre.Console/Style.cs
+++ b/src/Spectre.Console/Style.cs
@@ -34,11 +34,6 @@ namespace Spectre.Console
         /// </summary>
         public static Style Plain { get; } = new Style();
 
-        private Style()
-            : this(null, null, null, null)
-        {
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="Style"/> class.
         /// </summary>


### PR DESCRIPTION
Remove the redunant constructor. It doesn't even have aesthetic advantages because it's a private constructor.