### PR TITLE
fixed 404 in documentation

### DIFF
--- a/docs/input/cli/commands.md
+++ b/docs/input/cli/commands.md
@@ -25,7 +25,7 @@ public class HelloCommand : Command<HelloCommand.Settings>
 
 ## Configuring
 
-Commands are configured via the [`CommandApp`](commandApp)'s `Configure` method.
+Commands are configured via the [`CommandApp`](commandapp)'s `Configure` method.
 
 ```csharp
 var app = new CommandApp();
@@ -45,7 +45,7 @@ app.Configure(config =>
 
 ## Dependency Injection
 
-Constructor injection is supported on commands. See the [`CommandApp`](commandApp) documentation for further information on configuring `Spectre.Console` for your container.
+Constructor injection is supported on commands. See the [`CommandApp`](commandapp) documentation for further information on configuring `Spectre.Console` for your container.
 
 ## Validation
 

--- a/docs/input/cli/getting-started.md
+++ b/docs/input/cli/getting-started.md
@@ -78,6 +78,6 @@ app.exe c:\windows --hidden --pattern *.dll
 
 Much more is possible. You can have multiple commands per application, settings can be customized and extended and the default behavior of the `CommandApp` can be extended and customized.
 
-* See [CommandApp](./commandApp) for customizing how Spectre.Console.Cli builds the settings.
+* See [CommandApp](./commandapp) for customizing how Spectre.Console.Cli builds the settings.
 * See [Create Commands](./commands) for information about different command types and their configurations.
 * See [Specifying Settings](./settings) for information about defining the settings.


### PR DESCRIPTION
links were pointing to ./commandApp, however
the generated page is ./commandapp