### PR TITLE
Added a TypeRegistrar to CommandAppTester

### DIFF
--- a/src/Spectre.Console.Testing/Cli/CommandAppTester.cs
+++ b/src/Spectre.Console.Testing/Cli/CommandAppTester.cs
@@ -12,6 +12,20 @@ namespace Spectre.Console.Testing
         private Action<IConfigurator>? _configuration;
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CommandAppTester"/> class.
+        /// </summary>
+        /// <param name="registrar">The registrar.</param>
+        public CommandAppTester(ITypeRegistrar? registrar = null)
+        {
+            Registrar = registrar;
+        }
+
+        /// <summary>
+        /// Gets or sets the Registrar to use in the CommandApp.
+        /// </summary>
+        public ITypeRegistrar? Registrar { get; set; }
+
+        /// <summary>
         /// Sets the default command.
         /// </summary>
         /// <typeparam name="T">The default command type.</typeparam>
@@ -88,7 +102,7 @@ namespace Spectre.Console.Testing
             CommandContext? context = null;
             CommandSettings? settings = null;
 
-            var app = new CommandApp();
+            var app = new CommandApp(Registrar);
             _appConfiguration?.Invoke(app);
 
             if (_configuration != null)

--- a/test/Spectre.Console.Tests/Utilities/FakeTypeRegistrar.cs
+++ b/test/Spectre.Console.Tests/Utilities/FakeTypeRegistrar.cs
@@ -8,6 +8,7 @@ namespace Spectre.Console.Testing
     {
         public Dictionary<Type, List<Type>> Registrations { get; }
         public Dictionary<Type, List<object>> Instances { get; }
+        public Func<Dictionary<Type, List<Type>>, Dictionary<Type, List<object>>, ITypeResolver> TypeResolverFactory { get; set; }
 
         public FakeTypeRegistrar()
         {
@@ -50,7 +51,7 @@ namespace Spectre.Console.Testing
 
         public ITypeResolver Build()
         {
-            return null;
+            return TypeResolverFactory?.Invoke(Registrations, Instances);
         }
     }
 }

--- a/test/Spectre.Console.Tests/Utilities/FakeTypeResolver.cs
+++ b/test/Spectre.Console.Tests/Utilities/FakeTypeResolver.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Spectre.Console.Cli;
+
+namespace Spectre.Console.Testing
+{
+    public sealed class FakeTypeResolver : ITypeResolver
+    {
+        private readonly Dictionary<Type, List<Type>> _registrations;
+        private readonly Dictionary<Type, List<object>> _instances;
+
+        public FakeTypeResolver(
+            Dictionary<Type, List<Type>> registrations,
+            Dictionary<Type, List<object>> instances)
+        {
+            _registrations = registrations ?? throw new ArgumentNullException(nameof(registrations));
+            _instances = instances ?? throw new ArgumentNullException(nameof(instances));
+        }
+
+        public static Func<Dictionary<Type, List<Type>>, Dictionary<Type, List<object>>, ITypeResolver> Factory =>
+            (r, i) => new FakeTypeResolver(r, i);
+
+        public object Resolve(Type type)
+        {
+            if (_instances.TryGetValue(type, out var instances))
+            {
+                return instances.FirstOrDefault();
+            }
+
+            if (_registrations.TryGetValue(type, out var registrations))
+            {
+                return registrations.Count == 0 
+                    ? null 
+                    : Activator.CreateInstance(type);
+            }
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
exposed as a public property.
For convenience, and to keep the similarity to the real CommandApp
it is also available in the ctor of CommandAppTester.

This is in regard to #461 

I'm not quite fond of the used-in-this-one-place implementation of `FakeRegistrar`, but I see no real good alternative except exposing the `DefaultRegistrar` to be used in tests or creating a second (fully implemented) `ITypeRegistrar` for tests.