### PR TITLE
Introduce MarkupInterpolated and MarkupLineInterpolated extensions

### DIFF
--- a/docs/input/best-practices.md
+++ b/docs/input/best-practices.md
@@ -60,6 +60,10 @@ Spectre.Console will tell your terminal to use the color that is configured in t
 If you are using an 8 or 24-bit color for the foreground text, it is recommended that you also set an appropriate
 background color to match.
 
+**Do** escape data when outputting any user input or any external data via Markup using the [`EscapeMarkup`](xref:M:Spectre.Console.Markup.Escape(System.String)) method on the data. Any user input containing `[` or `]` will likely cause a runtime error while rendering otherwise.
+
+**Consider** replacing `Markup` and `MarkupLine` with [`MarkupInterpolated`](xref:M:Spectre.Console.AnsiConsole.MarkupInterpolated(System.FormattableString)) and [`MarkupLineInterpolated`](xref:M:Spectre.Console.AnsiConsole.MarkupLineInterpolated(System.FormattableString)). Both these methods will automatically escape all data in the interpolated string holes. When working with widgets such as the Table and Tree, consider using [`Markup.FromInterpolated`](xref:M:Spectre.Console.Markup.FromInterpolated(System.FormattableString,Spectre.Console.Style)) to generate an `IRenderable` from an interpolated string.
+
 ### Live-Rendering Best Practices
 
 Spectre.Console has a variety of [live-rendering capabilities](live) widgets. These widgets can be used to display data

--- a/docs/input/markup.md
+++ b/docs/input/markup.md
@@ -63,6 +63,15 @@ You can also use the `Markup.Escape` method.
 ```csharp
 AnsiConsole.Markup("[red]{0}[/]", Markup.Escape("Hello [World]"));
 ```
+
+## Escaping Interpolated Strings
+
+When working with interpolated string, you can use the `MarkupInterpolated` and `MarkupInterpolatedLine` methods to automatically escape the values in the interpolated string holes.
+
+```csharp
+AnsiConsole.MarkupInterpolated("[red]{0}[/]", "Hello [World]");
+```
+
 ## Setting background color
 
 You can set the background color in markup by prefixing the color with

--- a/src/Spectre.Console/AnsiConsole.Markup.cs
+++ b/src/Spectre.Console/AnsiConsole.Markup.cs
@@ -24,25 +24,62 @@ public static partial class AnsiConsole
         Console.Markup(format, args);
     }
 
-    /// <summary>
-    /// Writes the specified markup to the console.
-    /// </summary>
-    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-    /// <param name="format">A composite format string.</param>
-    /// <param name="args">An array of objects to write.</param>
-    public static void Markup(IFormatProvider provider, string format, params object[] args)
-    {
-        Console.Markup(provider, format, args);
-    }
+        /// <summary>
+        /// Writes the specified markup to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// AnsiConsole.MarkupInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupInterpolated(FormattableString value)
+        {
+            Console.MarkupInterpolated(value);
+        }
 
-    /// <summary>
-    /// Writes the specified markup, followed by the current line terminator, to the console.
-    /// </summary>
-    /// <param name="value">The value to write.</param>
-    public static void MarkupLine(string value)
-    {
-        Console.MarkupLine(value);
-    }
+        /// <summary>
+        /// Writes the specified markup to the console.
+        /// </summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write.</param>
+        public static void Markup(IFormatProvider provider, string format, params object[] args)
+        {
+            Console.Markup(provider, format, args);
+        }
+
+        /// <summary>
+        /// Writes the specified markup to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// AnsiConsole.MarkupInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupInterpolated(IFormatProvider provider, FormattableString value)
+        {
+            Console.MarkupInterpolated(provider, value);
+        }
+
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// </summary>
+        /// <param name="value">The value to write.</param>
+        public static void MarkupLine(string value)
+        {
+            Console.MarkupLine(value);
+        }
 
     /// <summary>
     /// Writes the specified markup, followed by the current line terminator, to the console.
@@ -54,14 +91,52 @@ public static partial class AnsiConsole
         Console.MarkupLine(format, args);
     }
 
-    /// <summary>
-    /// Writes the specified markup, followed by the current line terminator, to the console.
-    /// </summary>
-    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-    /// <param name="format">A composite format string.</param>
-    /// <param name="args">An array of objects to write.</param>
-    public static void MarkupLine(IFormatProvider provider, string format, params object[] args)
-    {
-        Console.MarkupLine(provider, format, args);
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// AnsiConsole.MarkupLineInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupLineInterpolated(FormattableString value)
+        {
+            Console.MarkupLineInterpolated(value);
+        }
+
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// </summary>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write.</param>
+        public static void MarkupLine(IFormatProvider provider, string format, params object[] args)
+        {
+            Console.MarkupLine(provider, format, args);
+        }
+
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// AnsiConsole.MarkupLineInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupLineInterpolated(IFormatProvider provider, FormattableString value)
+        {
+            Console.MarkupLineInterpolated(provider, value);
+        }
     }
 }

--- a/src/Spectre.Console/AnsiConsole.Markup.cs
+++ b/src/Spectre.Console/AnsiConsole.Markup.cs
@@ -24,62 +24,62 @@ public static partial class AnsiConsole
         Console.Markup(format, args);
     }
 
-        /// <summary>
-        /// Writes the specified markup to the console.
-        /// <para/>
-        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// string input = args[0];
-        /// string output = Process(input);
-        /// AnsiConsole.MarkupInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
-        /// </code>
-        /// </example>
-        /// <param name="value">The interpolated string value to write.</param>
-        public static void MarkupInterpolated(FormattableString value)
-        {
-            Console.MarkupInterpolated(value);
-        }
+    /// <summary>
+    /// Writes the specified markup to the console.
+    /// <para/>
+    /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// string input = args[0];
+    /// string output = Process(input);
+    /// AnsiConsole.MarkupInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+    /// </code>
+    /// </example>
+    /// <param name="value">The interpolated string value to write.</param>
+    public static void MarkupInterpolated(FormattableString value)
+    {
+        Console.MarkupInterpolated(value);
+    }
 
-        /// <summary>
-        /// Writes the specified markup to the console.
-        /// </summary>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void Markup(IFormatProvider provider, string format, params object[] args)
-        {
-            Console.Markup(provider, format, args);
-        }
+    /// <summary>
+    /// Writes the specified markup to the console.
+    /// </summary>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void Markup(IFormatProvider provider, string format, params object[] args)
+    {
+        Console.Markup(provider, format, args);
+    }
 
-        /// <summary>
-        /// Writes the specified markup to the console.
-        /// <para/>
-        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// string input = args[0];
-        /// string output = Process(input);
-        /// AnsiConsole.MarkupInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
-        /// </code>
-        /// </example>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="value">The interpolated string value to write.</param>
-        public static void MarkupInterpolated(IFormatProvider provider, FormattableString value)
-        {
-            Console.MarkupInterpolated(provider, value);
-        }
+    /// <summary>
+    /// Writes the specified markup to the console.
+    /// <para/>
+    /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// string input = args[0];
+    /// string output = Process(input);
+    /// AnsiConsole.MarkupInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+    /// </code>
+    /// </example>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="value">The interpolated string value to write.</param>
+    public static void MarkupInterpolated(IFormatProvider provider, FormattableString value)
+    {
+        Console.MarkupInterpolated(provider, value);
+    }
 
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// </summary>
-        /// <param name="value">The value to write.</param>
-        public static void MarkupLine(string value)
-        {
-            Console.MarkupLine(value);
-        }
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// </summary>
+    /// <param name="value">The value to write.</param>
+    public static void MarkupLine(string value)
+    {
+        Console.MarkupLine(value);
+    }
 
     /// <summary>
     /// Writes the specified markup, followed by the current line terminator, to the console.
@@ -91,52 +91,51 @@ public static partial class AnsiConsole
         Console.MarkupLine(format, args);
     }
 
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// <para/>
-        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// string input = args[0];
-        /// string output = Process(input);
-        /// AnsiConsole.MarkupLineInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
-        /// </code>
-        /// </example>
-        /// <param name="value">The interpolated string value to write.</param>
-        public static void MarkupLineInterpolated(FormattableString value)
-        {
-            Console.MarkupLineInterpolated(value);
-        }
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// <para/>
+    /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// string input = args[0];
+    /// string output = Process(input);
+    /// AnsiConsole.MarkupLineInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+    /// </code>
+    /// </example>
+    /// <param name="value">The interpolated string value to write.</param>
+    public static void MarkupLineInterpolated(FormattableString value)
+    {
+        Console.MarkupLineInterpolated(value);
+    }
 
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// </summary>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void MarkupLine(IFormatProvider provider, string format, params object[] args)
-        {
-            Console.MarkupLine(provider, format, args);
-        }
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// </summary>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void MarkupLine(IFormatProvider provider, string format, params object[] args)
+    {
+        Console.MarkupLine(provider, format, args);
+    }
 
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// <para/>
-        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// string input = args[0];
-        /// string output = Process(input);
-        /// AnsiConsole.MarkupLineInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
-        /// </code>
-        /// </example>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="value">The interpolated string value to write.</param>
-        public static void MarkupLineInterpolated(IFormatProvider provider, FormattableString value)
-        {
-            Console.MarkupLineInterpolated(provider, value);
-        }
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// <para/>
+    /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// string input = args[0];
+    /// string output = Process(input);
+    /// AnsiConsole.MarkupLineInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+    /// </code>
+    /// </example>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="value">The interpolated string value to write.</param>
+    public static void MarkupLineInterpolated(IFormatProvider provider, FormattableString value)
+    {
+        Console.MarkupLineInterpolated(provider, value);
     }
 }

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
@@ -16,27 +16,66 @@ public static partial class AnsiConsoleExtensions
         Markup(console, CultureInfo.CurrentCulture, format, args);
     }
 
-    /// <summary>
-    /// Writes the specified markup to the console.
-    /// </summary>
-    /// <param name="console">The console to write to.</param>
-    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-    /// <param name="format">A composite format string.</param>
-    /// <param name="args">An array of objects to write.</param>
-    public static void Markup(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
-    {
-        Markup(console, string.Format(provider, format, args));
-    }
+        /// <summary>
+        /// Writes the specified markup to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// console.MarkupInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupInterpolated(this IAnsiConsole console, FormattableString value)
+        {
+            MarkupInterpolated(console, CultureInfo.CurrentCulture, value);
+        }
 
-    /// <summary>
-    /// Writes the specified markup to the console.
-    /// </summary>
-    /// <param name="console">The console to write to.</param>
-    /// <param name="value">The value to write.</param>
-    public static void Markup(this IAnsiConsole console, string value)
-    {
-        console.Write(MarkupParser.Parse(value));
-    }
+        /// <summary>
+        /// Writes the specified markup to the console.
+        /// </summary>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write.</param>
+        public static void Markup(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
+        {
+            Markup(console, string.Format(provider, format, args));
+        }
+
+        /// <summary>
+        /// Writes the specified markup to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// console.MarkupInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value)
+        {
+            MarkupInterpolated(console, provider, value, appendNewLine: false);
+        }
+
+        /// <summary>
+        /// Writes the specified markup to the console.
+        /// </summary>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="value">The value to write.</param>
+        public static void Markup(this IAnsiConsole console, string value)
+        {
+            console.Write(MarkupParser.Parse(value));
+        }
 
     /// <summary>
     /// Writes the specified markup, followed by the current line terminator, to the console.
@@ -49,25 +88,72 @@ public static partial class AnsiConsoleExtensions
         MarkupLine(console, CultureInfo.CurrentCulture, format, args);
     }
 
-    /// <summary>
-    /// Writes the specified markup, followed by the current line terminator, to the console.
-    /// </summary>
-    /// <param name="console">The console to write to.</param>
-    /// <param name="value">The value to write.</param>
-    public static void MarkupLine(this IAnsiConsole console, string value)
-    {
-        Markup(console, value + Environment.NewLine);
-    }
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// console.MarkupLineInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupLineInterpolated(this IAnsiConsole console, FormattableString value)
+        {
+            MarkupLineInterpolated(console, CultureInfo.CurrentCulture, value);
+        }
 
-    /// <summary>
-    /// Writes the specified markup, followed by the current line terminator, to the console.
-    /// </summary>
-    /// <param name="console">The console to write to.</param>
-    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-    /// <param name="format">A composite format string.</param>
-    /// <param name="args">An array of objects to write.</param>
-    public static void MarkupLine(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
-    {
-        Markup(console, provider, format + Environment.NewLine, args);
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// </summary>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="value">The value to write.</param>
+        public static void MarkupLine(this IAnsiConsole console, string value)
+        {
+            Markup(console, value + Environment.NewLine);
+        }
+
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// </summary>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="format">A composite format string.</param>
+        /// <param name="args">An array of objects to write.</param>
+        public static void MarkupLine(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
+        {
+            Markup(console, provider, format + Environment.NewLine, args);
+        }
+
+        /// <summary>
+        /// Writes the specified markup, followed by the current line terminator, to the console.
+        /// <para/>
+        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// string input = args[0];
+        /// string output = Process(input);
+        /// console.MarkupLineInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+        /// </code>
+        /// </example>
+        /// <param name="console">The console to write to.</param>
+        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+        /// <param name="value">The interpolated string value to write.</param>
+        public static void MarkupLineInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value)
+        {
+            MarkupInterpolated(console, provider, value, appendNewLine: true);
+        }
+
+        private static void MarkupInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value, bool appendNewLine)
+        {
+            object?[] args = value.GetArguments().Select(arg => arg is string s ? s.EscapeMarkup() : arg).ToArray();
+            var format = appendNewLine ? value.Format + Environment.NewLine : value.Format;
+            Markup(console, string.Format(provider, format, args));
+        }
     }
 }

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
@@ -64,7 +64,7 @@ public static partial class AnsiConsoleExtensions
     /// <param name="value">The interpolated string value to write.</param>
     public static void MarkupInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value)
     {
-        MarkupInterpolated(console, provider, value, appendNewLine: false);
+        Markup(console, Console.Markup.EscapeInterpolated(provider, value));
     }
 
     /// <summary>
@@ -146,13 +146,6 @@ public static partial class AnsiConsoleExtensions
     /// <param name="value">The interpolated string value to write.</param>
     public static void MarkupLineInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value)
     {
-        MarkupInterpolated(console, provider, value, appendNewLine: true);
-    }
-
-    private static void MarkupInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value, bool appendNewLine)
-    {
-        object?[] args = value.GetArguments().Select(arg => arg is string s ? s.EscapeMarkup() : arg).ToArray();
-        var format = appendNewLine ? value.Format + Environment.NewLine : value.Format;
-        Markup(console, string.Format(provider, format, args));
+        MarkupLine(console, Console.Markup.EscapeInterpolated(provider, value));
     }
 }

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
@@ -16,66 +16,66 @@ public static partial class AnsiConsoleExtensions
         Markup(console, CultureInfo.CurrentCulture, format, args);
     }
 
-        /// <summary>
-        /// Writes the specified markup to the console.
-        /// <para/>
-        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// string input = args[0];
-        /// string output = Process(input);
-        /// console.MarkupInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
-        /// </code>
-        /// </example>
-        /// <param name="console">The console to write to.</param>
-        /// <param name="value">The interpolated string value to write.</param>
-        public static void MarkupInterpolated(this IAnsiConsole console, FormattableString value)
-        {
-            MarkupInterpolated(console, CultureInfo.CurrentCulture, value);
-        }
+    /// <summary>
+    /// Writes the specified markup to the console.
+    /// <para/>
+    /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// string input = args[0];
+    /// string output = Process(input);
+    /// console.MarkupInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+    /// </code>
+    /// </example>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="value">The interpolated string value to write.</param>
+    public static void MarkupInterpolated(this IAnsiConsole console, FormattableString value)
+    {
+        MarkupInterpolated(console, CultureInfo.CurrentCulture, value);
+    }
 
-        /// <summary>
-        /// Writes the specified markup to the console.
-        /// </summary>
-        /// <param name="console">The console to write to.</param>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void Markup(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
-        {
-            Markup(console, string.Format(provider, format, args));
-        }
+    /// <summary>
+    /// Writes the specified markup to the console.
+    /// </summary>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void Markup(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
+    {
+        Markup(console, string.Format(provider, format, args));
+    }
 
-        /// <summary>
-        /// Writes the specified markup to the console.
-        /// <para/>
-        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// string input = args[0];
-        /// string output = Process(input);
-        /// console.MarkupInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
-        /// </code>
-        /// </example>
-        /// <param name="console">The console to write to.</param>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="value">The interpolated string value to write.</param>
-        public static void MarkupInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value)
-        {
-            MarkupInterpolated(console, provider, value, appendNewLine: false);
-        }
+    /// <summary>
+    /// Writes the specified markup to the console.
+    /// <para/>
+    /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// string input = args[0];
+    /// string output = Process(input);
+    /// console.MarkupInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+    /// </code>
+    /// </example>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="value">The interpolated string value to write.</param>
+    public static void MarkupInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value)
+    {
+        MarkupInterpolated(console, provider, value, appendNewLine: false);
+    }
 
-        /// <summary>
-        /// Writes the specified markup to the console.
-        /// </summary>
-        /// <param name="console">The console to write to.</param>
-        /// <param name="value">The value to write.</param>
-        public static void Markup(this IAnsiConsole console, string value)
-        {
-            console.Write(MarkupParser.Parse(value));
-        }
+    /// <summary>
+    /// Writes the specified markup to the console.
+    /// </summary>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="value">The value to write.</param>
+    public static void Markup(this IAnsiConsole console, string value)
+    {
+        console.Write(MarkupParser.Parse(value));
+    }
 
     /// <summary>
     /// Writes the specified markup, followed by the current line terminator, to the console.
@@ -88,72 +88,71 @@ public static partial class AnsiConsoleExtensions
         MarkupLine(console, CultureInfo.CurrentCulture, format, args);
     }
 
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// <para/>
-        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// string input = args[0];
-        /// string output = Process(input);
-        /// console.MarkupLineInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
-        /// </code>
-        /// </example>
-        /// <param name="console">The console to write to.</param>
-        /// <param name="value">The interpolated string value to write.</param>
-        public static void MarkupLineInterpolated(this IAnsiConsole console, FormattableString value)
-        {
-            MarkupLineInterpolated(console, CultureInfo.CurrentCulture, value);
-        }
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// <para/>
+    /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// string input = args[0];
+    /// string output = Process(input);
+    /// console.MarkupLineInterpolated($"[blue]{input}[/] -> [green]{output}[/]");
+    /// </code>
+    /// </example>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="value">The interpolated string value to write.</param>
+    public static void MarkupLineInterpolated(this IAnsiConsole console, FormattableString value)
+    {
+        MarkupLineInterpolated(console, CultureInfo.CurrentCulture, value);
+    }
 
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// </summary>
-        /// <param name="console">The console to write to.</param>
-        /// <param name="value">The value to write.</param>
-        public static void MarkupLine(this IAnsiConsole console, string value)
-        {
-            Markup(console, value + Environment.NewLine);
-        }
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// </summary>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="value">The value to write.</param>
+    public static void MarkupLine(this IAnsiConsole console, string value)
+    {
+        Markup(console, value + Environment.NewLine);
+    }
 
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// </summary>
-        /// <param name="console">The console to write to.</param>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void MarkupLine(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
-        {
-            Markup(console, provider, format + Environment.NewLine, args);
-        }
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// </summary>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void MarkupLine(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
+    {
+        Markup(console, provider, format + Environment.NewLine, args);
+    }
 
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// <para/>
-        /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
-        /// </summary>
-        /// <example>
-        /// <code>
-        /// string input = args[0];
-        /// string output = Process(input);
-        /// console.MarkupLineInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
-        /// </code>
-        /// </example>
-        /// <param name="console">The console to write to.</param>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="value">The interpolated string value to write.</param>
-        public static void MarkupLineInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value)
-        {
-            MarkupInterpolated(console, provider, value, appendNewLine: true);
-        }
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// <para/>
+    /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// string input = args[0];
+    /// string output = Process(input);
+    /// console.MarkupLineInterpolated(CultureInfo.InvariantCulture, $"[blue]{input}[/] -> [green]{output}[/]");
+    /// </code>
+    /// </example>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="value">The interpolated string value to write.</param>
+    public static void MarkupLineInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value)
+    {
+        MarkupInterpolated(console, provider, value, appendNewLine: true);
+    }
 
-        private static void MarkupInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value, bool appendNewLine)
-        {
-            object?[] args = value.GetArguments().Select(arg => arg is string s ? s.EscapeMarkup() : arg).ToArray();
-            var format = appendNewLine ? value.Format + Environment.NewLine : value.Format;
-            Markup(console, string.Format(provider, format, args));
-        }
+    private static void MarkupInterpolated(this IAnsiConsole console, IFormatProvider provider, FormattableString value, bool appendNewLine)
+    {
+        object?[] args = value.GetArguments().Select(arg => arg is string s ? s.EscapeMarkup() : arg).ToArray();
+        var format = appendNewLine ? value.Format + Environment.NewLine : value.Format;
+        Markup(console, string.Format(provider, format, args));
     }
 }

--- a/src/Spectre.Console/Widgets/Markup.cs
+++ b/src/Spectre.Console/Widgets/Markup.cs
@@ -55,6 +55,29 @@ public sealed class Markup : Renderable, IAlignable, IOverflowable
     }
 
     /// <summary>
+    /// Returns a new instance of a Markup widget from an interpolated string.
+    /// </summary>
+    /// <param name="value">The interpolated string value to write.</param>
+    /// <param name="style">The style of the text.</param>
+    /// <returns>A new markup instance.</returns>
+    public static Markup FromInterpolated(FormattableString value, Style? style = null)
+    {
+        return FromInterpolated(CultureInfo.CurrentCulture, value, style);
+    }
+
+    /// <summary>
+    /// Returns a new instance of a Markup widget from an interpolated string.
+    /// </summary>
+    /// <param name="provider">The format provider to use.</param>
+    /// <param name="value">The interpolated string value to write.</param>
+    /// <param name="style">The style of the text.</param>
+    /// <returns>A new markup instance.</returns>
+    public static Markup FromInterpolated(IFormatProvider provider, FormattableString value, Style? style = null)
+    {
+        return new Markup(EscapeInterpolated(provider, value), style);
+    }
+
+    /// <summary>
     /// Escapes text so that it won’t be interpreted as markup.
     /// </summary>
     /// <param name="text">The text to escape.</param>
@@ -82,5 +105,11 @@ public sealed class Markup : Renderable, IAlignable, IOverflowable
         }
 
         return text.RemoveMarkup();
+    }
+
+    internal static string EscapeInterpolated(IFormatProvider provider, FormattableString value)
+    {
+        object?[] args = value.GetArguments().Select(arg => arg is string s ? s.EscapeMarkup() : arg).ToArray();
+        return string.Format(provider, value.Format, args);
     }
 }

--- a/test/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
@@ -153,4 +153,25 @@ public sealed class MarkupTests
         console.Output.NormalizeLineEndings()
             .ShouldBe("{\n");
     }
+
+    [Fact]
+    public void Can_Use_Interpolated_Markup_As_IRenderable()
+    {
+        // Given
+        var console = new TestConsole();
+        const string Num = "[value[";
+        var table = new Table().AddColumns("First Column");
+        table.AddRow(Markup.FromInterpolated($"Result: {Num}"));
+
+        // When
+        console.Write(table);
+
+        // Then
+        console.Output.NormalizeLineEndings().ShouldBe(@"┌─────────────────┐
+│ First Column    │
+├─────────────────┤
+│ Result: [value[ │
+└─────────────────┘
+".NormalizeLineEndings());
+    }
 }

--- a/test/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
@@ -72,6 +72,25 @@ public sealed class MarkupTests
             // Then
             result.ShouldBe(expected);
         }
+
+        [Theory]
+        [InlineData("Hello", "World", "\x1B[38;5;11mHello\x1B[0m \x1B[38;5;9mWorld\x1B[0m 2021-02-03")]
+        [InlineData("Hello", "World [", "\x1B[38;5;11mHello\x1B[0m \x1B[38;5;9mWorld [\x1B[0m 2021-02-03")]
+        [InlineData("Hello", "World ]", "\x1B[38;5;11mHello\x1B[0m \x1B[38;5;9mWorld ]\x1B[0m 2021-02-03")]
+        [InlineData("[Hello]", "World", "\x1B[38;5;11m[Hello]\x1B[0m \x1B[38;5;9mWorld\x1B[0m 2021-02-03")]
+        [InlineData("[[Hello]]", "[World]", "\x1B[38;5;11m[[Hello]]\x1B[0m \x1B[38;5;9m[World]\x1B[0m 2021-02-03")]
+        public void Should_Escape_Markup_When_Using_MarkupInterpolated(string input1, string input2, string expected)
+        {
+            // Given
+            var console = new TestConsole().EmitAnsiSequences();
+            var date = new DateTime(2021, 2, 3);
+
+            // When
+            console.MarkupInterpolated($"[yellow]{input1}[/] [red]{input2}[/] {date:yyyy-MM-dd}");
+
+            // Then
+            console.Output.ShouldBe(expected);
+        }
     }
 
     [Theory]


### PR DESCRIPTION
This supersedes #564 by @0xced. GitHub properly made a mess of his repository and honestly, shame on me for using it. 

My penance was documenting the methods as well as introducing an additional method to allow the string interpolation auto-formatting to be used to create a new instance of the `Markup` widget for using in `Table`, `Tree`, etc.