### PR TITLE
Fixes non-interactive progress bars from rendering little info

### DIFF
--- a/src/Spectre.Console/Widgets/Progress/Renderers/FallbackProgressRenderer.cs
+++ b/src/Spectre.Console/Widgets/Progress/Renderers/FallbackProgressRenderer.cs
@@ -33,7 +33,7 @@ namespace Spectre.Console
                 {
                     if (!task.IsStarted || task.IsFinished)
                     {
-                        return;
+                        continue;
                     }
 
                     hasStartedTasks = true;


### PR DESCRIPTION
If any task was not-started or finishes then everything stops rendering. I suspect this worked ok but wasn't noticed until we introduced the indeterminate progress task that starts off not-started which caused everything to bail early in the demos.