### PR TITLE
Optimize operating system detection.

### DIFF
--- a/src/Spectre.Console/AnsiConsoleFactory.cs
+++ b/src/Spectre.Console/AnsiConsoleFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.InteropServices;
 using Spectre.Console.Enrichment;
 using Spectre.Console.Internal;
 
@@ -89,7 +88,7 @@ namespace Spectre.Console
                 if (buffer.IsStandardOut() || buffer.IsStandardError())
                 {
                     // Are we running on Windows?
-                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    if (OperatingSystem.IsWindows())
                     {
                         // Not the first console we're creating?
                         if (AnsiConsole.Created)

--- a/src/Spectre.Console/Internal/Backends/Ansi/AnsiDetector.cs
+++ b/src/Spectre.Console/Internal/Backends/Ansi/AnsiDetector.cs
@@ -35,7 +35,7 @@ namespace Spectre.Console
         public static (bool SupportsAnsi, bool LegacyConsole) Detect(bool stdError, bool upgrade)
         {
             // Running on Windows?
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (OperatingSystem.IsWindows())
             {
                 // Running under ConEmu?
                 var conEmu = Environment.GetEnvironmentVariable("ConEmuANSI");

--- a/src/Spectre.Console/OperatingSystem.netstandard.cs
+++ b/src/Spectre.Console/OperatingSystem.netstandard.cs
@@ -1,0 +1,87 @@
+#if NETSTANDARD
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Shims the System.OperatingSystem class on .NET Standard.
+    /// </summary>
+    /// <remarks>
+    /// Adopted from dotnet/runtime.
+    /// </remarks>
+    internal static unsafe class OperatingSystem
+    {
+        private static readonly bool _isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+        private static readonly (int Major, int Minor, int Build, int Revision) _windowsVersion = GetWindowsVersion();
+
+        public static bool IsWindows() => _isWindows;
+
+        public static bool IsWindowsVersionAtLeast(int major, int minor = 0, int build = 0, int revision = 0)
+        {
+            if (!IsWindows())
+            {
+                return false;
+            }
+
+            var current = _windowsVersion;
+
+            if (current.Major != major)
+            {
+                return current.Major > major;
+            }
+
+            if (current.Minor != minor)
+            {
+                return current.Minor > minor;
+            }
+
+            if (current.Build != build)
+            {
+                return current.Build > build;
+            }
+
+            return current.Revision >= revision;
+        }
+
+        private static (int Major, int Minor, int Build, int Revision) GetWindowsVersion()
+        {
+            if (!IsWindows())
+            {
+                return default;
+            }
+
+            RTL_OSVERSIONINFOEX versionInfo = default;
+            versionInfo.dwOSVersionInfoSize = (uint)sizeof(RTL_OSVERSIONINFOEX);
+            int exitCode = RtlGetVersion(&versionInfo);
+
+            // It is documented that the API always succeeds.
+            Debug.Assert(exitCode == 0, "RtlGetVersion failed.");
+
+            return ((int)versionInfo.dwMajorVersion, (int)versionInfo.dwMinorVersion, (int)versionInfo.dwBuildNumber, 0);
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+        [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1307:Accessible fields should begin with upper-case letter", Justification = "We use the same field names as the Windows API declaration")]
+        private struct RTL_OSVERSIONINFOEX
+        {
+            internal uint dwOSVersionInfoSize;
+
+            internal uint dwMajorVersion;
+
+            internal uint dwMinorVersion;
+
+            internal uint dwBuildNumber;
+
+            internal uint dwPlatformId;
+
+            internal fixed char szCSDVersion[128];
+        }
+
+        [DllImport("ntdll.dll", ExactSpelling = true)]
+        private static extern int RtlGetVersion(RTL_OSVERSIONINFOEX* lpVersionInformation);
+    }
+}
+#endif

--- a/src/Spectre.Console/Spectre.Console.csproj
+++ b/src/Spectre.Console/Spectre.Console.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net5.0;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
+    <!--Needed by the OperatingSystem .NET Standard shim.-->
+    <AllowUnsafeBlocks Condition="'$(TargetFramework)' == 'netstandard2.0'">true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR changes the operating system from `RuntimeInformation.IsOSPlatform` to use `OperationSystem.IsXxx`. Their advantage is that they are better optimized by the JIT, and recognized by the trimmer.

Because this class is not available on .NET Standard, it was minimally shimmed in an internal class that gets the correct version of Windows [the way .NET 5+ does it](https://github.com/dotnet/runtime/blob/e0ebe9ee047b07352d262e5f1335e186dc0f1b50/src/libraries/System.Private.CoreLib/src/System/Environment.Windows.cs#L107-L119). As a disadvantage, unsafe code was enabled to write the shim, but is allowed only when targeting .NET Standard 2.0.