### PR TITLE
Fix parsing of exceptions on .NET Framework

### DIFF
--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
@@ -14,11 +14,7 @@ namespace Spectre.Console
                 throw new ArgumentNullException(nameof(exception));
             }
 
-            var info = ExceptionParser.Parse(exception.ToString());
-            if (info == null)
-            {
-                return new Text(exception.ToString());
-            }
+            var info = ExceptionParser.Parse(exception);
 
             return GetException(info, settings);
         }

--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionParser.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionParser.cs
@@ -1,90 +1,27 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Spectre.Console
 {
     internal static class ExceptionParser
     {
-        private static readonly Regex _messageRegex = new Regex(@"^(?'type'.*):\s(?'message'.*)$");
         private static readonly Regex _stackFrameRegex = new Regex(@"^\s*\w*\s(?'method'.*)\((?'params'.*)\)");
         private static readonly Regex _fullStackFrameRegex = new Regex(@"^\s*(?'at'\w*)\s(?'method'.*)\((?'params'.*)\)\s(?'in'\w*)\s(?'path'.*)\:(?'line'\w*)\s(?'linenumber'\d*)$");
 
-        public static ExceptionInfo? Parse(string exception)
+        public static ExceptionInfo Parse(Exception exception)
         {
             if (exception is null)
             {
                 throw new ArgumentNullException(nameof(exception));
             }
 
-            var lines = exception.SplitLines();
-            return Parse(new Queue<string>(lines));
-        }
-
-        private static ExceptionInfo? Parse(Queue<string> lines)
-        {
-            if (lines.Count == 0)
-            {
-                // Error: No lines to parse
-                return null;
-            }
-
-            var line = lines.Dequeue();
-            line = line.ReplaceExact(" ---> ", string.Empty);
-
-            var match = _messageRegex.Match(line);
-            if (!match.Success)
-            {
-                return null;
-            }
-
-            var inner = (ExceptionInfo?)null;
-
-            // Stack frames
-            var frames = new List<StackFrameInfo>();
-            while (lines.Count > 0)
-            {
-                if (lines.Peek().TrimStart().StartsWith("---> ", StringComparison.OrdinalIgnoreCase))
-                {
-                    inner = Parse(lines);
-                    if (inner == null)
-                    {
-                        // Error: Could not parse inner exception
-                        return null;
-                    }
-
-                    continue;
-                }
-
-                line = lines.Dequeue();
-
-                if (string.IsNullOrWhiteSpace(line))
-                {
-                    // Empty line
-                    continue;
-                }
-
-                if (line.TrimStart().StartsWith("--- ", StringComparison.OrdinalIgnoreCase))
-                {
-                    // End of inner exception
-                    break;
-                }
-
-                var stackFrame = ParseStackFrame(line);
-                if (stackFrame == null)
-                {
-                    // Error: Could not parse stack frame
-                    return null;
-                }
-
-                frames.Add(stackFrame);
-            }
-
-            return new ExceptionInfo(
-                match.Groups["type"].Value,
-                match.Groups["message"].Value,
-                frames, inner);
+            var exceptionType = exception.GetType();
+            var frames = exception.StackTrace?.SplitLines().Select(ParseStackFrame).Where(e => e != null).Cast<StackFrameInfo>().ToList() ?? new List<StackFrameInfo>();
+            var inner = exception.InnerException is null ? null : Parse(exception.InnerException);
+            return new ExceptionInfo(exceptionType.FullName ?? exceptionType.Name, exception.Message, frames, inner);
         }
 
         private static StackFrameInfo? ParseStackFrame(string frame)

--- a/test/Spectre.Console.Tests/Spectre.Console.Tests.csproj
+++ b/test/Spectre.Console.Tests/Spectre.Console.Tests.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net5.0;net48</TargetFrameworks>
+    <TargetFramework Condition="!$([MSBuild]::IsOSPlatform('Windows'))">net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,10 +19,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="Spectre.Verify.Extensions" Version="0.3.0" />
     <PackageReference Include="Verify.Xunit" Version="9.0.0-beta.1" />

--- a/test/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Shouldly;
 using Spectre.Console.Testing;
@@ -261,6 +262,9 @@ namespace Spectre.Console.Tests.Unit
             {
                 task = ctx.AddTask("foo");
                 task.Increment(double.Epsilon);
+                // Make sure that at least one millisecond has elapsed between the increments else the RemainingTime is null
+                // when the last timestamp is equal to the first timestamp of the samples.
+                Thread.Sleep(1);
                 task.Increment(double.Epsilon);
             });
 

--- a/test/Spectre.Console.Tests/VerifyConfiguration.cs
+++ b/test/Spectre.Console.Tests/VerifyConfiguration.cs
@@ -13,3 +13,13 @@ namespace Spectre.Console.Tests
         }
     }
 }
+
+#if !NET5_0_OR_GREATER
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed class ModuleInitializerAttribute : Attribute
+    {
+    }
+}
+#endif


### PR DESCRIPTION
On .NET Framework, `exception.ToString()` uses a slightly different format than on .NET Core.

So in order to properly transform an `Exception` into an `ExceptionInfo` on both .NET Core and .NET Framework we use `exception.StackTrace` + `exception.InnerException`. As an added benefit, it greatly simplifies the implementation of the `ExceptionParser` class.

This required a few tweaks to the test project to make it compile and run on .NET Framework 4.8 (first commit of this pull request).

The last commit of this pull request addresses a new intermittent test failure that appeared when running tests on .NET Framework.