### PR TITLE
Removed the additional registration of ICommand

### DIFF
--- a/src/Spectre.Console/Cli/Internal/Extensions/TypeRegistrarExtensions.cs
+++ b/src/Spectre.Console/Cli/Internal/Extensions/TypeRegistrarExtensions.cs
@@ -27,7 +27,6 @@ namespace Spectre.Console.Cli
 
                 if (command.CommandType != null)
                 {
-                    registrar?.Register(typeof(ICommand), command.CommandType);
                     registrar?.Register(command.CommandType, command.CommandType);
                 }
 

--- a/test/Spectre.Console.Tests/Unit/Cli/CommandAppTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Cli/CommandAppTests.cs
@@ -382,10 +382,12 @@ namespace Spectre.Console.Tests.Unit.Cli
             });
 
             // Then
-            registrar.Registrations.ContainsKey(typeof(ICommand)).ShouldBeTrue();
-            registrar.Registrations[typeof(ICommand)].ShouldContain(typeof(GenericCommand<FooCommandSettings>));
-            registrar.Registrations[typeof(ICommand)].ShouldContain(typeof(DogCommand));
-            registrar.Registrations[typeof(ICommand)].ShouldContain(typeof(HorseCommand));
+            registrar.Registrations.ContainsKey(typeof(GenericCommand<FooCommandSettings>)).ShouldBeTrue();
+            registrar.Registrations.ContainsKey(typeof(DogCommand)).ShouldBeTrue();
+            registrar.Registrations.ContainsKey(typeof(HorseCommand)).ShouldBeTrue();
+            registrar.Registrations[typeof(GenericCommand<FooCommandSettings>)].ShouldContain(typeof(GenericCommand<FooCommandSettings>));
+            registrar.Registrations[typeof(DogCommand)].ShouldContain(typeof(DogCommand));
+            registrar.Registrations[typeof(HorseCommand)].ShouldContain(typeof(HorseCommand));
         }
 
         [Fact]
@@ -406,8 +408,8 @@ namespace Spectre.Console.Tests.Unit.Cli
             });
 
             // Then
-            registrar.Registrations.ContainsKey(typeof(ICommand)).ShouldBeTrue();
-            registrar.Registrations[typeof(ICommand)].ShouldContain(typeof(DogCommand));
+            registrar.Registrations.ContainsKey(typeof(DogCommand)).ShouldBeTrue();
+            registrar.Registrations[typeof(DogCommand)].ShouldContain(typeof(DogCommand));
         }
 
         [Fact]


### PR DESCRIPTION
As discussed in https://github.com/spectreconsole/spectre.console/discussions/532 the additional registration is not needed anymore.

I modified two tests which were specifically testing for the `ICommand` registration.
I also tested all the demos, and they all worked.

**However**, this will be a breaking change for anyone who implemented a custom `ITypeRegistrar` and relied upon the `ICommands` to be registered.