### PR TITLE
Adds additional check that analyzer is within a method

### DIFF
--- a/src/Spectre.Console.Analyzer/Analyzers/FavorInstanceAnsiConsoleOverStaticAnalyzer.cs
+++ b/src/Spectre.Console.Analyzer/Analyzers/FavorInstanceAnsiConsoleOverStaticAnalyzer.cs
@@ -37,6 +37,12 @@ namespace Spectre.Console.Analyzer
                         return;
                     }
 
+                    // if we aren't in a method then it might be too complex for us to handle.
+                    if (!invocationOperation.Syntax.Ancestors().OfType<MethodDeclarationSyntax>().Any())
+                    {
+                        return;
+                    }
+
                     if (!HasFieldAnsiConsole(invocationOperation.Syntax) &&
                         !HasParameterAnsiConsole(invocationOperation.Syntax))
                     {

--- a/test/Spectre.Console.Analyzer.Tests/Unit/Analyzers/UseInstanceAnsiConsoleTests.cs
+++ b/test/Spectre.Console.Analyzer.Tests/Unit/Analyzers/UseInstanceAnsiConsoleTests.cs
@@ -11,6 +11,28 @@ namespace Spectre.Console.Analyzer.Tests.Unit.Analyzers
             DiagnosticSeverity.Info);
 
         [Fact]
+        public async void Should_only_warn_within_methods()
+        {
+            const string Source = @"
+using Spectre.Console;
+
+internal sealed class Foo
+{
+    private readonly IAnsiConsole _console;
+
+    public Foo(IAnsiConsole console = null)
+    {
+        _console = console ?? AnsiConsole.Create(new AnsiConsoleSettings());
+    }
+}
+";
+
+            await SpectreAnalyzerVerifier<FavorInstanceAnsiConsoleOverStaticAnalyzer>
+                .VerifyAnalyzerAsync(Source)
+                .ConfigureAwait(false);
+        }
+        
+        [Fact]
         public async void Instance_console_has_no_warnings()
         {
             const string Source = @"


### PR DESCRIPTION
Resolve #487 

I suspect some more edge cases might crop up where this gives a false positive, but a false positive is better than an exception for now I suppose.