### PR TITLE
Automatically provide global using

### DIFF
--- a/src/Spectre.Console/Spectre.Console.csproj
+++ b/src/Spectre.Console/Spectre.Console.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
@@ -9,6 +9,11 @@
   <ItemGroup>
     <PackageReference Include="Wcwidth" Version="0.2.0" />
     <PackageReference Include="System.Memory" Version="4.5.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Spectre.Console.props" Pack="true" PackagePath="build\net5.0\Spectre.Console.props" />
+    <None Include="Spectre.Console.props" Pack="true" PackagePath="build\netstandard2.0\Spectre.Console.props" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Spectre.Console/Spectre.Console.props
+++ b/src/Spectre.Console/Spectre.Console.props
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup>
+    <Import Include="Spectre.Console" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
The new C# 10 feature lights up automatically via the provided item group with the `Import` element.

There's talk of a future opt-out (or opt-in?) MSBuild property to control these global usings, but the provided approach will work and integrate seamlessly with whatever the project/SDK configures.

For reference, see https://github.com/dotnet/aspnetcore/issues/32451.

Note we provide the "legacy" MSBuild xmlns attribute so as not to break downlevel IDEs or legacy project files that happen to reference this package.

Fixes #515