### PR TITLE
Add SVG encoder

### DIFF
--- a/src/Spectre.Console.sln
+++ b/src/Spectre.Console.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30225.117
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Spectre.Console", "Spectre.Console\Spectre.Console.csproj", "{80DCBEF3-99D6-46C0-9C5B-42B4534D9113}"
 EndProject

--- a/src/Spectre.Console/AnsiConsole.Recording.cs
+++ b/src/Spectre.Console/AnsiConsole.Recording.cs
@@ -45,6 +45,20 @@ public static partial class AnsiConsole
     }
 
     /// <summary>
+    /// Exports all recorded console output as SVG text.
+    /// </summary>
+    /// <returns>The recorded output as SVG text.</returns>
+    public static string ExportSvg()
+    {
+        if (_recorder == null)
+        {
+            throw new InvalidOperationException("Cannot export SVG since a recording hasn't been started.");
+        }
+
+        return _recorder.ExportSvg();
+    }
+
+    /// <summary>
     /// Exports all recorded console output using a custom encoder.
     /// </summary>
     /// <param name="encoder">The encoder to use.</param>
@@ -53,7 +67,7 @@ public static partial class AnsiConsole
     {
         if (_recorder == null)
         {
-            throw new InvalidOperationException("Cannot export HTML since a recording hasn't been started.");
+            throw new InvalidOperationException("Cannot export since a recording hasn't been started.");
         }
 
         if (encoder is null)

--- a/src/Spectre.Console/Color.cs
+++ b/src/Spectre.Console/Color.cs
@@ -243,6 +243,23 @@ public partial struct Color : IEquatable<Color>
     }
 
     /// <summary>
+    /// Converts a hexadecimal format string to a <see cref="Color"/>.
+    /// </summary>
+    /// <param name="hex">The hexadecimal format string to parse.</param>
+    /// <returns>A <see cref="Color"/> representing the hexadecimal format string.</returns>
+    public static Color FromHex(string hex)
+    {
+        var color = StyleParser.ParseHexColor(hex, out var error);
+        if (color == null || error != null)
+        {
+            error ??= "Could not parse hex color";
+            throw new InvalidOperationException(error);
+        }
+
+        return color.Value;
+    }
+
+    /// <summary>
     /// Converts the color to a markup string.
     /// </summary>
     /// <returns>A <see cref="string"/> representing the color as markup.</returns>

--- a/src/Spectre.Console/Extensions/RecorderExtensions.cs
+++ b/src/Spectre.Console/Extensions/RecorderExtensions.cs
@@ -37,4 +37,21 @@ public static class RecorderExtensions
 
         return recorder.Export(_htmlEncoder);
     }
+
+    /// <summary>
+    /// Exports the recorded content as SVG.
+    /// </summary>
+    /// <param name="recorder">The recorder.</param>
+    /// <returns>The recorded content as HTML.</returns>
+    public static string ExportSvg(this Recorder recorder)
+    {
+        if (recorder is null)
+        {
+            throw new ArgumentNullException(nameof(recorder));
+        }
+
+        return recorder.Export(
+            new SvgEncoder(
+                new SvgEncoderSettings()));
+    }
 }

--- a/src/Spectre.Console/Internal/Text/Encoding/HtmlEncoder.cs
+++ b/src/Spectre.Console/Internal/Text/Encoding/HtmlEncoder.cs
@@ -1,3 +1,5 @@
+using System.Web;
+
 namespace Spectre.Console.Internal;
 
 internal sealed class HtmlEncoder : IAnsiConsoleEncoder
@@ -42,7 +44,7 @@ internal sealed class HtmlEncoder : IAnsiConsoleEncoder
                     }
 
                     builder.Append('>');
-                    builder.Append(line);
+                    builder.Append(HttpUtility.HtmlEncode(line));
                     builder.Append("</span>");
 
                     if (parts.Length > 1 && !last)

--- a/src/Spectre.Console/Internal/Text/Encoding/Svg/SvgCssBuilder.cs
+++ b/src/Spectre.Console/Internal/Text/Encoding/Svg/SvgCssBuilder.cs
@@ -1,0 +1,62 @@
+namespace Spectre.Console.Internal;
+
+internal static class SvgCssBuilder
+{
+    public static string BuildCss(SvgTheme theme, Style style)
+    {
+        var css = new List<string>();
+
+        var foreground = theme.GetColor(style.Foreground);
+        var background = theme.GetColor(style.Background);
+
+        if ((style.Decoration & Decoration.Invert) != 0)
+        {
+            var temp = foreground;
+            foreground = background;
+            background = temp;
+        }
+
+        if ((style.Decoration & Decoration.Dim) != 0)
+        {
+            var blender = background;
+            if (blender.Equals(Color.Default))
+            {
+                blender = Color.White;
+            }
+
+            foreground = foreground.Blend(blender, 0.5f);
+        }
+
+        if (!foreground.Equals(Color.Default))
+        {
+            css.Add($"color: #{foreground.ToHex()}");
+        }
+
+        if (!background.Equals(Color.Default))
+        {
+            css.Add($"background-color: #{background.ToHex()}");
+        }
+
+        if ((style.Decoration & Decoration.Bold) != 0)
+        {
+            css.Add("font-weight: bold");
+        }
+
+        if ((style.Decoration & Decoration.Bold) != 0)
+        {
+            css.Add("font-style: italic");
+        }
+
+        if ((style.Decoration & Decoration.Underline) != 0)
+        {
+            css.Add("text-decoration: underline");
+        }
+
+        if ((style.Decoration & Decoration.Strikethrough) != 0)
+        {
+            css.Add("text-decoration: line-through");
+        }
+
+        return string.Join(";", css);
+    }
+}

--- a/src/Spectre.Console/Internal/Text/Encoding/Svg/SvgEncoder.cs
+++ b/src/Spectre.Console/Internal/Text/Encoding/Svg/SvgEncoder.cs
@@ -1,0 +1,90 @@
+using System.Web;
+
+namespace Spectre.Console.Internal;
+
+internal sealed class SvgEncoder : IAnsiConsoleEncoder
+{
+    private readonly SvgEncoderSettings _settings;
+
+    public SvgEncoder(SvgEncoderSettings settings)
+    {
+        _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+    }
+
+    public string Encode(IAnsiConsole console, IEnumerable<IRenderable> renderable)
+    {
+        var template = GetTemplate();
+        if (template == null)
+        {
+            throw new InvalidOperationException("Template could not be found");
+        }
+
+        var context = new RenderContext(new EncoderCapabilities(ColorSystem.TrueColor));
+        var segmentLines = Segment.SplitLines(
+            renderable.SelectMany(r => r.Render(context, console.Profile.Width)));
+
+        var lines = new List<string>();
+        foreach (var segmentLine in segmentLines)
+        {
+            var line = new List<string>();
+
+            foreach (var segment in segmentLine)
+            {
+                if (segment.IsControlCode)
+                {
+                    continue;
+                }
+
+                var text = HttpUtility.HtmlEncode(segment.Text);
+
+                if (segment.Style != Style.Plain)
+                {
+                    var rule = SvgCssBuilder.BuildCss(_settings.Theme, segment.Style);
+                    text = $"<span style=\"color: #{_settings.Theme.ForegroundColor.ToHex()};{rule}; \">{text}</span>";
+                }
+                else
+                {
+                    text = $"<span style=\"color: #{_settings.Theme.ForegroundColor.ToHex()}; \">{text}</span>";
+                }
+
+                line.Add(text);
+            }
+
+            lines.Add($"<div>{string.Concat(line)}</div>");
+        }
+
+        var terminalPadding = 12;
+        var requiredCodeHeight = _settings.LineHeight * segmentLines.Count;
+        var terminalHeight = requiredCodeHeight + 60;
+        var terminalWidth =
+            (int)((console.Profile.Width * _settings.FontWidthScale * _settings.FontSize)
+            + (2 * terminalPadding)
+            + console.Profile.Width);
+
+        var totalHeight = terminalHeight + (2 * _settings.Margin);
+        var totalWidth = terminalWidth + (2 * _settings.Margin);
+
+        return template
+            .Replace("@(total_width)", totalWidth.ToString())
+            .Replace("@(total_height)", totalHeight.ToString())
+            .Replace("@(font_size)", _settings.FontSize.ToString())
+            .Replace("@(theme_background_color)", "#" + _settings.Theme.BackgroundColor.ToHex())
+            .Replace("@(theme_foreground_color)", "#" + _settings.Theme.ForegroundColor.ToHex())
+            .Replace("@(line_height)", _settings.LineHeight.ToString())
+            .Replace("@(code)", string.Concat(lines));
+    }
+
+    private static string? GetTemplate()
+    {
+        var stream = typeof(SvgEncoder).Assembly.GetManifestResourceStream("Spectre.Console.Svg.Templates.Simple.svg");
+        if (stream != null)
+        {
+            using (var reader = new StreamReader(stream))
+            {
+                return reader.ReadToEnd();
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Spectre.Console/Internal/Text/Encoding/Svg/SvgEncoderSettings.cs
+++ b/src/Spectre.Console/Internal/Text/Encoding/Svg/SvgEncoderSettings.cs
@@ -1,0 +1,35 @@
+namespace Spectre.Console.Internal;
+
+/// <summary>
+/// Represents settings for the SVG encoder.
+/// </summary>
+internal sealed class SvgEncoderSettings
+{
+    /// <summary>
+    /// Gets or sets the font size.
+    /// Default value is 18.
+    /// </summary>
+    public int FontSize { get; set; } = 18;
+
+    /// <summary>
+    /// Gets or sets the line height.
+    /// Default value is 22.
+    /// </summary>
+    public int LineHeight { get; set; } = 22;
+
+    /// <summary>
+    /// Gets or sets the font width scale.
+    /// Default value is 0.6.
+    /// </summary>
+    public float FontWidthScale { get; set; } = 0.6f;
+
+    /// <summary>
+    /// Gets or sets the margin (in pixels).
+    /// </summary>
+    public int Margin { get; set; } = 140;
+
+    /// <summary>
+    /// Gets or sets the theme to use.
+    /// </summary>
+    public SvgTheme Theme { get; set; } = new DefaultTheme();
+}

--- a/src/Spectre.Console/Internal/Text/Encoding/Svg/SvgTheme.cs
+++ b/src/Spectre.Console/Internal/Text/Encoding/Svg/SvgTheme.cs
@@ -1,0 +1,87 @@
+namespace Spectre.Console.Internal;
+
+/// <summary>
+/// Represents a theme used for SVG rendering.
+/// </summary>
+internal abstract class SvgTheme
+{
+    private readonly Dictionary<Color, Color> _lookup;
+    private readonly Dictionary<byte, Color> _lookupNumbers;
+    private readonly Dictionary<string, Color> _lookupNames;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SvgTheme"/> class.
+    /// </summary>
+    protected SvgTheme()
+    {
+        _lookup = new Dictionary<Color, Color>();
+        _lookupNumbers = new Dictionary<byte, Color>();
+        _lookupNames = new Dictionary<string, Color>();
+    }
+
+    /// <summary>
+    /// Gets the background color.
+    /// </summary>
+    public abstract Color BackgroundColor { get; }
+
+    /// <summary>
+    /// Gets the foreground color.
+    /// </summary>
+    public abstract Color ForegroundColor { get; }
+
+    /// <summary>
+    /// Overrides a color with the specified one.
+    /// </summary>
+    /// <param name="color">The color to override.</param>
+    /// <param name="newColor">The color to use instead of the overridden color.</param>
+    protected void Override(Color color, Color newColor)
+    {
+        if (color.Number != null)
+        {
+            _lookupNumbers[color.Number.Value] = newColor;
+
+            var name = ColorTable.GetName(color.Number.Value);
+            if (name != null)
+            {
+                _lookupNames[name] = newColor;
+            }
+        }
+
+        _lookup[color] = newColor;
+    }
+
+    internal Color GetColor(Color color)
+    {
+        if (color.IsDefault)
+        {
+            return color;
+        }
+
+        if (color.Number != null)
+        {
+            // Found by number?
+            if (_lookupNumbers.TryGetValue(color.Number.Value, out var numberResult))
+            {
+                return numberResult;
+            }
+
+            // Found by name?
+            var name = ColorTable.GetName(color.Number.Value);
+            if (name != null)
+            {
+                if (_lookupNames.TryGetValue(name, out var namedResult))
+                {
+                    return namedResult;
+                }
+            }
+        }
+
+        // Exact match?
+        if (_lookup.TryGetValue(color, out var result))
+        {
+            return result;
+        }
+
+        return color;
+    }
+}

--- a/src/Spectre.Console/Internal/Text/Encoding/Svg/Templates/Simple.svg
+++ b/src/Spectre.Console/Internal/Text/Encoding/Svg/Templates/Simple.svg
@@ -1,0 +1,44 @@
+<svg width="@(total_width)" height="@(total_height)" viewBox="0 0 @(total_width) @(total_height)" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        span {
+            display: inline-block;
+            white-space: pre;
+            vertical-align: top;
+            margin: 0;
+            font-size: @(font_size)px;
+            font-family:'Fira Code','Cascadia Code',Monaco,Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace;
+        }
+        a {
+            text-decoration: none;
+            color: inherit;
+        }
+        #wrapper {
+            padding: 0px;
+        }
+        #terminal {
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            background-color: @(theme_background_color);
+            border-radius: 14px;
+            outline: 1px solid #484848;
+        }
+        #terminal-body {
+            line-height: @(line_height)px;
+            padding: 14px;
+            padding-bottom: 35px;
+        }
+    </style>
+    <foreignObject x="0" y="0" width="100%" height="100%">
+        <body xmlns="http://www.w3.org/1999/xhtml">
+            <div id="wrapper">
+                <div id="terminal">
+                    <div id='terminal-body'>
+                        @(code)
+                    </div>
+                </div>
+            </div>
+        </body>
+    </foreignObject>
+</svg>

--- a/src/Spectre.Console/Internal/Text/Encoding/Svg/Themes/DefaultTheme.cs
+++ b/src/Spectre.Console/Internal/Text/Encoding/Svg/Themes/DefaultTheme.cs
@@ -1,0 +1,36 @@
+namespace Spectre.Console.Internal;
+
+/// <summary>
+/// The default SVG theme.
+/// </summary>
+internal sealed class DefaultTheme : SvgTheme
+{
+    /// <inheritdoc/>
+    public override Color ForegroundColor { get; } = Color.FromHex("#CCCCCC");
+
+    /// <inheritdoc/>
+    public override Color BackgroundColor { get; } = Color.FromHex("#2D2D2D");
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DefaultTheme"/> class.
+    /// </summary>
+    public DefaultTheme()
+    {
+        Override(Color.Black, Color.FromHex("#2D2D2D"));
+        Override(Color.Maroon, Color.FromHex("#F2777A"));
+        Override(Color.Green, Color.FromHex("#99CC99"));
+        Override(Color.Olive, Color.FromHex("#FFCC66"));
+        Override(Color.Navy, Color.FromHex("#6699CC"));
+        Override(Color.Purple, Color.FromHex("#CC99CC"));
+        Override(Color.Teal, Color.FromHex("#66CCCC"));
+        Override(Color.Silver, Color.FromHex("#CCCCCC"));
+        Override(Color.Grey, Color.FromHex("#999999"));
+        Override(Color.Red, Color.FromHex("#F2777A"));
+        Override(Color.Lime, Color.FromHex("#99CC99"));
+        Override(Color.Yellow, Color.FromHex("#FFCC66"));
+        Override(Color.Blue, Color.FromHex("#6699CC"));
+        Override(Color.Fuchsia, Color.FromHex("#CC99CC"));
+        Override(Color.Aqua, Color.FromHex("#66CCCC"));
+        Override(Color.White, Color.FromHex("#FFFFFF"));
+    }
+}

--- a/src/Spectre.Console/Spectre.Console.csproj
+++ b/src/Spectre.Console/Spectre.Console.csproj
@@ -13,7 +13,9 @@
 
   <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="Properties/stylecop.json" />
+    <EmbeddedResource Include="Internal\Text\Encoding\Svg\Templates\Simple.svg" />
     <EmbeddedResource Include="Widgets\Figlet\Fonts\Standard.flf" />
+    <None Remove="Internal\Text\Encoding\Svg\Templates\Simple.svg" />
     <None Remove="Widgets\Figlet\Fonts\Standard.flf" />
     <None Include="../../resources/gfx/small-logo.png" Pack="true" PackagePath="\" Link="Properties/small-logo.png" />
     <None Include="..\.editorconfig" Link="Cli\.editorconfig" />

--- a/src/Spectre.Console/StyleParser.cs
+++ b/src/Spectre.Console/StyleParser.cs
@@ -149,7 +149,7 @@ internal static class StyleParser
             effectiveLink);
     }
 
-    private static Color? ParseHexColor(string hex, out string? error)
+    public static Color? ParseHexColor(string hex, out string? error)
     {
         error = null;
 

--- a/test/Spectre.Console.Tests/Spectre.Console.Tests.csproj
+++ b/test/Spectre.Console.Tests/Spectre.Console.Tests.csproj
@@ -1,19 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="..\..\src\stylecop.json" Link="Properties/stylecop.json" />
   </ItemGroup>
 
-  <PropertyGroup>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">net6.0;net5.0;net48</TargetFrameworks>
-    <TargetFrameworks Condition="!$([MSBuild]::IsOSPlatform('Windows'))">net6.0;net5.0</TargetFrameworks>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Remove="Data\starwars.flf" />
-  </ItemGroup>
-
-  <ItemGroup>
     <EmbeddedResource Include="Data\starwars.flf" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR is mainly for discussion, so let's not merge it yet.

I've pretty much ported all the code for this PR from Rich: https://github.com/Textualize/rich/pull/2101, so if we decide to merge it, we should make sure to add attribution.

* Is this the road we want to take with SVG rendering, or should we try to build something similar to what @phil-scott-78 did with the Asciicast encoder?
* Should this be in a separate repo, away from the core project?

## Todo

- [ ] Add proper attribution to Rich
- [ ] Un-internalize the theme classes and the settings

## Example

![test](https://user-images.githubusercontent.com/357872/160306338-f95e4313-fefb-4def-9eeb-d8e3a6fad808.svg)