### PR TITLE
fix: table title's first letter is getting capitalized by default

### DIFF
--- a/src/Spectre.Console/Widgets/Table/TableRenderer.cs
+++ b/src/Spectre.Console/Widgets/Table/TableRenderer.cs
@@ -163,7 +163,7 @@ namespace Spectre.Console
                 return Array.Empty<Segment>();
             }
 
-            var paragraph = new Markup(header.Text.CapitalizeFirstLetter(), header.Style ?? defaultStyle)
+            var paragraph = new Markup(header.Text, header.Style ?? defaultStyle)
                 .Alignment(Justify.Center)
                 .Overflow(Overflow.Ellipsis);
 

--- a/test/Spectre.Console.Tests/Expectations/Widgets/Table/Render_Title_Caption_LowerCase.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Widgets/Table/Render_Title_Caption_LowerCase.Output.verified.txt
@@ -1,0 +1,8 @@
+        hello world        
+╭────────┬────────┬───────╮
+│ Foo    │ Bar    │ Baz   │
+├────────┼────────┼───────┤
+│ Qux    │ Corgi  │ Waldo │
+│ Grault │ Garply │ Fred  │
+╰────────┴────────┴───────╯
+       goodbye world       

--- a/test/Spectre.Console.Tests/Unit/Widgets/Table/TableTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Widgets/Table/TableTests.cs
@@ -482,6 +482,26 @@ namespace Spectre.Console.Tests.Unit
         }
 
         [Fact]
+        [Expectation("Render_Title_Caption_LowerCase")]
+        public Task Should_Render_Table_Without_Capitalizing_First_Letter()
+        {
+            // Given
+            var console = new TestConsole();
+            var table = new Table { Border = TableBorder.Rounded };
+            table.Title = new TableTitle("hello world");
+            table.Caption = new TableTitle("goodbye world");
+            table.AddColumns("Foo", "Bar", "Baz");
+            table.AddRow("Qux", "Corgi", "Waldo");
+            table.AddRow("Grault", "Garply", "Fred");
+
+            // When
+            console.Write(table);
+
+            // Then
+            return Verifier.Verify(console.Output);
+        }
+
+        [Fact]
         [Expectation("Render_Fold")]
         public Task Should_Render_With_Folded_Text_Table_Correctly()
         {


### PR DESCRIPTION
fix for #638