### PR TITLE
Upgrades Statiq and re-enables docs publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,6 @@ jobs:
 
   docs:
     name: Documentation
-    if: false # Disable for now
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,7 +17,6 @@ jobs:
 
   build:
     name: Deploy
-    if: false # Disable for now
     runs-on: windows-latest
     steps:
     - name: Checkout

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,6 @@ jobs:
 
   docs:
     name: Documentation
-    if: false # Disable for now
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -45,7 +44,7 @@ jobs:
 
   build:
     name: Build
-    # needs: [docs]
+    needs: [docs]
     if: "!contains(github.event.head_commit.message, 'skip-ci') || startsWith(github.ref, 'refs/tags/')"
     strategy:
       matrix:

--- a/docs/Docs.csproj
+++ b/docs/Docs.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Playwright" Version="1.13.0-next-1" />
 
-    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.31" />
+    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.34" />
     <PackageReference Include="MinVer" PrivateAssets="All" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Previous versions of Statiq had a bug with .NET 6 RC1. The latest has a workaround that allows publishing