### PR TITLE
Wrong method in code example

### DIFF
--- a/docs/input/widgets/calendar.md
+++ b/docs/input/widgets/calendar.md
@@ -58,7 +58,7 @@ You can hide the calendar header.
 
 ```csharp
 var calendar = new Calendar(2020,10);
-calendar.ShowHeader();
+calendar.HideHeader();
 AnsiConsole.Render(calendar);
 ```
 


### PR DESCRIPTION
Wrong method called in the documentation for the Calendar widget.