### PR TITLE
docs: Add missing inheritance and nullable types in settings.md

### DIFF
--- a/docs/input/cli/settings.md
+++ b/docs/input/cli/settings.md
@@ -11,7 +11,7 @@ Example:
 public sealed class MyCommandSettings : CommandSettings
 {
     [CommandArgument(0, "[name]")]
-    public string Name { get; set; }
+    public string? Name { get; set; }
 
     [CommandOption("-c|--count")]
     public int Count { get; set; }
@@ -33,7 +33,7 @@ For example, we could split the above name argument into two values with an opti
 public string FirstName { get; set; }
 
 [CommandArgument(1, "[lastName]")]
-public string LastName { get; set; }
+public string? LastName { get; set; }
 ```
 
 ## CommandOption
@@ -96,7 +96,7 @@ Would allow the user to run `app.exe Dwayne Elizondo "Mountain Dew" Herbert Cama
 `Spectre.Console.Cli` supports constructor initialization and init only initialization. For constructor initialization, the parameter name of the constructor must match the name of the property name of the settings class. Order does not matter.
 
 ```csharp
-public class Settings
+public class Settings : CommandSettings
 {
     public Settings(string[] name)
     {
@@ -112,7 +112,7 @@ public class Settings
 Also supported are init only properties.
 
 ```csharp
-public class Settings
+public class Settings : CommandSettings
 {
     [Description("The name to display")]
     [CommandArgument(0, "[Name]")]
@@ -125,7 +125,7 @@ public class Settings
 Simple type validation is performed automatically, but for scenarios where more complex validation is required, overriding the `Validate` method is supported. This method must return either `ValidationResult.Error` or `ValidationResult.Success`.
 
 ```csharp
-public class Settings
+public class Settings : CommandSettings
 {
     [Description("The name to display")]
     [CommandArgument(0, "[Name]")]

--- a/docs/input/cli/settings.md
+++ b/docs/input/cli/settings.md
@@ -14,7 +14,7 @@ public sealed class MyCommandSettings : CommandSettings
     public string? Name { get; set; }
 
     [CommandOption("-c|--count")]
-    public int Count { get; set; }
+    public int? Count { get; set; }
 }
 ```
 
@@ -50,7 +50,7 @@ There is a special mode for `CommandOptions` on boolean types. Typically all `Co
 
 ```csharp
 [CommandOption("--debug")]
-public bool Debug { get; set; }
+public bool? Debug { get; set; }
 ```
 
 ### Hidden options
@@ -59,7 +59,7 @@ public bool Debug { get; set; }
 
 ```csharp
 [CommandOption("--hidden-opt", IsHidden = true)]
-public bool HiddenOpt { get; set; }
+public bool? HiddenOpt { get; set; }
 ```
 
 ## Description
@@ -105,7 +105,7 @@ public class Settings : CommandSettings
 
     [Description("The name to display")]
     [CommandArgument(0, "[Name]")]
-    public string Name { get; }
+    public string? Name { get; }
 }
 ```
 
@@ -116,7 +116,7 @@ public class Settings : CommandSettings
 {
     [Description("The name to display")]
     [CommandArgument(0, "[Name]")]
-    public string Name { get; init; }
+    public string? Name { get; init; }
 }
 ```
 
@@ -129,7 +129,7 @@ public class Settings : CommandSettings
 {
     [Description("The name to display")]
     [CommandArgument(0, "[Name]")]
-    public string Name { get; init; }
+    public string? Name { get; init; }
 
     public override ValidationResult Validate()
     {


### PR DESCRIPTION
Seems like `settings.md` documentation file is missing some nullable types for non-required properties. Also, examples at the bottom are not compilable because there is a missing inheritance 