### PR TITLE
(GH-567) Enabled IRenderable in `SelectionPrompt` and `MultiSelectionPrompt`

### DIFF
--- a/src/Spectre.Console/Prompts/IPromptItemRenderer.cs
+++ b/src/Spectre.Console/Prompts/IPromptItemRenderer.cs
@@ -1,0 +1,20 @@
+using Spectre.Console.Rendering;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Implement this interface to create a renderer for
+    /// <see cref="SelectionPrompt{T}"/> or <see cref="MultiSelectionPrompt{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the item to render.</typeparam>
+    public interface IPromptItemRenderer<in T>
+    {
+        /// <summary>
+        /// Renders one item.
+        /// </summary>
+        /// <param name="item">The item to render.</param>
+        /// <param name="context">The <see cref="PromptItemContext"/> in which to render the item.</param>
+        /// <returns>The <see cref="IRenderable"/> to show in the prompt.</returns>
+        IRenderable Render(T item, PromptItemContext context);
+    }
+}

--- a/src/Spectre.Console/Prompts/MultiSelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPromptExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Spectre.Console.Rendering;
 
 namespace Spectre.Console
 {
@@ -297,6 +298,25 @@ namespace Spectre.Console
         /// <param name="displaySelector">The function to get a display string for a given choice.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
         public static MultiSelectionPrompt<T> UseConverter<T>(this MultiSelectionPrompt<T> obj, Func<T, string>? displaySelector)
+            where T : notnull
+        {
+            SimpleMarkupPromptItemRenderer<T>? renderer = null;
+            if (displaySelector != null)
+            {
+                renderer = new SimpleMarkupPromptItemRenderer<T>(displaySelector);
+            }
+
+            return obj.UseConverter(renderer);
+        }
+
+        /// <summary>
+        /// Sets the function to create a renderable for a given choice.
+        /// </summary>
+        /// <typeparam name="T">The prompt type.</typeparam>
+        /// <param name="obj">The prompt.</param>
+        /// <param name="displaySelector">The <see cref="IPromptItemRenderer{T}"/> to generate an <see cref="IRenderable"/> for a given choice.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static MultiSelectionPrompt<T> UseConverter<T>(this MultiSelectionPrompt<T> obj, IPromptItemRenderer<T>? displaySelector)
             where T : notnull
         {
             if (obj is null)

--- a/src/Spectre.Console/Prompts/PromptItemContext.cs
+++ b/src/Spectre.Console/Prompts/PromptItemContext.cs
@@ -1,0 +1,18 @@
+namespace Spectre.Console
+{
+    /// <summary>
+    /// This context will be provided to the <see cref="IPromptItemRenderer{T}.Render"/> method.
+    /// </summary>
+    public sealed class PromptItemContext
+    {
+        /// <summary>
+        /// Gets the state of the current item.
+        /// </summary>
+        public PromptItemState State { get; internal set; }
+
+        /// <summary>
+        /// Gets the Style of the prompt for the item.
+        /// </summary>
+        public Style? PromptStyle { get; internal set; }
+    }
+}

--- a/src/Spectre.Console/Prompts/PromptItemState.cs
+++ b/src/Spectre.Console/Prompts/PromptItemState.cs
@@ -1,0 +1,23 @@
+namespace Spectre.Console
+{
+    /// <summary>
+    /// Defines the states an item can have.
+    /// </summary>
+    public enum PromptItemState
+    {
+        /// <summary>
+        /// An item that is not the current item and not disabled.
+        /// </summary>
+        Normal,
+
+        /// <summary>
+        /// The current item under the cursor. (If the item is not disabled.)
+        /// </summary>
+        Current,
+
+        /// <summary>
+        /// Disabled item.
+        /// </summary>
+        Disabled,
+    }
+}

--- a/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Spectre.Console.Rendering;
 
 namespace Spectre.Console
 {
@@ -187,6 +188,25 @@ namespace Spectre.Console
         /// <param name="displaySelector">The function to get a display string for a given choice.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
         public static SelectionPrompt<T> UseConverter<T>(this SelectionPrompt<T> obj, Func<T, string>? displaySelector)
+            where T : notnull
+        {
+            SimpleMarkupPromptItemRenderer<T>? renderer = null;
+            if (displaySelector != null)
+            {
+                renderer = new SimpleMarkupPromptItemRenderer<T>(displaySelector);
+            }
+
+            return obj.UseConverter(renderer);
+        }
+
+        /// <summary>
+        /// Sets the function to create a display string for a given choice.
+        /// </summary>
+        /// <typeparam name="T">The prompt type.</typeparam>
+        /// <param name="obj">The prompt.</param>
+        /// <param name="displaySelector">The <see cref="IPromptItemRenderer{T}"/> to generate an <see cref="IRenderable"/> for a given choice.</param>
+        /// <returns>The same instance so that multiple calls can be chained.</returns>
+        public static SelectionPrompt<T> UseConverter<T>(this SelectionPrompt<T> obj, IPromptItemRenderer<T>? displaySelector)
             where T : notnull
         {
             if (obj is null)

--- a/src/Spectre.Console/Prompts/SimpleMarkupPromptItemRenderer.cs
+++ b/src/Spectre.Console/Prompts/SimpleMarkupPromptItemRenderer.cs
@@ -1,0 +1,38 @@
+using System;
+using Spectre.Console.Rendering;
+
+namespace Spectre.Console
+{
+    /// <summary>
+    /// This <see cref="IPromptItemRenderer{T}"/> is based on a simple
+    /// simple <c>Func&lt;T, string&gt;</c> converter to supply the
+    /// markup required to render an item.
+    /// </summary>
+    /// <typeparam name="T">The type of the item that should be rendered.</typeparam>
+    public sealed class SimpleMarkupPromptItemRenderer<T> : IPromptItemRenderer<T>
+    {
+        private readonly Func<T, string> _markupConverter;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimpleMarkupPromptItemRenderer{T}"/> class.
+        /// </summary>
+        /// <param name="markupConverter">The underlying converter to convert to markup.</param>
+        public SimpleMarkupPromptItemRenderer(Func<T, string> markupConverter)
+        {
+            _markupConverter = markupConverter;
+        }
+
+        /// <inheritdoc cref="IPromptItemRenderer{T}.Render"/>
+        public IRenderable Render(T item, PromptItemContext context)
+        {
+            var text = _markupConverter(item);
+
+            if (context.State == PromptItemState.Current)
+            {
+                text = text.RemoveMarkup();
+            }
+
+            return new Markup(text, context.PromptStyle ?? Style.Plain);
+        }
+    }
+}


### PR DESCRIPTION
This was done in three places:

* The `Converter` property now accepts an `IPromptItemRenderer<T>` instead of a `Func<T, string>`. (The `UseConverter<T>()` extension has been modified accordingly, but provides an additional overload using the old syntax for backwards compatibility.)
  The `IPromptItemRenderer<T>` has the benefit of being able to provide different visualizations for normal, disabled and current items.
* The `TypeConverter` that can be used have been broadened to include `TypeConverter` that return `true` for `CanConvertFrom(typeof(IRenderable))` or `CanConvertFrom(typeof(Renderable))`.
* If the type of the prompt item is an `IRenderable` that will be used directly.

The order of usage/conversion is as follows:
* If `Converter` is set, that converter will be used.
* If the item can be cast to `IRenderable` (i.e. `item.Node.Data is IRenderable == true`), then the item will be rendered "as is".
* The `TypeConverter` is requested
  * If the `TypeConverter` supports converting to `IRenderable`, that conversion is used.
  * The  `TypeConverter` is used to convert to `string` (which is then interpreted as markup).

### Breaking Change
If a program used the `Converter` property directly instead of the `UseConverter<T>()` extension - this code will break. I have added a `SimpleMarkupPromptItemRenderer` to ease the migration path. (Additionally, the `UseConverter<T>()` has an overload that takes the old syntax of  `Func<T, string>`, so that could be used, too.)

E.g. the old code
```
prompt.Converter = x => x.ToString();
``` 
can be converted to 
```
prompt.Converter = new SimpleMarkupPromptItemRenderer(x => x.ToString());
```
or, alternatively, use the `UseConverter<T>()` extension:

```
prompt.UseConverter(x => x.ToString());
```

This is the only breaking change in the code - every thing else should work  as before, unchanged.

All the unit tests still pass, and I have added a simple example of the usage in the Prompt examples.

fixes #567 