### PR TITLE
Make building more flexible by allowing feature bands

### DIFF
--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "projects": [ "src", "tests" ],
   "sdk": {
     "version": "5.0.301",
-    "rollForward": "latestPatch"
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Currently, the latest stable .NET5 is version 5.0.400, which 
fails with `latestPatch` but works with `latestFeature`. 

Given that the project doesn't appear to depend on any low
level primitives or behaviors that might break from .NET 
feature band upgrades, it's far more convenient for contributors 
to have a more flexible requirement.