### PR TITLE
Add option to configure the style of the choices list and the default value in TextPrompt

### DIFF
--- a/src/Spectre.Console/Prompts/TextPrompt.cs
+++ b/src/Spectre.Console/Prompts/TextPrompt.cs
@@ -69,6 +69,11 @@ public sealed class TextPrompt<T> : IPrompt<T>
     public Style? DefaultValueStyle { get; set; }
 
     /// <summary>
+    /// Gets or sets the style in which the list of choices is displayed.
+    /// </summary>
+    public Style? ChoicesStyle { get; set; }
+
+    /// <summary>
     /// Gets or sets the default value.
     /// </summary>
     internal DefaultPromptValue<T>? DefaultValue { get; set; }
@@ -188,7 +193,8 @@ public sealed class TextPrompt<T> : IPrompt<T>
             appendSuffix = true;
             var converter = Converter ?? TypeConverterHelper.ConvertToString;
             var choices = string.Join("/", Choices.Select(choice => converter(choice)));
-            builder.AppendFormat(CultureInfo.InvariantCulture, " [blue][[{0}]][/]", choices);
+            var choicesStyle = ChoicesStyle?.ToMarkup() ?? "blue";
+            builder.AppendFormat(CultureInfo.InvariantCulture, " [{0}][[{1}]][/]", choicesStyle, choices);
         }
 
         if (ShowDefaultValue && DefaultValue != null)

--- a/src/Spectre.Console/Prompts/TextPrompt.cs
+++ b/src/Spectre.Console/Prompts/TextPrompt.cs
@@ -64,6 +64,11 @@ public sealed class TextPrompt<T> : IPrompt<T>
     public Func<T, ValidationResult>? Validator { get; set; }
 
     /// <summary>
+    /// Gets or sets the style in which the default value is displayed.
+    /// </summary>
+    public Style? DefaultValueStyle { get; set; }
+
+    /// <summary>
     /// Gets or sets the default value.
     /// </summary>
     internal DefaultPromptValue<T>? DefaultValue { get; set; }
@@ -190,9 +195,12 @@ public sealed class TextPrompt<T> : IPrompt<T>
         {
             appendSuffix = true;
             var converter = Converter ?? TypeConverterHelper.ConvertToString;
+            var defaultValueStyle = DefaultValueStyle?.ToMarkup() ?? "green";
+
             builder.AppendFormat(
                 CultureInfo.InvariantCulture,
-                " [green]({0})[/]",
+                " [{0}]({1})[/]",
+                defaultValueStyle,
                 IsSecret ? "******" : converter(DefaultValue.Value));
         }
 

--- a/src/Spectre.Console/Prompts/TextPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/TextPromptExtensions.cs
@@ -305,4 +305,27 @@ public static class TextPromptExtensions
         obj.Converter = displaySelector;
         return obj;
     }
+
+    /// <summary>
+    /// Sets the style in which the default value is displayed.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="style">The default value style.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static TextPrompt<T> DefaultValueStyle<T>(this TextPrompt<T> obj, Style style)
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        if (style is null)
+        {
+            throw new ArgumentNullException(nameof(style));
+        }
+
+        obj.DefaultValueStyle = style;
+        return obj;
+    }
 }

--- a/src/Spectre.Console/Prompts/TextPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/TextPromptExtensions.cs
@@ -328,4 +328,27 @@ public static class TextPromptExtensions
         obj.DefaultValueStyle = style;
         return obj;
     }
+
+    /// <summary>
+    /// Sets the style in which the list of choices is displayed.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="style">The style to use for displaying the choices.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static TextPrompt<T> ChoicesStyle<T>(this TextPrompt<T> obj, Style style)
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        if (style is null)
+        {
+            throw new ArgumentNullException(nameof(style));
+        }
+
+        obj.ChoicesStyle = style;
+        return obj;
+    }
 }

--- a/test/Spectre.Console.Tests/Expectations/Prompts/Text/ChoicesStyleNotSet.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Prompts/Text/ChoicesStyleNotSet.Output.verified.txt
@@ -1,0 +1,1 @@
+Enter Value: [38;5;12m[Choice 1/Choice 2][0m: Choice 2

--- a/test/Spectre.Console.Tests/Expectations/Prompts/Text/ChoicesStyleSet.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Prompts/Text/ChoicesStyleSet.Output.verified.txt
@@ -1,0 +1,1 @@
+Enter Value: [38;5;9m[Choice 1/Choice 2][0m: Choice 2

--- a/test/Spectre.Console.Tests/Expectations/Prompts/Text/DefaultValueStyleNotSet.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Prompts/Text/DefaultValueStyleNotSet.Output.verified.txt
@@ -1,0 +1,1 @@
+Enter Value: [38;5;2m(default)[0m: Input

--- a/test/Spectre.Console.Tests/Expectations/Prompts/Text/DefaultValueStyleSet.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Prompts/Text/DefaultValueStyleSet.Output.verified.txt
@@ -1,0 +1,1 @@
+Enter Value: [38;5;9m(default)[0m: Input

--- a/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -241,4 +241,49 @@ public sealed class TextPromptTests
         // Then
         return Verifier.Verify(console.Output);
     }
+
+    [Fact]
+    [Expectation("DefaultValueStyleNotSet")]
+    public Task Uses_default_style_for_default_value_if_no_style_is_set()
+    {
+        // Given
+        var console = new TestConsole
+        {
+            EmitAnsiSequences = true,
+        };
+        console.Input.PushTextWithEnter("Input");
+
+        var prompt = new TextPrompt<string>("Enter Value:")
+                .ShowDefaultValue()
+                .DefaultValue("default");
+
+        // When
+        console.Prompt(prompt);
+
+        // Then
+        return Verifier.Verify(console.Output);
+    }
+
+    [Fact]
+    [Expectation("DefaultValueStyleSet")]
+    public Task Uses_specified_default_value_style()
+    {
+        // Given
+        var console = new TestConsole
+        {
+            EmitAnsiSequences = true,
+        };
+        console.Input.PushTextWithEnter("Input");
+
+        var prompt = new TextPrompt<string>("Enter Value:")
+                .ShowDefaultValue()
+                .DefaultValue("default")
+                .DefaultValueStyle(new Style(foreground: Color.Red));
+
+        // When
+        console.Prompt(prompt);
+
+        // Then
+        return Verifier.Verify(console.Output);
+    }
 }

--- a/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -286,4 +286,51 @@ public sealed class TextPromptTests
         // Then
         return Verifier.Verify(console.Output);
     }
+
+    [Fact]
+    [Expectation("ChoicesStyleNotSet")]
+    public Task Uses_default_style_for_choices_if_no_style_is_set()
+    {
+        // Given
+        var console = new TestConsole
+        {
+            EmitAnsiSequences = true,
+        };
+        console.Input.PushTextWithEnter("Choice 2");
+
+        var prompt = new TextPrompt<string>("Enter Value:")
+                .ShowChoices()
+                .AddChoice("Choice 1")
+                .AddChoice("Choice 2");
+
+        // When
+        console.Prompt(prompt);
+
+        // Then
+        return Verifier.Verify(console.Output);
+    }
+
+    [Fact]
+    [Expectation("ChoicesStyleSet")]
+    public Task Uses_the_specified_choices_style()
+    {
+        // Given
+        var console = new TestConsole
+        {
+            EmitAnsiSequences = true,
+        };
+        console.Input.PushTextWithEnter("Choice 2");
+
+        var prompt = new TextPrompt<string>("Enter Value:")
+                .ShowChoices()
+                .AddChoice("Choice 1")
+                .AddChoice("Choice 2")
+                .ChoicesStyle(new Style(foreground: Color.Red));
+
+        // When
+        console.Prompt(prompt);
+
+        // Then
+        return Verifier.Verify(console.Output);
+    }
 }


### PR DESCRIPTION
TextPrompt currently uses a fixed style for the default value (green text) and the list of choices (blue text).

This PR adds two new properties to TextPrompt (`DefaultValueStyle` and `ChoicesStyle`) that allow customozing the style of these values.
If no styles are set, the current green & blue values continue to be used.

Note: I'm unsure if there are tests that cover the styling of TextPrompt. If there is a place I can add a test for this, it would be great if you could point me in the right direction.
