### PR TITLE
Removes printing of error messages when propagating

### DIFF
--- a/src/Spectre.Console.Testing/Cli/CommandAppTester.cs
+++ b/src/Spectre.Console.Testing/Cli/CommandAppTester.cs
@@ -53,6 +53,15 @@ namespace Spectre.Console.Testing
             }
             catch (T ex)
             {
+                if (ex is CommandAppException commandAppException && commandAppException.Pretty != null)
+                {
+                    console.Write(commandAppException.Pretty);
+                }
+                else
+                {
+                    console.WriteLine(ex.Message);
+                }
+
                 return new CommandAppFailure(ex, console.Output);
             }
             catch (Exception ex)

--- a/src/Spectre.Console/Cli/CommandApp.cs
+++ b/src/Spectre.Console/Cli/CommandApp.cs
@@ -90,13 +90,6 @@ namespace Spectre.Console.Cli
             }
             catch (Exception ex)
             {
-                // Render the exception.
-                var pretty = GetRenderableErrorMessage(ex);
-                if (pretty != null)
-                {
-                    _configurator.Settings.Console.SafeRender(pretty);
-                }
-
                 // Should we always propagate when debugging?
                 if (Debugger.IsAttached
                     && ex is CommandAppException appException
@@ -108,6 +101,13 @@ namespace Spectre.Console.Cli
                 if (_configurator.Settings.PropagateExceptions)
                 {
                     throw;
+                }
+
+                // Render the exception.
+                var pretty = GetRenderableErrorMessage(ex);
+                if (pretty != null)
+                {
+                    _configurator.Settings.Console.SafeRender(pretty);
                 }
 
                 return -1;

--- a/src/Spectre.Console/Cli/CommandAppException.cs
+++ b/src/Spectre.Console/Cli/CommandAppException.cs
@@ -8,7 +8,10 @@ namespace Spectre.Console.Cli
     /// </summary>
     public abstract class CommandAppException : Exception
     {
-        internal IRenderable? Pretty { get; }
+        /// <summary>
+        /// Gets the pretty formatted exception message.
+        /// </summary>
+        public IRenderable? Pretty { get; }
 
         internal virtual bool AlwaysPropagateWhenDebugging => false;
 


### PR DESCRIPTION
Per #385 if the user wants to propagate the exception and display the full stack trace on an unhandled exception, we have already printed out an error message ourselves resulting in both being displayed. This moves the printing of the message after the throws.