### PR TITLE
Update Roslynator.Analyzers to version 3.3

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -37,7 +37,7 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.312">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Analyzers" Version="3.0.0">
+    <PackageReference Include="Roslynator.Analyzers" Version="3.3.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
I kept running into https://github.com/JosefPihrt/Roslynator/issues/833 when using Rider, but it seems this was fixed in version 3.2 thanks to a fix in how they are doing assemblies. Looks like this would also include benefits for people using VS2022 too