### PR TITLE
Do not use Thread.Sleep in examples when running on CI

### DIFF
--- a/examples/Console/Live/Program.cs
+++ b/examples/Console/Live/Program.cs
@@ -20,7 +20,7 @@ namespace Spectre.Console.Examples
                     {
                         action();
                         ctx.Refresh();
-                        Thread.Sleep(delay);
+                        ThreadSleeper.Sleep(delay);
                     }
 
                     // Columns

--- a/examples/Console/Progress/Program.cs
+++ b/examples/Console/Progress/Program.cs
@@ -45,7 +45,7 @@ namespace Spectre.Console.Examples
                         }
 
                         // Simulate some delay
-                        Thread.Sleep(100);
+                        ThreadSleeper.Sleep(100);
                     }
 
                     // Now start the "warp" task
@@ -56,7 +56,7 @@ namespace Spectre.Console.Examples
                         warpTask.Increment(12 * random.NextDouble());
 
                         // Simulate some delay
-                        Thread.Sleep(100);
+                        ThreadSleeper.Sleep(100);
                     }
                 });
 

--- a/examples/Console/Status/Program.cs
+++ b/examples/Console/Status/Program.cs
@@ -12,29 +12,29 @@ namespace Spectre.Console.Examples
                 .Start("[yellow]Initializing warp drive[/]", ctx =>
                 {
                     // Initialize
-                    Thread.Sleep(3000);
+                    ThreadSleeper.Sleep(3000);
                     WriteLogMessage("Starting gravimetric field displacement manifold");
-                    Thread.Sleep(1000);
+                    ThreadSleeper.Sleep(1000);
                     WriteLogMessage("Warming up deuterium chamber");
-                    Thread.Sleep(2000);
+                    ThreadSleeper.Sleep(2000);
                     WriteLogMessage("Generating antideuterium");
 
                     // Warp nacelles
-                    Thread.Sleep(3000);
+                    ThreadSleeper.Sleep(3000);
                     ctx.Spinner(Spinner.Known.BouncingBar);
                     ctx.Status("[bold blue]Unfolding warp nacelles[/]");
                     WriteLogMessage("Unfolding left warp nacelle");
-                    Thread.Sleep(2000);
+                    ThreadSleeper.Sleep(2000);
                     WriteLogMessage("Left warp nacelle [green]online[/]");
                     WriteLogMessage("Unfolding right warp nacelle");
-                    Thread.Sleep(1000);
+                    ThreadSleeper.Sleep(1000);
                     WriteLogMessage("Right warp nacelle [green]online[/]");
 
                     // Warp bubble
-                    Thread.Sleep(3000);
+                    ThreadSleeper.Sleep(3000);
                     ctx.Spinner(Spinner.Known.Star2);
                     ctx.Status("[bold blue]Generating warp bubble[/]");
-                    Thread.Sleep(3000);
+                    ThreadSleeper.Sleep(3000);
                     ctx.Spinner(Spinner.Known.Star);
                     ctx.Status("[bold blue]Stabilizing warp bubble[/]");
 
@@ -42,18 +42,18 @@ namespace Spectre.Console.Examples
                     ctx.Spinner(Spinner.Known.Monkey);
                     ctx.Status("[bold blue]Performing safety checks[/]");
                     WriteLogMessage("Enabling interior dampening");
-                    Thread.Sleep(2000);
+                    ThreadSleeper.Sleep(2000);
                     WriteLogMessage("Interior dampening [green]enabled[/]");
 
                     // Warp!
-                    Thread.Sleep(3000);
+                    ThreadSleeper.Sleep(3000);
                     ctx.Spinner(Spinner.Known.Moon);
                     WriteLogMessage("Preparing for warp");
-                    Thread.Sleep(1000);
+                    ThreadSleeper.Sleep(1000);
                     for (var warp = 1; warp < 10; warp++)
                     {
                         ctx.Status($"[bold blue]Warp {warp}[/]");
-                        Thread.Sleep(500);
+                        ThreadSleeper.Sleep(500);
                     }
                 });
 

--- a/examples/Shared/ThreadSleeper.cs
+++ b/examples/Shared/ThreadSleeper.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading;
+
+namespace Spectre.Console.Examples
+{
+    public static class ThreadSleeper
+    {
+        private static bool IsInCi = Environment.GetEnvironmentVariable("CI") != null;
+
+        /// <summary>
+        /// Suspends the current thread for timeout milliseconds as long as the environmental variable
+        /// "CI" isn't found.
+        /// </summary>
+        /// <param name="millisecondsTimeout"></param>
+        public static void Sleep(int millisecondsTimeout)
+        {
+            if (IsInCi == false)
+            {
+                Thread.Sleep(millisecondsTimeout);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Wanted to see how fast PR builds would be without the `Thread.Sleep` calls in the examples. Looking for a `CI` environmental variable and if so skipping the `Thread.Sleep`