### PR TITLE
Introduce MarkupInterpolated and MarkupLineInterpolated extensions

### DIFF
--- a/src/Spectre.Console/AnsiConsole.Markup.cs
+++ b/src/Spectre.Console/AnsiConsole.Markup.cs
@@ -28,6 +28,24 @@ namespace Spectre.Console
 
         /// <summary>
         /// Writes the specified markup to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// AnsiConsole.MarkupInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupInterpolated(FormattableString value)
+        {
+            Console.MarkupInterpolated(value);
+        }
+
+        /// <summary>
+        /// Writes the specified markup to the console.
         /// </summary>
         /// <param name="provider">An object that supplies culture-specific formatting information.</param>
         /// <param name="format">A composite format string.</param>
@@ -35,6 +53,25 @@ namespace Spectre.Console
         public static void Markup(IFormatProvider provider, string format, params object[] args)
         {
             Console.Markup(provider, format, args);
+        }
+
+        /// <summary>
+        /// Writes the specified markup to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// AnsiConsole.MarkupInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupInterpolated(IFormatProvider provider, FormattableString value)
+        {
+            Console.MarkupInterpolated(provider, value);
         }
 
         /// <summary>
@@ -58,6 +95,24 @@ namespace Spectre.Console
 
         /// <summary>
         /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// AnsiConsole.MarkupLineInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupLineInterpolated(FormattableString value)
+        {
+            Console.MarkupLineInterpolated(value);
+        }
+
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
         /// </summary>
         /// <param name="provider">An object that supplies culture-specific formatting information.</param>
         /// <param name="format">A composite format string.</param>
@@ -65,6 +120,25 @@ namespace Spectre.Console
         public static void MarkupLine(IFormatProvider provider, string format, params object[] args)
         {
             Console.MarkupLine(provider, format, args);
+        }
+
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// AnsiConsole.MarkupLineInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupLineInterpolated(IFormatProvider provider, FormattableString value)
+        {
+            Console.MarkupLineInterpolated(provider, value);
         }
     }
 }

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Linq;
 
 namespace Spectre.Console
 {
@@ -21,6 +22,25 @@ namespace Spectre.Console
 
         /// <summary>
         /// Writes the specified markup to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// console.MarkupInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupInterpolated(this IAnsiConsole console, FormattableString value)
+        {
+            MarkupInterpolated(console, CultureInfo.CurrentCulture, value);
+        }
+
+        /// <summary>
+        /// Writes the specified markup to the console.
         /// </summary>
         /// <param name="console">The console to write to.</param>
         /// <param name="provider">An object that supplies culture-specific formatting information.</param>
@@ -29,6 +49,26 @@ namespace Spectre.Console
         public static void Markup(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
         {
             Markup(console, string.Format(provider, format, args));
+        }
+
+        /// <summary>
+        /// Writes the specified markup to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// console.MarkupInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value)
+        {
+            MarkupInterpolated(console, provider, value, appendNewLine: false);
         }
 
         /// <summary>
@@ -54,6 +94,25 @@ namespace Spectre.Console
 
         /// <summary>
         /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// console.MarkupLineInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupLineInterpolated(this IAnsiConsole console, FormattableString value)
+        {
+            MarkupLineInterpolated(console, CultureInfo.CurrentCulture, value);
+        }
+
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
         /// </summary>
         /// <param name="console">The console to write to.</param>
         /// <param name="value">The value to write.</param>
@@ -72,6 +131,33 @@ namespace Spectre.Console
         public static void MarkupLine(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
         {
             Markup(console, provider, format + Environment.NewLine, args);
+        }
+
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// console.MarkupLineInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupLineInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value)
+        {
+            MarkupInterpolated(console, provider, value, appendNewLine: true);
+        }
+
+        private static void MarkupInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value, bool appendNewLine)
+        {
+            object?[] args = value.GetArguments().Select(arg => arg is string s ? s.EscapeMarkup() : arg).ToArray();
+            var format = appendNewLine ? value.Format + Environment.NewLine : value.Format;
+            Markup(console, string.Format(provider, format, args));
         }
     }
 }

--- a/test/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
@@ -139,5 +139,24 @@ namespace Spectre.Console.Tests.Unit
             console.Output.NormalizeLineEndings()
                 .ShouldBe("{\n");
         }
+
+        [Theory]
+        [InlineData("Hello", "World", "\x1B[38;5;11mHello\x1B[0m \x1B[38;5;9mWorld\x1B[0m 2021-02-03")]
+        [InlineData("Hello", "World [", "\x1B[38;5;11mHello\x1B[0m \x1B[38;5;9mWorld [\x1B[0m 2021-02-03")]
+        [InlineData("Hello", "World ]", "\x1B[38;5;11mHello\x1B[0m \x1B[38;5;9mWorld ]\x1B[0m 2021-02-03")]
+        [InlineData("[Hello]", "World", "\x1B[38;5;11m[Hello]\x1B[0m \x1B[38;5;9mWorld\x1B[0m 2021-02-03")]
+        [InlineData("[[Hello]]", "[World]", "\x1B[38;5;11m[[Hello]]\x1B[0m \x1B[38;5;9m[World]\x1B[0m 2021-02-03")]
+        public void Should_Escape_Markup_When_Using_MarkupInterpolated(string input1, string input2, string expected)
+        {
+            // Given
+            var console = new TestConsole().EmitAnsiSequences();
+            var date = new DateTime(2021, 2, 3);
+
+            // When
+            console.MarkupInterpolated($"[yellow]{input1}[/] [red]{input2}[/] {date:yyyy-MM-dd}");
+
+            // Then
+            console.Output.ShouldBe(expected);
+        }
     }
 }


### PR DESCRIPTION
These new methods enable easily writing markup with a nice and intuitive syntax without having to worry about escaping the markup.

```csharp
string input = args[0];
string output = Process(input);
AnsiConsole.MarkupLineInterpolated($"[blue]{input}[/] -> [green]{output}[/]");

```

The `Interpolated` suffix was inspired by the Entity Framework Core [FromSqlInterpolated][1] method.

[1]: https://docs.microsoft.com/en-us/ef/core/querying/raw-sql#passing-parameters