### PR TITLE
Fixes #587 Support negative numbers as command option values

### DIFF
--- a/test/Spectre.Console.Tests/Unit/Cli/CommandAppTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Cli/CommandAppTests.cs
@@ -135,6 +135,39 @@ public sealed partial class CommandAppTests
     }
 
     [Fact]
+    public void Should_Pass_Case_4_With_Negative_Integer_Argument()
+    {
+        // Given
+        var app = new CommandAppTester();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddBranch<AnimalSettings>("animal", animal =>
+            {
+                animal.AddCommand<DogCommand>("dog");
+            });
+        });
+
+        // When
+        var result = app.Run(new[]
+        {
+            "animal", "4", "dog", "-12", "--good-boy",
+            "--name", "Rufus",
+        });
+
+        // Then
+        result.ExitCode.ShouldBe(0);
+        result.Settings.ShouldBeOfType<DogSettings>().And(dog =>
+        {
+            dog.Legs.ShouldBe(4);
+            dog.Age.ShouldBe(-12);
+            dog.GoodBoy.ShouldBe(true);
+            dog.IsAlive.ShouldBe(false);
+            dog.Name.ShouldBe("Rufus");
+        });
+    }
+
+    [Fact]
     public void Should_Pass_Case_5()
     {
         // Given

--- a/test/Spectre.Console.Tests/Unit/Cli/CommandTreeTokenizerTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Cli/CommandTreeTokenizerTests.cs
@@ -77,7 +77,7 @@ public static class CommandTreeTokenizerTests
         [Fact]
         public void With_Negative_Numeric_Prefixed_String_Value()
         {
-            var result = CommandTreeTokenizer.Tokenize(new [] { "-6..2 "});
+            var result = CommandTreeTokenizer.Tokenize(new[] { "-6..2 " });
             Assert.Empty(result.Remaining);
             var t = Assert.Single(result.Tokens);
             t.TokenKind.ShouldBe(CommandTreeToken.Kind.String);

--- a/test/Spectre.Console.Tests/Unit/Cli/CommandTreeTokenizerTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Cli/CommandTreeTokenizerTests.cs
@@ -1,0 +1,90 @@
+namespace Spectre.Console.Tests.Unit.Cli;
+
+public static class CommandTreeTokenizerTests
+{
+    public sealed class ShortOptions
+    {
+        [Fact]
+        public void Valueless()
+        {
+            var result = CommandTreeTokenizer.Tokenize(new[] { "-a" });
+            Assert.Empty(result.Remaining);
+            var t = Assert.Single(result.Tokens);
+
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.ShortOption);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(0);
+            t.Value.ShouldBe("a");
+            t.Representation.ShouldBe("-a");
+        }
+
+        [Theory]
+        [InlineData("-a:foo")]
+        [InlineData("-a=foo")]
+        public void With_Value(string param)
+        {
+            var result = CommandTreeTokenizer.Tokenize(new[] { param });
+            Assert.Empty(result.Remaining);
+            Assert.Equal(2, result.Tokens.Count);
+
+            var t = result.Tokens.Consume();
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.ShortOption);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(0);
+            t.Value.ShouldBe("a");
+            t.Representation.ShouldBe("-a");
+
+            t = result.Tokens.Consume();
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.String);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(3);
+            t.Value.ShouldBe("foo");
+            t.Representation.ShouldBe("foo");
+        }
+
+        [Theory]
+        [InlineData("-a:-1.5", null)]
+        [InlineData("-a=-1.5", null)]
+        [InlineData("-a", "-1.5")]
+        public void With_Negative_Numeric_Value(string firstArg, string secondArg)
+        {
+            List<string> args = new List<string>();
+            args.Add(firstArg);
+            if (secondArg != null)
+            {
+                args.Add(secondArg);
+            }
+
+            var result = CommandTreeTokenizer.Tokenize(args);
+            Assert.Empty(result.Remaining);
+            Assert.Equal(2, result.Tokens.Count);
+
+            var t = result.Tokens.Consume();
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.ShortOption);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(0);
+            t.Value.ShouldBe("a");
+            t.Representation.ShouldBe("-a");
+
+            t = result.Tokens.Consume();
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.String);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(3);
+            t.Value.ShouldBe("-1.5");
+            t.Representation.ShouldBe("-1.5");
+        }
+
+        [Fact]
+        public void With_Negative_Numeric_Prefixed_String_Value()
+        {
+            var result = CommandTreeTokenizer.Tokenize(new [] { "-6..2 "});
+            Assert.Empty(result.Remaining);
+            var t = Assert.Single(result.Tokens);
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.String);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(0);
+            t.Value.ShouldBe("-6..2");
+            t.Representation.ShouldBe("-6..2");
+        }
+    }
+}


### PR DESCRIPTION
Decided to create some unit tests for the tokenizer, as it would've been too much of a mess to test all of this through CommandApp. That's obviously up for debate, but at least the tokenizer tests helped me with this.