### PR TITLE
Removes automatic registration of settings

### DIFF
--- a/src/Spectre.Console.Tests/Unit/Cli/CommandAppTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Cli/CommandAppTests.cs
@@ -358,15 +358,15 @@ namespace Spectre.Console.Tests.Unit.Cli
 
             // Then
             registrar.Registrations.ContainsKey(typeof(ICommand)).ShouldBeTrue();
-            registrar.Registrations.ContainsKey(typeof(DogSettings));
             registrar.Registrations[typeof(ICommand)].ShouldContain(typeof(DogCommand));
         }
 
         [Fact]
-        public void Should_Register_Default_Command_Settings_When_Configuring_Application()
+        public void Can_Register_Default_Command_Settings_When_Configuring_Application()
         {
             // Given
             var registrar = new FakeTypeRegistrar();
+            registrar.Register(typeof(DogSettings), typeof(DogSettings));
             var app = new CommandApp<DogCommand>(registrar);
             app.Configure(config =>
             {
@@ -380,7 +380,7 @@ namespace Spectre.Console.Tests.Unit.Cli
             });
 
             // Then
-            registrar.Registrations.ContainsKey(typeof(DogSettings));
+            registrar.Registrations.ContainsKey(typeof(DogSettings)).ShouldBeTrue();
             registrar.Registrations[typeof(DogSettings)].Count.ShouldBe(1);
             registrar.Registrations[typeof(DogSettings)].ShouldContain(typeof(DogSettings));
         }
@@ -415,10 +415,12 @@ namespace Spectre.Console.Tests.Unit.Cli
         }
 
         [Fact]
-        public void Should_Register_Command_Settings_When_Configuring_Application()
+        public void Can_Register_Command_Settings_When_Configuring_Application()
         {
             // Given
             var registrar = new FakeTypeRegistrar();
+            registrar.Register(typeof(DogSettings), typeof(DogSettings));
+            registrar.Register(typeof(MammalSettings), typeof(MammalSettings));
             var app = new CommandApp(registrar);
             app.Configure(config =>
             {

--- a/src/Spectre.Console/Cli/Internal/Binding/CommandPropertyBinder.cs
+++ b/src/Spectre.Console/Cli/Internal/Binding/CommandPropertyBinder.cs
@@ -25,9 +25,21 @@ namespace Spectre.Console.Cli
 
         private static CommandSettings CreateSettings(ITypeResolver resolver, Type settingsType)
         {
-            if (resolver.Resolve(settingsType) is CommandSettings settings)
+            try
             {
-                return settings;
+                if (resolver.Resolve(settingsType) is CommandSettings settings)
+                {
+                    return settings;
+                }
+            }
+            catch
+            {
+                // ignored
+            }
+
+            if (Activator.CreateInstance(settingsType) is CommandSettings instance)
+            {
+                return instance;
             }
 
             throw CommandParseException.CouldNotCreateSettings(settingsType);

--- a/src/Spectre.Console/Cli/Internal/Extensions/TypeRegistrarExtensions.cs
+++ b/src/Spectre.Console/Cli/Internal/Extensions/TypeRegistrarExtensions.cs
@@ -31,11 +31,6 @@ namespace Spectre.Console.Cli
                     registrar?.Register(command.CommandType, command.CommandType);
                 }
 
-                if (!command.SettingsType.IsAbstract)
-                {
-                    registrar?.Register(command.SettingsType, command.SettingsType);
-                }
-
                 foreach (var parameter in command.Parameters)
                 {
                     var pairDeconstructor = parameter?.PairDeconstructor?.Type;


### PR DESCRIPTION
Original intention was to register Settings automatically for DI. This ran into problem when the container verifies the configuration is valid for a settings using the constructor for initialization. It tries to resolve the parameters and fails.

This removes the automatic registration and falls back ActivatorCreateInstance when no Setting is registered.

Closes #373
