### PR TITLE
LineTreeGuide should not fall back to ASCII

### DIFF
--- a/examples/Console/Trees/Program.cs
+++ b/examples/Console/Trees/Program.cs
@@ -16,7 +16,7 @@ namespace Spectre.Console.Examples
             // Create the tree
             var tree = new Tree("Root")
                 .Style(Style.Parse("red"))
-                .Guide(TreeGuide.BoldLine);
+                .Guide(TreeGuide.Line);
 
             // Add some nodes
             var foo = tree.AddNode("[yellow]Foo[/]");

--- a/src/Spectre.Console/Rendering/Tree/LineTreeGuide.cs
+++ b/src/Spectre.Console/Rendering/Tree/LineTreeGuide.cs
@@ -8,9 +8,6 @@ namespace Spectre.Console.Rendering
     public sealed class LineTreeGuide : TreeGuide
     {
         /// <inheritdoc/>
-        public override TreeGuide? SafeTreeGuide => Ascii;
-
-        /// <inheritdoc/>
         public override string GetPart(TreeGuidePart part)
         {
             return part switch


### PR DESCRIPTION
If the user's environment didn't support unicode, we used
to fall back to using the AsciiTreeGuide if LineTreeGuide
was being used (which it is by default). This commit removes
that fallback since the characters used in LineTreeGuide is
covered by extended ASCII, which SHOULD be fine in almost all
scenarios.

Closes #324