### PR TITLE
Fix typo in PairDeconstructor class name

### DIFF
--- a/src/Spectre.Console/Cli/Internal/Modelling/CommandParameter.cs
+++ b/src/Spectre.Console/Cli/Internal/Modelling/CommandParameter.cs
@@ -28,7 +28,7 @@ namespace Spectre.Console.Cli
             Type parameterType, ParameterKind parameterKind, PropertyInfo property,
             string? description, TypeConverterAttribute? converter,
             DefaultValueAttribute? defaultValue,
-            PairDeconstructorAttribute? deconstuctor,
+            PairDeconstructorAttribute? deconstructor,
             ParameterValueProviderAttribute? valueProvider,
             IEnumerable<ParameterValidationAttribute> validators, bool required)
         {
@@ -39,7 +39,7 @@ namespace Spectre.Console.Cli
             Description = description;
             Converter = converter;
             DefaultValue = defaultValue;
-            PairDeconstructor = deconstuctor;
+            PairDeconstructor = deconstructor;
             ValueProvider = valueProvider;
             Validators = new List<ParameterValidationAttribute>(validators ?? Array.Empty<ParameterValidationAttribute>());
             Required = required;

--- a/src/Spectre.Console/Cli/PairDeconstructor.cs
+++ b/src/Spectre.Console/Cli/PairDeconstructor.cs
@@ -7,7 +7,7 @@ namespace Spectre.Console.Cli
     /// </summary>
     /// <typeparam name="TKey">The key type.</typeparam>
     /// <typeparam name="TValue">The value type.</typeparam>
-    public abstract class PairDeconstuctor<TKey, TValue> : IPairDeconstructor
+    public abstract class PairDeconstructor<TKey, TValue> : IPairDeconstructor
     {
         /// <summary>
         /// Deconstructs the provided <see cref="string"/> into a pair.
@@ -26,5 +26,16 @@ namespace Spectre.Console.Cli
 
             return Deconstruct(value);
         }
+    }
+
+    /// <summary>
+    /// Base class for a pair deconstructor.
+    /// </summary>
+    /// <typeparam name="TKey">The key type.</typeparam>
+    /// <typeparam name="TValue">The value type.</typeparam>
+    /// <remarks>This class is misspelled, use <see cref="PairDeconstructor{TKey,TValue}"/> instead.</remarks>
+    [Obsolete("Use PairDeconstructor instead")]
+    public abstract class PairDeconstuctor<TKey, TValue> : PairDeconstructor<TKey, TValue>
+    {
     }
 }

--- a/test/Spectre.Console.Tests/Unit/Cli/CommandAppTests.Pairs.cs
+++ b/test/Spectre.Console.Tests/Unit/Cli/CommandAppTests.Pairs.cs
@@ -56,7 +56,7 @@ namespace Spectre.Console.Tests.Unit.Cli
                 public IReadOnlyDictionary<string, string> Values { get; set; }
             }
 
-            public sealed class StringIntDeconstructor : PairDeconstuctor<string, string>
+            public sealed class StringIntDeconstructor : PairDeconstructor<string, string>
             {
                 protected override (string Key, string Value) Deconstruct(string value)
                 {


### PR DESCRIPTION
PairDeconstuctor → PairDeconstructor (was missing an 'r')

Keeping `PairDeconstuctor` and marking it as obsolete since it's a public type.