### PR TITLE
Add support custom max value for barcharts

### DIFF
--- a/src/Spectre.Console/Extensions/BarChartExtensions.cs
+++ b/src/Spectre.Console/Extensions/BarChartExtensions.cs
@@ -245,7 +245,7 @@ namespace Spectre.Console
         /// <param name="chart">The bar chart.</param>
         /// <param name="maxValue">Max value for the chart.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public static BarChart WithFixedMaxValue(this BarChart chart, double maxValue)
+        public static BarChart WithMaxValue(this BarChart chart, double maxValue)
         {
             if (chart is null)
             {

--- a/src/Spectre.Console/Extensions/BarChartExtensions.cs
+++ b/src/Spectre.Console/Extensions/BarChartExtensions.cs
@@ -238,5 +238,22 @@ namespace Spectre.Console
             chart.LabelAlignment = Justify.Right;
             return chart;
         }
+
+        /// <summary>
+        /// Sets the max fixed value for the chart.
+        /// </summary>
+        /// <param name="chart">The bar chart.</param>
+        /// <param name="maxValue">Max value for the chart.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static BarChart WithFixedMaxValue(this BarChart chart, double maxValue)
+        {
+            if (chart is null)
+            {
+                throw new ArgumentNullException(nameof(chart));
+            }
+
+            chart.MaxValue = maxValue;
+            return chart;
+        }
     }
 }

--- a/src/Spectre.Console/Widgets/Charts/BarChart.cs
+++ b/src/Spectre.Console/Widgets/Charts/BarChart.cs
@@ -44,6 +44,12 @@ namespace Spectre.Console
         public CultureInfo? Culture { get; set; }
 
         /// <summary>
+        /// Gets or sets the fixed max value for a bar chart.
+        /// </summary>
+        /// <remarks>Defaults to 0, which corresponds to largest value in chart.</remarks>
+        public double MaxValue { get; set; } = 0;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BarChart"/> class.
         /// </summary>
         public BarChart()
@@ -62,7 +68,7 @@ namespace Spectre.Console
         protected override IEnumerable<Segment> Render(RenderContext context, int maxWidth)
         {
             var width = Math.Min(Width ?? maxWidth, maxWidth);
-            var maxValue = Data.Max(item => item.Value);
+            var maxValue = Math.Max(MaxValue, Data.Max(item => item.Value));
 
             var grid = new Grid();
             grid.Collapse();

--- a/src/Spectre.Console/Widgets/Charts/BarChart.cs
+++ b/src/Spectre.Console/Widgets/Charts/BarChart.cs
@@ -46,8 +46,8 @@ namespace Spectre.Console
         /// <summary>
         /// Gets or sets the fixed max value for a bar chart.
         /// </summary>
-        /// <remarks>Defaults to 0, which corresponds to largest value in chart.</remarks>
-        public double MaxValue { get; set; } = 0;
+        /// <remarks>Defaults to null, which corresponds to largest value in chart.</remarks>
+        public double? MaxValue { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BarChart"/> class.
@@ -68,7 +68,7 @@ namespace Spectre.Console
         protected override IEnumerable<Segment> Render(RenderContext context, int maxWidth)
         {
             var width = Math.Min(Width ?? maxWidth, maxWidth);
-            var maxValue = Math.Max(MaxValue, Data.Max(item => item.Value));
+            var maxValue = Math.Max(MaxValue ?? 0d, Data.Max(item => item.Value));
 
             var grid = new Grid();
             grid.Collapse();

--- a/test/Spectre.Console.Tests/Expectations/Widgets/BarChart/Fixed_Max_Value.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Widgets/BarChart/Fixed_Max_Value.Output.verified.txt
@@ -1,0 +1,4 @@
+                          Number of fruits                  
+ Apple  ███ 12                                              
+Orange  █████████████████████████ 54                        
+Banana  ██████████████ 33                                   

--- a/test/Spectre.Console.Tests/Unit/Widgets/BarChartTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Widgets/BarChartTests.cs
@@ -58,7 +58,7 @@ namespace Spectre.Console.Tests.Unit
             // When
             console.Write(new BarChart()
                 .Width(60)
-                .WithFixedMaxValue(100)
+                .WithMaxValue(100)
                 .Label("Number of fruits")
                 .AddItem("Apple", 12)
                 .AddItem("Orange", 54)

--- a/test/Spectre.Console.Tests/Unit/Widgets/BarChartTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Widgets/BarChartTests.cs
@@ -47,5 +47,26 @@ namespace Spectre.Console.Tests.Unit
             // Then
             await Verifier.Verify(console.Output);
         }
+        
+        [Fact]
+        [Expectation("Fixed_Max_Value")]
+        public async Task Should_Render_Correctly_3()
+        {
+            // Given
+            var console = new TestConsole();
+
+            // When
+            console.Write(new BarChart()
+                .Width(60)
+                .WithFixedMaxValue(100)
+                .Label("Number of fruits")
+                .AddItem("Apple", 12)
+                .AddItem("Orange", 54)
+                .AddItem("Banana", 33));
+
+            // Then
+            await Verifier.Verify(console.Output);
+        }
+
     }
 }


### PR DESCRIPTION
With this PR, it will be possible to set a custom max value for barcharts, so that multiple charts could be visually aligned.

This PR closes issue #524.
