### PR TITLE
Fix exception formatting for generic methods

### DIFF
--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
@@ -149,12 +149,12 @@ namespace Spectre.Console
                 {
                     builder.AppendWithStyle(
                         settings.Style.NonEmphasized,
-                        type.Substring(0, index + 1).EscapeMarkup());
+                        type.Substring(0, index + 1));
                 }
 
                 builder.AppendWithStyle(
                     color,
-                    type.Substring(index + 1, type.Length - index - 1).EscapeMarkup());
+                    type.Substring(index + 1, type.Length - index - 1));
             }
             else
             {

--- a/test/Spectre.Console.Tests/Expectations/Exception/CallSite.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Exception/CallSite.Output.verified.txt
@@ -1,6 +1,6 @@
 System.InvalidOperationException: Something threw!
      System.InvalidOperationException: Throwing!
-       at Spectre.Console.Tests.Data.TestExceptions.GenericMethodThatThrows[[T0,T1,TRet]](Nullable`1 number) in /xyz/Exceptions.cs:nn
+       at Spectre.Console.Tests.Data.TestExceptions.GenericMethodThatThrows[T0,T1,TRet](Nullable`1 number) in /xyz/Exceptions.cs:nn
        at Spectre.Console.Tests.Data.TestExceptions.ThrowWithGenericInnerException() in /xyz/Exceptions.cs:nn
   at Spectre.Console.Tests.Data.TestExceptions.ThrowWithGenericInnerException() in /xyz/Exceptions.cs:nn
   at Spectre.Console.Tests.Unit.ExceptionTests.<>c.<Should_Write_Exceptions_With_Generic_Type_Parameters_In_Callsite_As_Expected>b__4_0() in /xyz/ExceptionTests.cs:nn


### PR DESCRIPTION
The generic parameters were double escaped and would display as `[[T0,T1,TRet]]` instead of `[T0,T1,TRet]`. This is because the `builder.AppendWithStyle` method already escapes its value so the caller must not escape the passed value.