### PR TITLE
Add table/grid column width in fixed, sizeToConent (auto) and star (proportional)

### DIFF
--- a/src/Spectre.Console/Extensions/ColumnExtensions.cs
+++ b/src/Spectre.Console/Extensions/ColumnExtensions.cs
@@ -1,3 +1,5 @@
+using System.Drawing;
+
 namespace Spectre.Console;
 
 /// <summary>
@@ -24,13 +26,13 @@ public static class ColumnExtensions
     }
 
     /// <summary>
-    /// Sets the width of the column.
+    /// Sets the width of the column to a fix size.
     /// </summary>
     /// <typeparam name="T">An object implementing <see cref="IColumn"/>.</typeparam>
     /// <param name="obj">The column.</param>
-    /// <param name="width">The column width.</param>
+    /// <param name="size">The column width.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static T Width<T>(this T obj, int? width)
+    public static T FixWidth<T>(this T obj, int size)
         where T : class, IColumn
     {
         if (obj is null)
@@ -38,7 +40,57 @@ public static class ColumnExtensions
             throw new ArgumentNullException(nameof(obj));
         }
 
-        obj.Width = width;
+        if (size < 0)
+        {
+            throw new ArgumentException("Fixed width cannot be negative", nameof(size));
+        }
+
+        obj.Width = size;
+        obj.SizeMode = SizeMode.Fixed;
+        return obj;
+    }
+
+    /// <summary>
+    /// Sets the width of the column to a proportional weight.
+    /// </summary>
+    /// <typeparam name="T">An object implementing <see cref="IColumn"/>.</typeparam>
+    /// <param name="obj">The column.</param>
+    /// <param name="weight">The column width.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static T StarWidth<T>(this T obj, double weight)
+        where T : class, IColumn
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        if (weight < 0.0)
+        {
+            throw new ArgumentException("Weight cannot be negative", nameof(weight));
+        }
+
+        obj.Width = weight;
+        obj.SizeMode = SizeMode.Star;
+        return obj;
+    }
+
+    /// <summary>
+    /// Sets the column to auto size to content.
+    /// </summary>
+    /// <typeparam name="T">An object implementing <see cref="IColumn"/>.</typeparam>
+    /// <param name="obj">The column.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static T SizeToContent<T>(this T obj)
+        where T : class, IColumn
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        obj.Width = null;
+        obj.SizeMode = SizeMode.SizeToContent;
         return obj;
     }
 }

--- a/src/Spectre.Console/IColumn.cs
+++ b/src/Spectre.Console/IColumn.cs
@@ -14,5 +14,10 @@ public interface IColumn : IAlignable, IPaddable
     /// <summary>
     /// Gets or sets the width of the column.
     /// </summary>
-    int? Width { get; set; }
+    double? Width { get; set; }
+
+    /// <summary>
+    ///
+    /// </summary>
+    SizeMode SizeMode { get; set; }
 }

--- a/src/Spectre.Console/SizeMode.cs
+++ b/src/Spectre.Console/SizeMode.cs
@@ -1,0 +1,16 @@
+﻿namespace Spectre.Console;
+
+/// <summary>
+/// Defines how the width value will be interpreted.
+/// </summary>
+public enum SizeMode
+{
+    /// <summary>Fixed size.</summary>
+    Fixed = 1,
+
+    /// <summary>Proportional sizing.</summary>
+    Star = 2,
+
+    /// <summary>Auto-size width to content.</summary>
+    SizeToContent = 0,
+}

--- a/src/Spectre.Console/Widgets/GridColumn.cs
+++ b/src/Spectre.Console/Widgets/GridColumn.cs
@@ -6,7 +6,8 @@ namespace Spectre.Console;
 public sealed class GridColumn : IColumn, IHasDirtyState
 {
     private bool _isDirty;
-    private int? _width;
+    private double? _width;
+    private SizeMode _sizeMode;
     private bool _noWrap;
     private Padding? _padding;
     private Justify? _alignment;
@@ -16,12 +17,41 @@ public sealed class GridColumn : IColumn, IHasDirtyState
 
     /// <summary>
     /// Gets or sets the width of the column.
-    /// If <c>null</c>, the column will adapt to its contents.
+    /// The interpretation of width depends on the value of <see cref="SizeMode"/>.<br/>
+    ///<br/>
+    /// By default it is set to <see langword="null"/>, and the column will size to its contents <see cref="SizeMode.SizeToContent"/>
+    /// is set to <see cref="SizeMode.SizeToContent" />.
     /// </summary>
-    public int? Width
+    public double? Width
     {
         get => _width;
         set => MarkAsDirty(() => _width = value);
+    }
+
+    /// <summary>
+    /// Gets or sets the size mode which defines how the column width will be interpreted:
+    /// <list type="bullet">
+    ///     <item>
+    ///         <term><see cref="SizeMode.SizeToContent">SizeToContent (Auto)</see></term>
+    ///         <description><see cref="Width" /> value is ignored and width will auto-size to content.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term><see cref="SizeMode.Fixed">Fixed</see></term>
+    ///         <description><see cref="Width" /> value is interpreted as integer, fixed size.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term><see cref="SizeMode.Star">Star (*)</see></term>
+    ///         <description><see cref="Width" /> value is interpreted as double and means proportional sizing.</description>
+    ///     </item>
+    /// </list>
+    /// If mixed <see cref="SizeMode.SizeToContent" /> and <see cref="SizeMode.Fixed" /> widths with <see cref="SizeMode.Star" /> (proportional) widths:<br/>
+    /// The <see cref="SizeMode.Star" /> columns are apportioned to the remainder after the <see cref="SizeMode.SizeToContent" /> and
+    /// <see cref="SizeMode.Fixed" /> widths have been calculated.<br/>
+    /// </summary>
+    public SizeMode SizeMode
+    {
+        get => _sizeMode;
+        set => MarkAsDirty(() => _sizeMode = value);
     }
 
     /// <summary>

--- a/src/Spectre.Console/Widgets/Table/Table.cs
+++ b/src/Spectre.Console/Widgets/Table/Table.cs
@@ -113,7 +113,7 @@ public sealed class Table : Renderable, IHasTableBorder, IExpandable, IAlignable
         var totalCellWidth = measurer.CalculateTotalCellWidth(maxWidth);
 
         // Calculate the minimum and maximum table width
-        var measurements = _columns.Select(column => measurer.MeasureColumn(column, totalCellWidth));
+        var measurements = measurer.MeasureColumns(totalCellWidth);
         var minTableWidth = measurements.Sum(x => x.Min) + measurer.GetNonColumnWidth();
         var maxTableWidth = Width ?? measurements.Sum(x => x.Max) + measurer.GetNonColumnWidth();
         return new Measurement(minTableWidth, maxTableWidth);

--- a/src/Spectre.Console/Widgets/Table/TableColumn.cs
+++ b/src/Spectre.Console/Widgets/Table/TableColumn.cs
@@ -17,9 +17,34 @@ public sealed class TableColumn : IColumn
 
     /// <summary>
     /// Gets or sets the width of the column.
-    /// If <c>null</c>, the column will adapt to its contents.
+    /// The interpretation of width depends on the value of <see cref="SizeMode"/>.<br/>
+    ///<br/>
+    /// By default it is set to <see langword="null"/>, and the column will size to its contents <see cref="SizeMode.SizeToContent"/>
+    /// is set to <see cref="SizeMode.SizeToContent" />.
     /// </summary>
-    public int? Width { get; set; }
+    public double? Width { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size mode which defines how the column width will be interpreted:
+    /// <list type="bullet">
+    ///     <item>
+    ///         <term><see cref="SizeMode.SizeToContent">SizeToContent (Auto)</see></term>
+    ///         <description><see cref="Width" /> value is ignored and width will auto-size to content.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term><see cref="SizeMode.Fixed">Fixed</see></term>
+    ///         <description><see cref="Width" /> value is interpreted as integer, fixed size.</description>
+    ///     </item>
+    ///     <item>
+    ///         <term><see cref="SizeMode.Star">Star (*)</see></term>
+    ///         <description><see cref="Width" /> value is interpreted as double and means proportional sizing.</description>
+    ///     </item>
+    /// </list>
+    /// If mixed <see cref="SizeMode.SizeToContent" /> and <see cref="SizeMode.Fixed" /> widths with <see cref="SizeMode.Star" /> (proportional) widths:<br/>
+    /// The <see cref="SizeMode.Star" /> columns are apportioned to the remainder after the <see cref="SizeMode.SizeToContent" /> and
+    /// <see cref="SizeMode.Fixed" /> widths have been calculated.<br/>
+    /// </summary>
+    public SizeMode SizeMode { get; set; }
 
     /// <summary>
     /// Gets or sets the padding of the column.


### PR DESCRIPTION
This PR allows to set the column witdh not only to fixed width or auto-size (size to content) 
but also allows proportional sizing:
```csharp
table.AddColumn(new TableColumn("Column 1").StarWidth(1.5));
table.AddColumn(new TableColumn("Column 2").StarWidth(1));
```
The numbers do not have to be integers.
In this example, column 1 is 1.5 times wider than column 2.

Also available:
```csharp
table.AddColumn(new TableColumn("Column 1").FixWidth(10));
table.AddColumn(new TableColumn("Column 2").FixWidth(10));
table.AddColumn(new TableColumn("Column 3").SizeToContent());
```

You can also mix auto-fit and fixed widths with star (proportional) widths; in that case the star columns are apportioned to the remainder after the auto-fit and fixed widths have been calculated:
```csharp
table.AddColumn(new TableColumn("Column 1").FixWidth(10));
table.AddColumn(new TableColumn("Column 2").StarWidth(1));
table.AddColumn(new TableColumn("Column 3").StarWidth(2));
table.AddColumn(new TableColumn("Column 4").SizeToContent());
```