### PR TITLE
Fix #698 - Update SixLabors.ImageSharp reference

### DIFF
--- a/src/Spectre.Console.ImageSharp/Spectre.Console.ImageSharp.csproj
+++ b/src/Spectre.Console.ImageSharp/Spectre.Console.ImageSharp.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It looks like the version of ImageSharp referenced in Spectre.Console.ImageSharp is failing to fully load images, causing the partial render issue in #698. Updating the reference to 2.0.0 has resolved the issue for me.