### PR TITLE
Remove `Render` from docs in favor of `Write`

### DIFF
--- a/docs/input/markup.md
+++ b/docs/input/markup.md
@@ -15,7 +15,7 @@ Console markup uses a syntax inspired by bbcode. If you write the style (see [St
 in square brackets, e.g. `[bold red]`, that style will apply until it is closed with a `[/]`.
 
 ```csharp
-AnsiConsole.Render(new Markup("[bold yellow]Hello[/] [red]World![/]"));
+AnsiConsole.Write(new Markup("[bold yellow]Hello[/] [red]World![/]"));
 ```
 
 The `Markup` class implements `IRenderable` which means that you 
@@ -26,7 +26,7 @@ rendering of `IRenderable` also have overloads for rendering rich text.
 var table = new Table();
 table.AddColumn(new TableColumn(new Markup("[yellow]Foo[/]")));
 table.AddColumn(new TableColumn("[blue]Bar[/]"));
-AnsiConsole.Render(table);
+AnsiConsole.Write(table);
 ```
 
 ## Convenience methods

--- a/docs/input/widgets/barchart.md
+++ b/docs/input/widgets/barchart.md
@@ -17,7 +17,7 @@ Use `BarChart` to render bar charts to the console.
 ### Basic usage
 
 ```csharp
-AnsiConsole.Render(new BarChart()
+AnsiConsole.Write(new BarChart()
     .Width(60)
     .Label("[green bold underline]Number of fruits[/]")
     .CenterLabel()
@@ -38,7 +38,7 @@ var items = new List<(string Label, double Value)>
 };
 
 // Render bar chart
-AnsiConsole.Render(new BarChart()
+AnsiConsole.Write(new BarChart()
     .Width(60)
     .Label("[green bold underline]Number of fruits[/]")
     .CenterLabel()
@@ -72,7 +72,7 @@ var items = new List<Fruit>
 };
 
 // Render bar chart
-AnsiConsole.Render(new BarChart()
+AnsiConsole.Write(new BarChart()
     .Width(60)
     .Label("[green bold underline]Number of fruits[/]")
     .CenterLabel()

--- a/docs/input/widgets/calendar.md
+++ b/docs/input/widgets/calendar.md
@@ -16,7 +16,7 @@ To render a calendar, create a `Calendar` instance with a target date.
 
 ```csharp
 var calendar = new Calendar(2020,10);
-AnsiConsole.Render(calendar);
+AnsiConsole.Write(calendar);
 ```
 
 <?# AsciiCast cast="calendar" /?>
@@ -27,8 +27,8 @@ You can set the calendar's culture to show localized weekdays.
 
 ```csharp
 var calendar = new Calendar(2020,10);
-calendar.Culture("ja-JP");
-AnsiConsole.Render(calendar);
+calendar.Culture("sv-SE");
+AnsiConsole.Write(calendar);
 ```
 
 <?# AsciiCast cast="calendar-culture" /?>
@@ -40,7 +40,7 @@ You can hide the calendar header.
 ```csharp
 var calendar = new Calendar(2020,10);
 calendar.HideHeader();
-AnsiConsole.Render(calendar);
+AnsiConsole.Write(calendar);
 ```
 
 You can set the header style of the calendar.
@@ -48,7 +48,7 @@ You can set the header style of the calendar.
 ```csharp
 var calendar = new Calendar(2020, 10);
 calendar.HeaderStyle(Style.Parse("blue bold"));
-AnsiConsole.Render(calendar);
+AnsiConsole.Write(calendar);
 ```
 
 <?# AsciiCast cast="calendar-header" /?>

--- a/docs/input/widgets/canvas-image.md
+++ b/docs/input/widgets/canvas-image.md
@@ -26,7 +26,7 @@ var image = new CanvasImage("cake.png");
 image.MaxWidth(16);
 
 // Render the image to the console
-AnsiConsole.Render(image);
+AnsiConsole.Write(image);
 ```
 
 ## Result
@@ -50,7 +50,7 @@ image.BilinearResampler();
 image.Mutate(ctx => ctx.Grayscale().Rotate(-45).EntropyCrop());
 
 // Render the image to the console
-AnsiConsole.Render(image);
+AnsiConsole.Write(image);
 ```
 
 ## Result

--- a/docs/input/widgets/canvas.md
+++ b/docs/input/widgets/canvas.md
@@ -28,7 +28,7 @@ for(var i = 0; i < canvas.Width; i++)
 }
 
 // Render the canvas
-AnsiConsole.Render(canvas);
+AnsiConsole.Write(canvas);
 ```
 
 ## Result

--- a/docs/input/widgets/figlet.md
+++ b/docs/input/widgets/figlet.md
@@ -9,7 +9,7 @@ Spectre.Console can render [FIGlet](http://www.figlet.org/) text by using the `F
 ## Default font
 
 ```csharp
-AnsiConsole.Render(
+AnsiConsole.Write(
     new FigletText("Hello")
         .LeftAligned()
         .Color(Color.Red));
@@ -23,7 +23,7 @@ AnsiConsole.Render(
 ```csharp
 var font = FigletFont.Load("starwars.flf");
 
-AnsiConsole.Render(
+AnsiConsole.Write(
     new FigletText(font, "Hello")
         .LeftAligned()
         .Color(Color.Red));

--- a/docs/input/widgets/rule.md
+++ b/docs/input/widgets/rule.md
@@ -18,7 +18,7 @@ To render a rule without a title:
 
 ```csharp
 var rule = new Rule();
-AnsiConsole.Render(rule);
+AnsiConsole.Write(rule);
 ```
 
 ## Title
@@ -27,7 +27,7 @@ You can set the rule title markup text.
 
 ```csharp
 var rule = new Rule("[red]Hello[/]");
-AnsiConsole.Render(rule);
+AnsiConsole.Write(rule);
 ```
 
 ```text
@@ -41,7 +41,7 @@ You can set the rule's title alignment.
 ```csharp
 var rule = new Rule("[red]Hello[/]");
 rule.Alignment = Justify.Left;
-AnsiConsole.Render(rule);
+AnsiConsole.Write(rule);
 ```
 
 ```text
@@ -53,7 +53,7 @@ You can also specify it via an extension method:
 ```csharp
 var rule = new Rule("[red]Hello[/]");
 rule.LeftAligned();
-AnsiConsole.Render(rule);
+AnsiConsole.Write(rule);
 ```
 
 ```text
@@ -66,12 +66,12 @@ AnsiConsole.Render(rule);
 ```csharp
 var rule = new Rule("[red]Hello[/]");
 rule.Style = Style.Parse("red dim");
-AnsiConsole.Render(rule);
+AnsiConsole.Write(rule);
 ```
 You can also specify it via an extension method
 
 ```csharp
 var rule = new Rule("[red]Hello[/]");
 rule.RuleStyle("red dim");
-AnsiConsole.Render(rule);
+AnsiConsole.Write(rule);
 ```

--- a/docs/input/widgets/table.md
+++ b/docs/input/widgets/table.md
@@ -35,7 +35,7 @@ table.AddRow("Baz", "[green]Qux[/]");
 table.AddRow(new Markup("[blue]Corgi[/]"), new Panel("Waldo"));
 
 // Render the table to the console
-AnsiConsole.Render(table);
+AnsiConsole.Write(table);
 ```
 
 This will render the following output:

--- a/docs/input/widgets/tree.md
+++ b/docs/input/widgets/tree.md
@@ -35,7 +35,7 @@ bar.AddNode(new Calendar(2020, 12)
     .HideHeader());
 
 // Render the tree
-AnsiConsole.Render(root);
+AnsiConsole.Write(root);
 ```
 
 ## Collapsing nodes


### PR DESCRIPTION
The `Render` method has been obsoleted.