### PR TITLE
fixed documentation for selection and multiselection (#499)

### DIFF
--- a/docs/input/prompts/multiselection.md
+++ b/docs/input/prompts/multiselection.md
@@ -29,9 +29,8 @@ var fruits = AnsiConsole.Prompt(
         .InstructionsText(
             "[grey](Press [blue]<space>[/] to toggle a fruit, " + 
             "[green]<enter>[/] to accept)[/]")
-        .AddChoice("Apple")
         .AddChoices(new[] {
-            "Apricot", "Avocado", 
+            "Apple", "Apricot", "Avocado", 
             "Banana", "Blackcurrant", "Blueberry",
             "Cherry", "Cloudberry", "Cocunut",
         }));

--- a/docs/input/prompts/selection.md
+++ b/docs/input/prompts/selection.md
@@ -22,9 +22,8 @@ var fruit = AnsiConsole.Prompt(
         .Title("What's your [green]favorite fruit[/]?")
         .PageSize(10)
         .MoreChoicesText("[grey](Move up and down to reveal more fruits)[/]")
-        .AddChoice("Apple")
         .AddChoices(new[] {
-            "Apricot", "Avocado", 
+            "Apple", "Apricot", "Avocado", 
             "Banana", "Blackcurrant", "Blueberry",
             "Cherry", "Cloudberry", "Cocunut",
         }));


### PR DESCRIPTION
fixes #499 

I removed `.AddChoice(T item)` - so the examples will compile again.