### PR TITLE
Future-proof conditional compilation

### DIFF
--- a/src/Spectre.Console/Cli/Internal/Extensions/StringExtensions.cs
+++ b/src/Spectre.Console/Cli/Internal/Extensions/StringExtensions.cs
@@ -1,17 +1,13 @@
-#if NET5_0
-using System;
-#endif
-
 namespace Spectre.Console.Cli
 {
     internal static class StringExtensions
     {
         internal static int OrdinalIndexOf(this string text, char token)
         {
-#if NET5_0
-            return text.IndexOf(token, StringComparison.Ordinal);
-#else
+#if NETSTANDARD2_0
             return text.IndexOf(token);
+#else
+            return text.IndexOf(token, System.StringComparison.Ordinal);
 #endif
         }
     }

--- a/src/Spectre.Console/Extensions/StringExtensions.cs
+++ b/src/Spectre.Console/Extensions/StringExtensions.cs
@@ -177,19 +177,19 @@ namespace Spectre.Console
 
         internal static string ReplaceExact(this string text, string oldValue, string? newValue)
         {
-#if NET5_0
-            return text.Replace(oldValue, newValue, StringComparison.Ordinal);
-#else
+#if NETSTANDARD2_0
             return text.Replace(oldValue, newValue);
+#else
+            return text.Replace(oldValue, newValue, StringComparison.Ordinal);
 #endif
         }
 
         internal static bool ContainsExact(this string text, string value)
         {
-#if NET5_0
-            return text.Contains(value, StringComparison.Ordinal);
-#else
+#if NETSTANDARD2_0
             return text.Contains(value);
+#else
+            return text.Contains(value, StringComparison.Ordinal);
 #endif
         }
     }

--- a/src/Spectre.Console/Internal/Backends/Ansi/AnsiLinkHasher.cs
+++ b/src/Spectre.Console/Internal/Backends/Ansi/AnsiLinkHasher.cs
@@ -32,10 +32,10 @@ namespace Spectre.Console
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static int GetLinkHashCode(string link)
         {
-#if NET5_0
-            return link.GetHashCode(StringComparison.Ordinal);
-#else
+#if NETSTANDARD2_0
             return link.GetHashCode();
+#else
+            return link.GetHashCode(StringComparison.Ordinal);
 #endif
         }
     }

--- a/src/Spectre.Console/Internal/Colors/ColorSystemDetector.cs
+++ b/src/Spectre.Console/Internal/Colors/ColorSystemDetector.cs
@@ -1,10 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
 
-#if !NET5_0
-using System.Text.RegularExpressions;
-#endif
-
 namespace Spectre.Console
 {
     internal static class ColorSystemDetector
@@ -61,7 +57,6 @@ namespace Spectre.Console
             return ColorSystem.EightBit;
         }
 
-        // See https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version
         private static bool GetWindowsVersionInformation(out int major, out int build)
         {
             major = 0;
@@ -72,15 +67,15 @@ namespace Spectre.Console
                 return false;
             }
 
-#if NET5_0
-            // The reason we're not always using this, is because it
-            // will return wrong values on other runtimes than net5.0
+#if NET5_0_OR_GREATER
+            // The reason we're not always using this, is because it will return wrong values on other runtimes than .NET 5+
+            // See https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/5.0/environment-osversion-returns-correct-version
             var version = Environment.OSVersion.Version;
             major = version.Major;
             build = version.Build;
             return true;
 #else
-            var regex = new Regex("Microsoft Windows (?'major'[0-9]*).(?'minor'[0-9]*).(?'build'[0-9]*)\\s*$");
+            var regex = new System.Text.RegularExpressions.Regex("Microsoft Windows (?'major'[0-9]*).(?'minor'[0-9]*).(?'build'[0-9]*)\\s*$");
             var match = regex.Match(RuntimeInformation.OSDescription);
             if (match.Success && int.TryParse(match.Groups["major"].Value, out major))
             {

--- a/src/Spectre.Console/Style.cs
+++ b/src/Spectre.Console/Style.cs
@@ -165,10 +165,10 @@ namespace Spectre.Console
         {
             int? GetLinkHashCode()
             {
-#if NET5_0
-                return Link?.GetHashCode(StringComparison.Ordinal);
-#else
+#if NETSTANDARD2_0
                 return Link?.GetHashCode();
+#else
+                return Link?.GetHashCode(StringComparison.Ordinal);
 #endif
             }
 


### PR DESCRIPTION
* Invert `#if NET5_0` conditions so that when adding net6.0 target framework, the _new_ APIs are used.
* Use `NET5_0_OR_GREATER` instead of `NET5_0` to ensure consistent behaviour on future target frameworks.