### PR TITLE
Fix the style parameter nullable annotation on AnsiConsoleExtensions

### DIFF
--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.cs
@@ -51,8 +51,8 @@ namespace Spectre.Console
         /// </summary>
         /// <param name="console">The console to write to.</param>
         /// <param name="text">The text to write.</param>
-        /// <param name="style">The text style.</param>
-        public static void Write(this IAnsiConsole console, string text, Style style)
+        /// <param name="style">The text style or <see cref="Style.Plain"/> if <see langword="null"/>.</param>
+        public static void Write(this IAnsiConsole console, string text, Style? style)
         {
             if (console is null)
             {
@@ -91,8 +91,8 @@ namespace Spectre.Console
         /// </summary>
         /// <param name="console">The console to write to.</param>
         /// <param name="text">The text to write.</param>
-        /// <param name="style">The text style.</param>
-        public static void WriteLine(this IAnsiConsole console, string text, Style style)
+        /// <param name="style">The text style or <see cref="Style.Plain"/> if <see langword="null"/>.</param>
+        public static void WriteLine(this IAnsiConsole console, string text, Style? style)
         {
             if (console is null)
             {

--- a/src/Spectre.Console/Widgets/Paragraph.cs
+++ b/src/Spectre.Console/Widgets/Paragraph.cs
@@ -47,7 +47,7 @@ namespace Spectre.Console
         /// Initializes a new instance of the <see cref="Paragraph"/> class.
         /// </summary>
         /// <param name="text">The text.</param>
-        /// <param name="style">The style of the text.</param>
+        /// <param name="style">The style of the text or <see cref="Style.Plain"/> if <see langword="null"/>.</param>
         public Paragraph(string text, Style? style = null)
             : this()
         {
@@ -63,7 +63,7 @@ namespace Spectre.Console
         /// Appends some text to this paragraph.
         /// </summary>
         /// <param name="text">The text to append.</param>
-        /// <param name="style">The style of the appended text.</param>
+        /// <param name="style">The style of the appended text or <see cref="Style.Plain"/> if <see langword="null"/>.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
         public Paragraph Append(string text, Style? style = null)
         {

--- a/src/Spectre.Console/Widgets/Text.cs
+++ b/src/Spectre.Console/Widgets/Text.cs
@@ -29,7 +29,7 @@ namespace Spectre.Console
         /// Initializes a new instance of the <see cref="Text"/> class.
         /// </summary>
         /// <param name="text">The text.</param>
-        /// <param name="style">The style of the text.</param>
+        /// <param name="style">The style of the text or <see cref="Style.Plain"/> if <see langword="null"/>.</param>
         public Text(string text, Style? style = null)
         {
             _paragraph = new Paragraph(text, style);


### PR DESCRIPTION
The style parameter is actually nullable. Also, the documentation of the style parameter has been made explicit that `Style.Plain` is used when a `null` style is passed.