### PR TITLE
Removes inline-block from console output in docs

### DIFF
--- a/docs/input/assets/styles.css
+++ b/docs/input/assets/styles.css
@@ -33647,7 +33647,7 @@ code.language-markup .token.script .token.keyword {
   border-style: solid;
   cursor: text;
   border-width: 0.5em;
-  font-family: 'Cascadia Code PL', 'Cascadia Code', Consolas, Menlo, 'Bitstream Vera Sans Mono', monospace, monospace;
+  font-family: 'Cascadia Code PL', 'Cascadia Code', Consolas, Menlo, 'Bitstream Vera Sans Mono', monospace;
   line-height: 1;
 }
 
@@ -33662,11 +33662,6 @@ code.language-markup .token.script .token.keyword {
   letter-spacing: normal;
   overflow: hidden;
   line-height: 1rem;
-}
-
-.asciinema-terminal .line span {
-  padding: 0;
-  display: inline-block;
 }
 
 .asciinema-terminal .line {

--- a/docs/tailwind.css
+++ b/docs/tailwind.css
@@ -257,10 +257,6 @@ code.language-markup .token.script .token.keyword {
     overflow: hidden;
     line-height: 1rem;
   }
-  .asciinema-terminal .line span {
-    padding: 0;
-    display: inline-block;
-  }
   .asciinema-terminal .line {
     display: block;
   }


### PR DESCRIPTION
This was causing the output to wrap in chrome on ipad and only the ipad. Not quite sure why it was needed in the first place, so it's gone.

Doesn't look like this breaks anything. tested on multiple screens in windows, safari/chrome on ipad, and android. 

![image](https://user-images.githubusercontent.com/2447331/119287444-80ba6880-bc14-11eb-8d5c-c105fcfaa898.png)
