### PR TITLE
Abort `SelectionPrompt` and `MultiSelectionPrompt` with `Escape` key

### DIFF
--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -55,7 +55,7 @@ internal sealed class ListPrompt<T>
 
                 var key = rawKey.Value;
                 var result = _strategy.HandleInput(key, state);
-                if (result == ListPromptInputResult.Submit)
+                if (result == ListPromptInputResult.Submit || result == ListPromptInputResult.Abort)
                 {
                     break;
                 }

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -54,7 +54,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
     internal ListPromptTree<T> Tree { get; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the prompt can be aborted.
+    /// Gets or sets a value indicating whether the prompt can be aborted by pressing the <c>ESC</c> key.
     /// </summary>
     public bool AllowAbort { get; set; } = false;
 

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -54,6 +54,11 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
     internal ListPromptTree<T> Tree { get; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the prompt can be aborted.
+    /// </summary>
+    public bool AllowAbort { get; set; } = false;
+
+    /// <summary>
     /// Gets a value indicating whether or not the prompt was aborted.
     /// </summary>
     public bool Aborted { get; private set; } = false;
@@ -191,7 +196,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
             return ListPromptInputResult.Refresh;
         }
 
-        if (key.Key == ConsoleKey.Escape)
+        if (key.Key == ConsoleKey.Escape && AllowAbort)
         {
             Aborted = true;
             return ListPromptInputResult.Abort;

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -54,6 +54,11 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
     internal ListPromptTree<T> Tree { get; }
 
     /// <summary>
+    /// Gets a value indicating whether or not the prompt was aborted.
+    /// </summary>
+    public bool Aborted { get; private set; } = false;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="MultiSelectionPrompt{T}"/> class.
     /// </summary>
     /// <param name="comparer">
@@ -151,6 +156,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
             }
 
             // Submit
+            Aborted = false;
             return ListPromptInputResult.Submit;
         }
 
@@ -183,6 +189,12 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
 
             // Refresh the list
             return ListPromptInputResult.Refresh;
+        }
+
+        if (key.Key == ConsoleKey.Escape)
+        {
+            Aborted = true;
+            return ListPromptInputResult.Abort;
         }
 
         return ListPromptInputResult.None;

--- a/src/Spectre.Console/Prompts/MultiSelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPromptExtensions.cs
@@ -329,4 +329,23 @@ public static class MultiSelectionPromptExtensions
         obj.Converter = displaySelector;
         return obj;
     }
+
+    /// <summary>
+    /// Sets the value indicating whether the prompt can be aborted.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="allowAbort">Value indicating whether the prompt can be aborted.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static MultiSelectionPrompt<T> AllowAbort<T>(this MultiSelectionPrompt<T> obj, bool allowAbort)
+        where T : notnull
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        obj.AllowAbort = allowAbort;
+        return obj;
+    }
 }

--- a/src/Spectre.Console/Prompts/MultiSelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPromptExtensions.cs
@@ -331,7 +331,7 @@ public static class MultiSelectionPromptExtensions
     }
 
     /// <summary>
-    /// Sets the value indicating whether the prompt can be aborted.
+    /// Sets a value indicating whether the prompt can be aborted by pressing the <c>ESC</c> key.
     /// </summary>
     /// <typeparam name="T">The prompt result type.</typeparam>
     /// <param name="obj">The prompt.</param>

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -48,7 +48,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     public SelectionMode Mode { get; set; } = SelectionMode.Leaf;
 
     /// <summary>
-    /// Gets or sets a value indicating whether the prompt can be aborted.
+    /// Gets or sets a value indicating whether the prompt can be aborted by pressing the <c>ESC</c> key.
     /// </summary>
     public bool AllowAbort { get; set; } = false;
 

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -48,6 +48,11 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     public SelectionMode Mode { get; set; } = SelectionMode.Leaf;
 
     /// <summary>
+    /// Flag indicating whether the prompt was aborted.
+    /// </summary>
+    public bool Aborted { get; private set; } = false;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="SelectionPrompt{T}"/> class.
     /// </summary>
     public SelectionPrompt()
@@ -95,7 +100,14 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
                 return ListPromptInputResult.None;
             }
 
+            Aborted = false;
             return ListPromptInputResult.Submit;
+        }
+
+        if (key.Key == ConsoleKey.Escape)
+        {
+            Aborted = true;
+            return ListPromptInputResult.Abort;
         }
 
         return ListPromptInputResult.None;

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -48,6 +48,11 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     public SelectionMode Mode { get; set; } = SelectionMode.Leaf;
 
     /// <summary>
+    /// Gets or sets a value indicating whether the prompt can be aborted.
+    /// </summary>
+    public bool AllowAbort { get; set; } = false;
+
+    /// <summary>
     /// Gets a value indicating whether or not the prompt was aborted.
     /// </summary>
     public bool Aborted { get; private set; } = false;
@@ -104,7 +109,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
             return ListPromptInputResult.Submit;
         }
 
-        if (key.Key == ConsoleKey.Escape)
+        if (key.Key == ConsoleKey.Escape && AllowAbort)
         {
             Aborted = true;
             return ListPromptInputResult.Abort;

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -48,7 +48,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     public SelectionMode Mode { get; set; } = SelectionMode.Leaf;
 
     /// <summary>
-    /// Flag indicating whether the prompt was aborted.
+    /// Gets a value indicating whether or not the prompt was aborted.
     /// </summary>
     public bool Aborted { get; private set; } = false;
 

--- a/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
@@ -219,4 +219,23 @@ public static class SelectionPromptExtensions
         obj.Converter = displaySelector;
         return obj;
     }
+
+    /// <summary>
+    /// Sets the value indicating whether the prompt can be aborted.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="allowAbort">Value indicating whether the prompt can be aborted.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static SelectionPrompt<T> AllowAbort<T>(this SelectionPrompt<T> obj, bool allowAbort)
+        where T : notnull
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        obj.AllowAbort = allowAbort;
+        return obj;
+    }
 }

--- a/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
@@ -221,7 +221,7 @@ public static class SelectionPromptExtensions
     }
 
     /// <summary>
-    /// Sets the value indicating whether the prompt can be aborted.
+    /// Sets a value indicating whether the prompt can be aborted by pressing the <c>ESC</c> key.
     /// </summary>
     /// <typeparam name="T">The prompt result type.</typeparam>
     /// <param name="obj">The prompt.</param>

--- a/test/Spectre.Console.Tests/Unit/Prompts/MultiSelectionPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/MultiSelectionPromptTests.cs
@@ -146,4 +146,44 @@ public sealed class MultiSelectionPromptTests
         // Then
         action.ShouldThrow<ArgumentOutOfRangeException>();
     }
+
+    [Fact]
+    public void Should_Set_Property_If_Aborted()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Escape);
+        var input = new string[] { "a", "b", "c" };
+
+        // When
+        var prompt = new MultiSelectionPrompt<string>()
+                .Title("Select some")
+                .AddChoices(input);
+        prompt.Show(console);
+
+        // Then
+        prompt.Aborted.ShouldBe(true);
+    }
+
+    [Fact]
+    public void Should_Set_Property_If_Not_Aborted()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+        var input = new string[] { "a", "b", "c" };
+
+        // When
+        var prompt = new MultiSelectionPrompt<string>()
+                .Title("Select some")
+                .AddChoices(input);
+        prompt.Show(console);
+
+        // Then
+        prompt.Aborted.ShouldBe(false);
+    }
 }

--- a/test/Spectre.Console.Tests/Unit/Prompts/MultiSelectionPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/MultiSelectionPromptTests.cs
@@ -160,6 +160,7 @@ public sealed class MultiSelectionPromptTests
         // When
         var prompt = new MultiSelectionPrompt<string>()
                 .Title("Select some")
+                .AllowAbort(true)
                 .AddChoices(input);
         prompt.Show(console);
 

--- a/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -21,4 +21,42 @@ public sealed class SelectionPromptTests
         // Then
         console.Output.ShouldContain(@"[red]This text will never be red[/]");
     }
+
+    [Fact]
+    public void Should_Set_Property_If_Aborted()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Escape);
+        var input = new string[] { "a", "b", "c" };
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices(input);
+        prompt.Show(console);
+
+        // Then
+        prompt.Aborted.ShouldBe(true);
+    }
+
+    [Fact]
+    public void Should_Set_Property_If_Not_Aborted()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+        var input = new string[] { "a", "b", "c" };
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices(input);
+        prompt.Show(console);
+
+        // Then
+        prompt.Aborted.ShouldBe(false);
+    }
 }

--- a/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -34,6 +34,7 @@ public sealed class SelectionPromptTests
         // When
         var prompt = new SelectionPrompt<string>()
                 .Title("Select one")
+                .AllowAbort(true)
                 .AddChoices(input);
         prompt.Show(console);
 


### PR DESCRIPTION
Code in this PR adds possibility to abort `SelectionPrompt` and `MultiSelectionPrompt` with `Escape` key. When `Escape` key is pressed, prompt is aborted and its `Aborted` property is set to `true`. I believe this PR does not change the current default behavior in any way, because `Escape` key still does nothing unless `AllowAbort` property is explicitly set to `true`.  

I tried to follow existing coding style as closely as possible. I did add some tests and made sure all existing tests are passing before opening this PR. As suggested by contribution guidelines I started the discussion first in https://github.com/spectreconsole/spectre.console/discussions/700 but then had to move on with the implementation before I received any reply. I'm really sorry for that but I couldn't continue with a soon-to-be-released<sup>TM</sup> [Pkcs11AdminConsole](https://github.com/Pkcs11Admin/Pkcs11AdminConsole) project without being able to abort these prompts.

If implementation in this PR is not suitable for inclusion I am willing to work on any suggested alternative.