### PR TITLE
Custom stack trace and method name resolver for Exception formatting

### DIFF
--- a/examples/Console/Exceptions/Exceptions.csproj
+++ b/examples/Console/Exceptions/Exceptions.csproj
@@ -12,4 +12,8 @@
     <ProjectReference Include="..\..\Shared\Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
+  </ItemGroup>
+
 </Project>

--- a/examples/Console/Exceptions/Program.cs
+++ b/examples/Console/Exceptions/Program.cs
@@ -1,11 +1,13 @@
 using System;
+using System.Diagnostics;
 using System.Security.Authentication;
+using System.Threading.Tasks;
 
 namespace Spectre.Console.Examples;
 
 public static class Program
 {
-    public static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
         try
         {
@@ -15,6 +17,11 @@ public static class Program
         {
             AnsiConsole.WriteLine();
             AnsiConsole.Write(new Rule("Default").LeftAligned());
+            AnsiConsole.WriteLine();
+            AnsiConsole.WriteLine(ex.ToString());
+
+            AnsiConsole.WriteLine();
+            AnsiConsole.Write(new Rule("Default format").LeftAligned());
             AnsiConsole.WriteLine();
             AnsiConsole.WriteException(ex);
 
@@ -43,6 +50,33 @@ public static class Program
                 }
             });
         }
+
+        try
+        {
+            await DoMagicAsync(42, null);
+        }
+        catch (Exception ex)
+        {
+            AnsiConsole.WriteLine();
+            AnsiConsole.Write(new Rule("Default Async").LeftAligned());
+            AnsiConsole.WriteLine();
+            AnsiConsole.WriteLine(ex.ToString());
+
+            AnsiConsole.WriteLine();
+            AnsiConsole.Write(new Rule("Default Formatted Async").LeftAligned());
+            AnsiConsole.WriteLine();
+            AnsiConsole.WriteException(ex);
+
+            AnsiConsole.WriteLine();
+            AnsiConsole.Write(new Rule("Demystify").LeftAligned());
+            AnsiConsole.WriteLine();
+            AnsiConsole.WriteException(ex, new ExceptionSettings()
+            {
+                StackTraceConverter = trace => new EnhancedStackTrace(trace),
+                MethodNameResolver = frame => ((EnhancedStackFrame)frame).MethodInfo.Name,
+                Format = ExceptionFormats.ShortenPaths
+            });
+        }
     }
 
     private static void DoMagic(int foo, string[,] bar)
@@ -58,6 +92,23 @@ public static class Program
     }
 
     private static void CheckCredentials(int qux, string[,] corgi)
+    {
+        throw new InvalidCredentialException("The credentials are invalid.");
+    }
+
+    private static async Task DoMagicAsync(int foo, string[,] bar)
+    {
+        try
+        {
+            await CheckCredentialsAsync(foo, bar);
+        }
+        catch (Exception ex)
+        {
+            throw new InvalidOperationException("Whaaat?", ex);
+        }
+    }
+
+    private static Task CheckCredentialsAsync(int qux, string[,] corgi)
     {
         throw new InvalidCredentialException("The credentials are invalid.");
     }

--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
@@ -9,7 +9,7 @@ internal static class ExceptionFormatter
             throw new ArgumentNullException(nameof(exception));
         }
 
-        var info = ExceptionConverter.Convert(exception);
+        var info = ExceptionConverter.Convert(exception, settings.StackTraceConverter, settings.MethodNameResolver);
 
         return GetException(info, settings);
     }

--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionSettings.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionSettings.cs
@@ -16,6 +16,16 @@ public sealed class ExceptionSettings
     public ExceptionStyle Style { get; set; }
 
     /// <summary>
+    /// Gets or sets a StackTrace converter.
+    /// </summary>
+    public Func<StackTrace, StackTrace>? StackTraceConverter { get; set; } = null;
+
+    /// <summary>
+    /// Gets or sets a custom method name resolver.
+    /// </summary>
+    public Func<StackFrame, string>? MethodNameResolver { get; set; } = null;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ExceptionSettings"/> class.
     /// </summary>
     public ExceptionSettings()


### PR DESCRIPTION
Newer versions of .NET clean up the exception messages internally for things like async and state machines. They clean the stack trace and also tweak the names. This gives a pretty big difference between our output and the default `ToString`. 

This allows the user to do their own tweaking to the method names and stack frames before the formatting. Or even better, use something like `Ben.Demystifer` to do the heavy lifting for them.

Here's the sample output using Ben.Demystifier. 

![image](https://user-images.githubusercontent.com/2447331/152223069-4d7d3335-9baa-4266-bc96-d95776d9d734.png)

I'm adding

```csharp
AnsiConsole.WriteException(ex, new ExceptionSettings()
{
    StackTraceConverter = trace => new EnhancedStackTrace(trace),
    MethodNameResolver = frame => ((EnhancedStackFrame)frame).MethodInfo.Name
});
```

I'm adding two new properties - one that allows the stack trace to be messed with prior to formatting, and another that allows a custom method name resolver. If neither are set it falls back to the previous settings. Feedback please on the names or if y'all can think of a better way to hook in without needing to deal with a big mess of inheritance.