### PR TITLE
Escape any Markup when displaying selected prompt items

### DIFF
--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -253,7 +253,7 @@ namespace Spectre.Console
                 var text = (Converter ?? TypeConverterHelper.ConvertToString)?.Invoke(item.Node.Data) ?? item.Node.Data.ToString() ?? "?";
                 if (current)
                 {
-                    text = text.RemoveMarkup();
+                    text = text.RemoveMarkup().EscapeMarkup();
                 }
 
                 var checkbox = item.Node.IsSelected

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -167,7 +167,7 @@ namespace Spectre.Console
                 var text = (Converter ?? TypeConverterHelper.ConvertToString)?.Invoke(item.Node.Data) ?? item.Node.Data.ToString() ?? "?";
                 if (current)
                 {
-                    text = text.RemoveMarkup();
+                    text = text.RemoveMarkup().EscapeMarkup();
                 }
 
                 grid.AddRow(new Markup(indent + prompt + " " + text, style));

--- a/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -1,0 +1,30 @@
+using System;
+using Shouldly;
+using Spectre.Console.Testing;
+using Xunit;
+
+namespace Spectre.Console.Tests.Unit
+{
+    public sealed class SelectionPromptTests
+    {
+        [Fact]
+        [GitHubIssue(608)]
+        public void Should_Not_Throw_When_Selecting_An_Item_With_Escaped_Markup()
+        {
+            // Given
+            var console = new TestConsole();
+            console.Profile.Capabilities.Interactive = true;
+            console.Input.PushKey(ConsoleKey.Enter);
+            var input = "[red]This text will never be red[/]".EscapeMarkup();
+
+            // When
+            var prompt = new SelectionPrompt<string>()
+                    .Title("Select one")
+                    .AddChoices(input);
+            prompt.Show(console);
+            
+            // Then
+            console.Output.ShouldContain(@"[red]This text will never be red[/]");
+        }    
+    }
+}


### PR DESCRIPTION
If the item contained escaped markup, after the call to RemoveMarkup
the string will contain unescaped markup (that the user explicitly had
escaped before) for those cases we need to escape all remaining markup.