### PR TITLE
(#555) Clarify ITypeResolver returns `null`

### DIFF
--- a/docs/input/cli/commandApp.md
+++ b/docs/input/cli/commandApp.md
@@ -74,6 +74,9 @@ return app.Run(args);
 
 `TypeRegistrar` is a custom class that must be created by the user. This [example using `Microsoft.Extensions.DependencyInjection` as the container](https://github.com/spectreconsole/spectre.console/tree/main/examples/Cli/Injection) provides an example `TypeRegistrar` and `TypeResolver` that can be added to your application with small adjustments for your DI container.
 
+Hint: If you do write your own implementation of `TypeRegistrar` and `TypeResolver` and you have some form of unit tests in place for your project,
+there is a utility `TypeRegistrarBaseTests` available that can be used to ensure your implementations adhere to the required implementation. Simply call `TypeRegistrarBaseTests.RunAllTests()` and expect no `TypeRegistrarBaseTests.TestFailedException` to be thrown.
+
 ## Interception
 
 `CommandApp` also provides a `SetInterceptor` configuration. An interceptor is run before all commands are executed. This is typically used for configuring logging or other infrastructure concerns.

--- a/examples/Cli/Injection/Infrastructure/TypeResolver.cs
+++ b/examples/Cli/Injection/Infrastructure/TypeResolver.cs
@@ -15,7 +15,12 @@ namespace Spectre.Console.Examples
 
         public object Resolve(Type type)
         {
-            return _provider.GetRequiredService(type);
+            if (type == null)
+            {
+                return null;
+            }
+
+            return _provider.GetService(type);
         }
 
         public void Dispose()

--- a/src/Spectre.Console.Testing/Cli/TypeRegistrarBaseTests.cs
+++ b/src/Spectre.Console.Testing/Cli/TypeRegistrarBaseTests.cs
@@ -1,0 +1,191 @@
+using System;
+using Spectre.Console.Cli;
+
+namespace Spectre.Console.Testing
+{
+    /// <summary>
+    /// This is a utility class for implementors of
+    /// <see cref="ITypeRegistrar"/> and corresponding <see cref="ITypeResolver"/>.
+    /// </summary>
+    public sealed class TypeRegistrarBaseTests
+    {
+        private readonly Func<ITypeRegistrar> _registrarFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TypeRegistrarBaseTests"/> class.
+        /// </summary>
+        /// <param name="registrarFactory">The factory to create a new, clean <see cref="ITypeRegistrar"/> to be used for each test.</param>
+        public TypeRegistrarBaseTests(Func<ITypeRegistrar> registrarFactory)
+        {
+            _registrarFactory = registrarFactory;
+        }
+
+        /// <summary>
+        /// Runs all tests.
+        /// </summary>
+        /// <exception cref="TestFailedException">This exception is raised, if a test fails.</exception>
+        public void RunAllTests()
+        {
+            var testCases = new Action<ITypeRegistrar>[]
+            {
+                RegistrationsCanBeResolved,
+                InstanceRegistrationsCanBeResolved,
+                LazyRegistrationsCanBeResolved,
+                ResolvingNotRegisteredServiceReturnsNull,
+                ResolvingNullTypeReturnsNull,
+            };
+
+            foreach (var test in testCases)
+            {
+                test(_registrarFactory());
+            }
+        }
+
+        private static void ResolvingNullTypeReturnsNull(ITypeRegistrar registrar)
+        {
+            // Given no registration
+            var resolver = registrar.Build();
+
+            try
+            {
+                // When
+                var actual = resolver.Resolve(null);
+
+                // Then
+                if (actual != null)
+                {
+                    throw new TestFailedException(
+                        $"Expected the resolver to resolve null, since null was requested as the service type. Actually resolved {actual.GetType().Name}.");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new TestFailedException(
+                    $"Expected the resolver not to throw, but caught {ex.GetType().Name}.", ex);
+            }
+        }
+
+        private static void ResolvingNotRegisteredServiceReturnsNull(ITypeRegistrar registrar)
+        {
+            // Given no registration
+            var resolver = registrar.Build();
+
+            try
+            {
+                // When
+                var actual = resolver.Resolve(typeof(IMockService));
+
+                // Then
+                if (actual != null)
+                {
+                    throw new TestFailedException(
+                        $"Expected the resolver to resolve null, since no service was registered. Actually resolved {actual.GetType().Name}.");
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new TestFailedException(
+                    $"Expected the resolver not to throw, but caught {ex.GetType().Name}.", ex);
+            }
+        }
+
+        private static void RegistrationsCanBeResolved(ITypeRegistrar registrar)
+        {
+            // Given
+            registrar.Register(typeof(IMockService), typeof(MockService));
+            var resolver = registrar.Build();
+
+            // When
+            var actual = resolver.Resolve(typeof(IMockService));
+
+            // Then
+            if (actual == null)
+            {
+                throw new TestFailedException(
+                    $"Expected the resolver to resolve an instance of {nameof(MockService)}. Actually resolved null.");
+            }
+
+            if (actual is not MockService)
+            {
+                throw new TestFailedException(
+                    $"Expected the resolver to resolve an instance of {nameof(MockService)}. Actually resolved {actual.GetType().Name}.");
+            }
+        }
+
+        private static void InstanceRegistrationsCanBeResolved(ITypeRegistrar registrar)
+        {
+            // Given
+            var instance = new MockService();
+            registrar.RegisterInstance(typeof(IMockService), instance);
+            var resolver = registrar.Build();
+
+            // When
+            var actual = resolver.Resolve(typeof(IMockService));
+
+            // Then
+            if (!ReferenceEquals(actual, instance))
+            {
+                throw new TestFailedException(
+                    "Expected the resolver to resolve exactly the registered instance.");
+            }
+        }
+
+        private static void LazyRegistrationsCanBeResolved(ITypeRegistrar registrar)
+        {
+            // Given
+            var instance = new MockService();
+            var factoryCalled = false;
+            registrar.RegisterLazy(typeof(IMockService), () =>
+            {
+                factoryCalled = true;
+                return instance;
+            });
+            var resolver = registrar.Build();
+
+            // When
+            var actual = resolver.Resolve(typeof(IMockService));
+
+            // Then
+            if (!factoryCalled)
+            {
+                throw new TestFailedException(
+                    "Expected the factory to be called, to resolve the lazy registration.");
+            }
+
+            if (!ReferenceEquals(actual, instance))
+            {
+                throw new TestFailedException(
+                    "Expected the resolver to return exactly the result of the lazy-registered factory.");
+            }
+        }
+
+        /// <summary>
+        /// internal use only.
+        /// </summary>
+        private interface IMockService
+        {
+        }
+
+        private class MockService : IMockService
+        {
+        }
+
+        /// <summary>
+        /// Exception, to be raised when a test fails.
+        /// </summary>
+        public sealed class TestFailedException : Exception
+        {
+            /// <inheritdoc cref="Exception" />
+            public TestFailedException(string message)
+                : base(message)
+            {
+            }
+
+            /// <inheritdoc cref="Exception" />
+            public TestFailedException(string message, Exception inner)
+                : base(message, inner)
+            {
+            }
+        }
+    }
+}

--- a/src/Spectre.Console/Cli/ITypeResolver.cs
+++ b/src/Spectre.Console/Cli/ITypeResolver.cs
@@ -11,7 +11,7 @@ namespace Spectre.Console.Cli
         /// Resolves an instance of the specified type.
         /// </summary>
         /// <param name="type">The type to resolve.</param>
-        /// <returns>An instance of the specified type.</returns>
+        /// <returns>An instance of the specified type, or <c>null</c> if no registration for the specified type exists.</returns>
         object? Resolve(Type? type);
     }
 }

--- a/src/Spectre.Console/Cli/Internal/Binding/CommandPropertyBinder.cs
+++ b/src/Spectre.Console/Cli/Internal/Binding/CommandPropertyBinder.cs
@@ -28,16 +28,9 @@ namespace Spectre.Console.Cli
 
         private static CommandSettings CreateSettings(ITypeResolver resolver, Type settingsType)
         {
-            try
+            if (resolver.Resolve(settingsType) is CommandSettings settings)
             {
-                if (resolver.Resolve(settingsType) is CommandSettings settings)
-                {
-                    return settings;
-                }
-            }
-            catch
-            {
-                // ignored
+                return settings;
             }
 
             if (Activator.CreateInstance(settingsType) is CommandSettings instance)

--- a/src/Spectre.Console/Cli/Internal/TypeResolverAdapter.cs
+++ b/src/Spectre.Console/Cli/Internal/TypeResolverAdapter.cs
@@ -20,14 +20,9 @@ namespace Spectre.Console.Cli
 
             try
             {
-                if (_resolver != null)
+                var obj = _resolver?.Resolve(type);
+                if (obj != null)
                 {
-                    var obj = _resolver.Resolve(type);
-                    if (obj == null)
-                    {
-                        throw CommandRuntimeException.CouldNotResolveType(type);
-                    }
-
                     return obj;
                 }
 

--- a/src/Spectre.Console/Spectre.Console.csproj
+++ b/src/Spectre.Console/Spectre.Console.csproj
@@ -17,6 +17,7 @@
     <None Remove="Widgets\Figlet\Fonts\Standard.flf" />
     <None Include="../../resources/gfx/small-logo.png" Pack="true" PackagePath="\" Link="Properties/small-logo.png" />
     <None Include="..\.editorconfig" Link="Cli\.editorconfig" />
+    <InternalsVisibleTo Include="$(AssemblyName).Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Spectre.Console.Tests/Spectre.Console.Tests.csproj
+++ b/test/Spectre.Console.Tests/Spectre.Console.Tests.csproj
@@ -7,10 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\..\src\Spectre.Console\Cli\Internal\Constants.cs" Link="Imported\Constants.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Remove="Data\starwars.flf" />
   </ItemGroup>
 
@@ -24,7 +20,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="Nullable" Version="1.3.0" PrivateAssets="all" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="Spectre.Verify.Extensions" Version="0.3.0" />
     <PackageReference Include="Verify.Xunit" Version="9.0.0-beta.1" />

--- a/test/Spectre.Console.Tests/Unit/Cli/DefaultTypeRegistrarTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Cli/DefaultTypeRegistrarTests.cs
@@ -1,0 +1,16 @@
+using Spectre.Console.Cli;
+using Spectre.Console.Testing;
+using Xunit;
+
+namespace Spectre.Console.Tests.Unit.Cli
+{
+    public sealed class DefaultTypeRegistrarTests
+    {
+        [Fact]
+        public void Should_Pass_Base_Registrar_Tests()
+        {
+            var harness = new TypeRegistrarBaseTests(() => new DefaultTypeRegistrar());
+            harness.RunAllTests();
+        }
+    }
+}


### PR DESCRIPTION
and does not throw on unresolvable types.
Also changed the `TypeResolverAdapter` to adhere
to those expectations and removed the now no longer
needed try-catch from `CommandPropertyBinder`.