### PR TITLE
Upgrade dotnet example tool to 1.6.0

### DIFF
--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-example": {
-      "version": "1.5.0",
+      "version": "1.6.0",
       "commands": [
         "dotnet-example"
       ]


### PR DESCRIPTION
There isn't an ARM64 version of `net5.0` runtime or SDK and upgrading to 1.6.0 allows Mac using M1 chip to run the examples. 