### PR TITLE
Marks Spectre.Console.Testing as not a test project

### DIFF
--- a/src/Spectre.Console.Testing/Spectre.Console.Testing.csproj
+++ b/src/Spectre.Console.Testing/Spectre.Console.Testing.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">


### PR DESCRIPTION
Probably something that only bothers me, but I'm in a habit of running `dotnet test` at the solution level. It was discovering this project as a test project even though it isn't. This produces an error complaining about not having a testhost.dll. I'm pretty sure this comes in via a props when xunit is referenced. 

This attribute in the csproj marks the project explicitly as not a test project