### PR TITLE
Check for default value before writing property values

### DIFF
--- a/src/Spectre.Console.Tests/Data/Settings/OptionalArgumentWithDefaultValueSettings.cs
+++ b/src/Spectre.Console.Tests/Data/Settings/OptionalArgumentWithDefaultValueSettings.cs
@@ -15,6 +15,12 @@ namespace Spectre.Console.Tests.Data
     {
         [CommandArgument(0, "[NAMES]")]
         public string[] Names { get; set; } = Array.Empty<string>();
+
+        [CommandOption("-c")]
+        public int Count { get; set; } = 1;
+
+        [CommandOption("-v")]
+        public int Value { get; set; } = 0;
     }
 
     public sealed class OptionalArgumentWithDefaultValueAndTypeConverterSettings : CommandSettings

--- a/src/Spectre.Console.Tests/Data/Settings/OptionalArgumentWithDefaultValueSettings.cs
+++ b/src/Spectre.Console.Tests/Data/Settings/OptionalArgumentWithDefaultValueSettings.cs
@@ -1,3 +1,4 @@
+using System;
 using System.ComponentModel;
 using Spectre.Console.Cli;
 
@@ -8,6 +9,12 @@ namespace Spectre.Console.Tests.Data
         [CommandArgument(0, "[GREETING]")]
         [DefaultValue("Hello World")]
         public string Greeting { get; set; }
+    }
+
+    public sealed class OptionalArgumentWithPropertyInitializerSettings : CommandSettings
+    {
+        [CommandArgument(0, "[NAMES]")]
+        public string[] Names { get; set; } = Array.Empty<string>();
     }
 
     public sealed class OptionalArgumentWithDefaultValueAndTypeConverterSettings : CommandSettings

--- a/src/Spectre.Console.Tests/Unit/Cli/CommandAppTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Cli/CommandAppTests.cs
@@ -245,6 +245,50 @@ namespace Spectre.Console.Tests.Unit.Cli
         }
 
         [Fact]
+        public void Should_Assign_Property_Initializer_To_Optional_Argument()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.SetDefaultCommand<GenericCommand<OptionalArgumentWithPropertyInitializerSettings>>();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+            });
+
+            // When
+            var result = app.Run(Array.Empty<string>());
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings
+                .ShouldBeOfType<OptionalArgumentWithPropertyInitializerSettings>()
+                .And(settings => settings.Names.ShouldNotBeNull())
+                .And(settings => settings.Names.ShouldBeEmpty());
+        }
+
+        [Fact]
+        public void Should_Overwrite_Property_Initializer_With_Argument_Value()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.SetDefaultCommand<GenericCommand<OptionalArgumentWithPropertyInitializerSettings>>();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+            });
+
+            // When
+            var result = app.Run("ABBA", "Herreys");
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings
+                .ShouldBeOfType<OptionalArgumentWithPropertyInitializerSettings>()
+                .And(settings => settings.Names.ShouldContain("ABBA"))
+                .And(settings => settings.Names.ShouldContain("Herreys"));
+        }
+
+        [Fact]
         public void Should_Assign_Default_Value_To_Optional_Argument_Using_Converter_If_Necessary()
         {
             // Given

--- a/src/Spectre.Console.Tests/Unit/Cli/CommandAppTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Cli/CommandAppTests.cs
@@ -262,6 +262,9 @@ namespace Spectre.Console.Tests.Unit.Cli
             result.ExitCode.ShouldBe(0);
             result.Settings
                 .ShouldBeOfType<OptionalArgumentWithPropertyInitializerSettings>()
+                .And(settings => settings.Count.ShouldBe(1))
+                .And(settings => settings.Value.ShouldBe(0))
+                .And(settings => settings.Names.ShouldNotBeNull())
                 .And(settings => settings.Names.ShouldNotBeNull())
                 .And(settings => settings.Names.ShouldBeEmpty());
         }
@@ -278,12 +281,14 @@ namespace Spectre.Console.Tests.Unit.Cli
             });
 
             // When
-            var result = app.Run("ABBA", "Herreys");
+            var result = app.Run("-c", "0", "-v", "50", "ABBA", "Herreys");
 
             // Then
             result.ExitCode.ShouldBe(0);
             result.Settings
                 .ShouldBeOfType<OptionalArgumentWithPropertyInitializerSettings>()
+                .And(settings => settings.Count.ShouldBe(0))
+                .And(settings => settings.Value.ShouldBe(50))
                 .And(settings => settings.Names.ShouldContain("ABBA"))
                 .And(settings => settings.Names.ShouldContain("Herreys"));
         }

--- a/src/Spectre.Console/Cli/Internal/Binding/CommandPropertyBinder.cs
+++ b/src/Spectre.Console/Cli/Internal/Binding/CommandPropertyBinder.cs
@@ -10,7 +10,10 @@ namespace Spectre.Console.Cli
 
             foreach (var (parameter, value) in lookup)
             {
-                parameter.Property.SetValue(settings, value);
+                if (value != default)
+                {
+                    parameter.Property.SetValue(settings, value);
+                }
             }
 
             // Validate the settings.


### PR DESCRIPTION
Previous version was overwriting values that might have been set via a property initializer.

Closes #422

cc @MiloszKrajewski