### PR TITLE
Fix OverflowException when estimating the progress remaining time

### DIFF
--- a/src/Spectre.Console.Tests/Unit/Progress/ProgressTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Progress/ProgressTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Shouldly;
 using Spectre.Console.Testing;
@@ -240,6 +241,31 @@ namespace Spectre.Console.Tests.Unit
                     "[38;5;11m━━[0m[38;5;8m━━━━━━━━[0m\n" + // taskInProgress2
                     "          \n" + // bottom padding
                     "[?25h"); // show cursor
+        }
+
+        [Fact]
+        public void Should_Report_Max_Remaining_Time_For_Extremely_Small_Progress()
+        {
+            // Given
+            var console = new TestConsole()
+                .Interactive();
+
+            var task = default(ProgressTask);
+            var progress = new Progress(console)
+                .Columns(new[] {new RemainingTimeColumn()})
+                .AutoRefresh(false)
+                .AutoClear(false);
+
+            // When
+            progress.Start(ctx =>
+            {
+                task = ctx.AddTask("foo");
+                task.Increment(double.Epsilon);
+                task.Increment(double.Epsilon);
+            });
+
+            // Then
+            task.RemainingTime.ShouldBe(TimeSpan.MaxValue);
         }
     }
 }

--- a/src/Spectre.Console.Tests/Unit/Progress/ProgressTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Progress/ProgressTests.cs
@@ -252,7 +252,7 @@ namespace Spectre.Console.Tests.Unit
 
             var task = default(ProgressTask);
             var progress = new Progress(console)
-                .Columns(new[] {new RemainingTimeColumn()})
+                .Columns(new[] { new RemainingTimeColumn() })
                 .AutoRefresh(false)
                 .AutoClear(false);
 

--- a/src/Spectre.Console/Widgets/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Widgets/Progress/ProgressTask.cs
@@ -286,21 +286,24 @@ namespace Spectre.Console
                 }
 
                 var speed = GetSpeed();
-                if (speed == null)
+                if (speed is null or 0)
                 {
                     return null;
                 }
 
-                // If the speed is zero, the estimate below
-                // will return infinity (since it's a double),
-                // so let's set the speed to 1 in that case.
-                if (speed == 0)
-                {
-                    speed = 1;
-                }
-
+                // If the speed is near zero, the estimate below
+                // will cause the TimeSpan creation to throw an
+                // OverflowException. Just return the maximum
+                // remaining time if it overflows.
                 var estimate = (MaxValue - Value) / speed.Value;
-                return TimeSpan.FromSeconds(estimate);
+                try
+                {
+                    return TimeSpan.FromSeconds(estimate);
+                }
+                catch (OverflowException)
+                {
+                    return TimeSpan.MaxValue;
+                }
             }
         }
 

--- a/src/Spectre.Console/Widgets/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Widgets/Progress/ProgressTask.cs
@@ -286,7 +286,7 @@ namespace Spectre.Console
                 }
 
                 var speed = GetSpeed();
-                if (speed is null or 0)
+                if (speed == null || speed == 0)
                 {
                     return null;
                 }

--- a/src/Spectre.Console/Widgets/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Widgets/Progress/ProgressTask.cs
@@ -291,19 +291,16 @@ namespace Spectre.Console
                     return null;
                 }
 
-                // If the speed is near zero, the estimate below
-                // will cause the TimeSpan creation to throw an
-                // OverflowException. Just return the maximum
-                // remaining time if it overflows.
+                // If the speed is near zero, the estimate below causes the
+                // TimeSpan creation to throw an OverflowException. Just return
+                // the maximum possible remaining time instead of overflowing.
                 var estimate = (MaxValue - Value) / speed.Value;
-                try
-                {
-                    return TimeSpan.FromSeconds(estimate);
-                }
-                catch (OverflowException)
+                if (estimate > TimeSpan.MaxValue.TotalSeconds)
                 {
                     return TimeSpan.MaxValue;
                 }
+
+                return TimeSpan.FromSeconds(estimate);
             }
         }
 


### PR DESCRIPTION
Also add a unit test (Should_Report_Max_Remaining_Time_For_Extremely_Small_Progress) to demonstrate how it could happen and to ensure that `TimeSpan.MaxValue` is used instead of an `OverflowException` being thrown.