### PR TITLE
Fix type conversion in the default pair deconstructor implementation

### DIFF
--- a/src/Spectre.Console/Cli/Internal/DefaultPairDeconstructor.cs
+++ b/src/Spectre.Console/Cli/Internal/DefaultPairDeconstructor.cs
@@ -19,9 +19,6 @@ namespace Spectre.Console.Cli
                 throw new ArgumentNullException(nameof(value));
             }
 
-            var keyConverter = GetConverter(keyType);
-            var valueConverter = GetConverter(valueType);
-
             var parts = value.Split(new[] { '=' }, StringSplitOptions.None);
             if (parts.Length < 1 || parts.Length > 2)
             {
@@ -47,15 +44,16 @@ namespace Spectre.Console.Cli
                 }
             }
 
-            return (Parse(keyConverter, keyType, stringkey),
-                Parse(valueConverter, valueType, stringValue));
+            return (Parse(stringkey, keyType),
+                Parse(stringValue, valueType));
         }
 
-        private static object Parse(TypeConverter converter, Type type, string value)
+        private static object? Parse(string value, Type targetType)
         {
             try
             {
-                return converter.ConvertTo(value, type);
+                var converter = GetConverter(targetType);
+                return converter.ConvertFrom(value);
             }
             catch
             {

--- a/test/Spectre.Console.Tests/Unit/Cli/CommandAppTests.Pairs.cs
+++ b/test/Spectre.Console.Tests/Unit/Cli/CommandAppTests.Pairs.cs
@@ -35,6 +35,12 @@ namespace Spectre.Console.Tests.Unit.Cli
                 public IDictionary<string, int> Values { get; set; }
             }
 
+            public sealed class DefaultPairDeconstructorEnumValueSettings : CommandSettings
+            {
+                [CommandOption("--var <VALUE>")]
+                public IDictionary<string, DayOfWeek> Values { get; set; }
+            }
+
             public sealed class LookupSettings : CommandSettings
             {
                 [CommandOption("--var <VALUE>")]
@@ -150,6 +156,35 @@ namespace Spectre.Console.Tests.Unit.Cli
                     pair.Values.Count.ShouldBe(2);
                     pair.Values["foo"].ShouldBe(3);
                     pair.Values["bar"].ShouldBe(4);
+                });
+            }
+
+            [Fact]
+            public void Should_Map_Pairs_With_Enum_Value_To_Pair_Deconstructable_Collection_Using_Default_Deconstructor()
+            {
+                // Given
+                var app = new CommandAppTester();
+                app.SetDefaultCommand<GenericCommand<DefaultPairDeconstructorEnumValueSettings>>();
+                app.Configure(config =>
+                {
+                    config.PropagateExceptions();
+                });
+
+                // When
+                var result = app.Run(new[]
+                {
+                    "--var", "foo=Monday",
+                    "--var", "bar=Tuesday",
+                });
+
+                // Then
+                result.ExitCode.ShouldBe(0);
+                result.Settings.ShouldBeOfType<DefaultPairDeconstructorEnumValueSettings>().And(pair =>
+                {
+                    pair.Values.ShouldNotBeNull();
+                    pair.Values.Count.ShouldBe(2);
+                    pair.Values["foo"].ShouldBe(DayOfWeek.Monday);
+                    pair.Values["bar"].ShouldBe(DayOfWeek.Tuesday);
                 });
             }
 


### PR DESCRIPTION
The code using the TypeConverter was written backwards (using `ConvertTo` instead of `ConvertFrom`) and would thus throw an exception. For example, when converting an enum:
> System.NotSupportedException: 'EnumConverter' is unable to convert 'System.String' to 'System.DayOfWeek'.

A test covering conversion of enums was added: `Should_Map_Pairs_With_Enum_Value_To_Pair_Deconstructable_Collection_Using_Default_Deconstructor`