### PR TITLE
Figlet hardblank update 

### DIFF
--- a/src/Spectre.Console/Widgets/Figlet/FigletFontParser.cs
+++ b/src/Spectre.Console/Widgets/Figlet/FigletFontParser.cs
@@ -40,7 +40,7 @@ namespace Spectre.Console
                     throw new InvalidOperationException("Unknown index for FIGlet character");
                 }
 
-                buffer.Add(line.Replace('$', ' ').ReplaceExact("@", string.Empty));
+                buffer.Add(line.Replace(header.Hardblank, ' ').ReplaceExact("@", string.Empty));
 
                 if (line.EndsWith("@@", StringComparison.Ordinal))
                 {


### PR DESCRIPTION
based on discussion# 417

Hardblank is currently hard-coded as "$". This fixes that.