### PR TITLE
(#485) referenced `CommandSettings` in docs

### DIFF
--- a/docs/input/cli/commands.md
+++ b/docs/input/cli/commands.md
@@ -7,7 +7,7 @@ Commands in `Spectre.Console.Cli` are defined by creating a class that inherits 
 ```csharp
 public class HelloCommand : Command<HelloCommand.Settings>
 {
-    public class Settings : LogCommandSettings
+    public class Settings : CommandSettings
     {
         [CommandArgument(0, "[Name]")]
         public string Name { get; set; }


### PR DESCRIPTION
instead of `LogCommandSettings` for the `Settings` of the `HelloCommand`.

fixes #485 