### PR TITLE
Using browser context for social cards

### DIFF
--- a/docs/src/SocialCards/index.cshtml
+++ b/docs/src/SocialCards/index.cshtml
@@ -8,6 +8,7 @@
 <html>
 
 <head>
+    <link rel="preload" as="font" href="/static/CascadiaCodePL.woff2">
     <link rel="stylesheet" href="static/styles.css" />
 </head>
 <body>


### PR DESCRIPTION
Scott Hanselman recommended using the context instead of the browser object. Browser object creates a new context on each call which is a new process. Obviously we don't want that. 

Also added an extra check for a load based on network idle. This will not only ensure things are loaded, but there is a built in 500ms timeout looking for inactivity which will let the font rendering process do it's thing which seems to lag a tad with Chromium.

And while we are at it, preloading the font can't hurt.