### PR TITLE
Updated Microsoft.CodeAnalysis.* to current versions

### DIFF
--- a/src/Spectre.Console.Analyzer/Analyzers/FavorInstanceAnsiConsoleOverStaticAnalyzer.cs
+++ b/src/Spectre.Console.Analyzer/Analyzers/FavorInstanceAnsiConsoleOverStaticAnalyzer.cs
@@ -24,7 +24,7 @@ public class FavorInstanceAnsiConsoleOverStaticAnalyzer : SpectreAnalyzer
                 // if this operation isn't an invocation against one of the System.Console methods
                 // defined in _methods then we can safely stop analyzing and return;
                 var invocationOperation = (IInvocationOperation)context.Operation;
-                if (!Equals(invocationOperation.TargetMethod.ContainingType, ansiConsoleType))
+                if (!SymbolEqualityComparer.Default.Equals(invocationOperation.TargetMethod.ContainingType, ansiConsoleType))
                 {
                     return;
                 }
@@ -63,7 +63,7 @@ public class FavorInstanceAnsiConsoleOverStaticAnalyzer : SpectreAnalyzer
             .Ancestors().OfType<MethodDeclarationSyntax>()
             .First()
             .ParameterList.Parameters
-            .Any(i => i.Type.NormalizeWhitespace().ToString() == "IAnsiConsole");
+            .Any(i => i.Type?.NormalizeWhitespace().ToString() == "IAnsiConsole");
     }
 
     private static bool HasFieldAnsiConsole(SyntaxNode syntaxNode)
@@ -72,7 +72,7 @@ public class FavorInstanceAnsiConsoleOverStaticAnalyzer : SpectreAnalyzer
             .Ancestors()
             .OfType<MethodDeclarationSyntax>()
             .First()
-            .Modifiers.Any(i => i.Kind() == SyntaxKind.StaticKeyword);
+            .Modifiers.Any(i => i.IsKind(SyntaxKind.StaticKeyword));
 
         return syntaxNode
             .Ancestors().OfType<ClassDeclarationSyntax>()
@@ -81,6 +81,6 @@ public class FavorInstanceAnsiConsoleOverStaticAnalyzer : SpectreAnalyzer
             .OfType<FieldDeclarationSyntax>()
             .Any(i =>
                 i.Declaration.Type.NormalizeWhitespace().ToString() == "IAnsiConsole" &&
-                (!isStatic ^ i.Modifiers.Any(modifier => modifier.Kind() == SyntaxKind.StaticKeyword)));
+                (!isStatic ^ i.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.StaticKeyword))));
     }
 }

--- a/src/Spectre.Console.Analyzer/Analyzers/NoConcurrentLiveRenderablesAnalyzer.cs
+++ b/src/Spectre.Console.Analyzer/Analyzers/NoConcurrentLiveRenderablesAnalyzer.cs
@@ -33,12 +33,14 @@ public class NoConcurrentLiveRenderablesAnalyzer : SpectreAnalyzer
                     .Select(i => context.Compilation.GetTypeByMetadataName(i))
                     .ToImmutableArray();
 
-                if (liveTypes.All(i => !Equals(i, methodSymbol.ContainingType)))
+                if (liveTypes.All(i => !SymbolEqualityComparer.Default.Equals(i, methodSymbol.ContainingType)))
                 {
                     return;
                 }
 
+#pragma warning disable RS1030
                 var model = context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree);
+#pragma warning restore RS1030
                 var parentInvocations = invocationOperation
                     .Syntax.Ancestors()
                     .OfType<InvocationExpressionSyntax>()

--- a/src/Spectre.Console.Analyzer/Analyzers/NoPromptsDuringLiveRenderablesAnalyzer.cs
+++ b/src/Spectre.Console.Analyzer/Analyzers/NoPromptsDuringLiveRenderablesAnalyzer.cs
@@ -34,12 +34,15 @@ public class NoPromptsDuringLiveRenderablesAnalyzer : SpectreAnalyzer
                 var ansiConsoleType = context.Compilation.GetTypeByMetadataName("Spectre.Console.AnsiConsole");
                 var ansiConsoleExtensionsType = context.Compilation.GetTypeByMetadataName("Spectre.Console.AnsiConsoleExtensions");
 
-                if (!Equals(methodSymbol.ContainingType, ansiConsoleType) && !Equals(methodSymbol.ContainingType, ansiConsoleExtensionsType))
+                if (!SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, ansiConsoleType) &&
+                    !SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, ansiConsoleExtensionsType))
                 {
                     return;
                 }
 
+#pragma warning disable RS1030
                 var model = context.Compilation.GetSemanticModel(context.Operation.Syntax.SyntaxTree);
+#pragma warning restore RS1030
                 var parentInvocations = invocationOperation
                     .Syntax.Ancestors()
                     .OfType<InvocationExpressionSyntax>()

--- a/src/Spectre.Console.Analyzer/Analyzers/UseSpectreInsteadOfSystemConsoleAnalyzer.cs
+++ b/src/Spectre.Console.Analyzer/Analyzers/UseSpectreInsteadOfSystemConsoleAnalyzer.cs
@@ -33,7 +33,7 @@ public class UseSpectreInsteadOfSystemConsoleAnalyzer : SpectreAnalyzer
 
                 var systemConsoleType = context.Compilation.GetTypeByMetadataName("System.Console");
 
-                if (!Equals(invocationOperation.TargetMethod.ContainingType, systemConsoleType))
+                if (!SymbolEqualityComparer.Default.Equals(invocationOperation.TargetMethod.ContainingType, systemConsoleType))
                 {
                     return;
                 }

--- a/src/Spectre.Console.Analyzer/Fixes/CodeActions/SwitchToAnsiConsoleAction.cs
+++ b/src/Spectre.Console.Analyzer/Fixes/CodeActions/SwitchToAnsiConsoleAction.cs
@@ -35,7 +35,7 @@ public class SwitchToAnsiConsoleAction : CodeAction
         var originalCaller = ((MemberAccessExpressionSyntax)_originalInvocation.Expression).Name.ToString();
 
         var syntaxTree = await _document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-        var root = (CompilationUnitSyntax)await syntaxTree.GetRootAsync(cancellationToken).ConfigureAwait(false);
+        var root = (CompilationUnitSyntax)await syntaxTree!.GetRootAsync(cancellationToken).ConfigureAwait(false);
 
         // If there is an ansiConsole passed into the method then we'll use it.
         // otherwise we'll check for a field level instance.
@@ -66,7 +66,7 @@ public class SwitchToAnsiConsoleAction : CodeAction
             .Ancestors().OfType<MethodDeclarationSyntax>()
             .First()
             .ParameterList.Parameters
-            .FirstOrDefault(i => i.Type.NormalizeWhitespace().ToString() == "IAnsiConsole")
+            .FirstOrDefault(i => i.Type?.NormalizeWhitespace().ToString() == "IAnsiConsole")
             ?.Identifier.Text;
     }
 
@@ -79,7 +79,7 @@ public class SwitchToAnsiConsoleAction : CodeAction
             .Ancestors()
             .OfType<MethodDeclarationSyntax>()
             .First()
-            .Modifiers.Any(i => i.Kind() == SyntaxKind.StaticKeyword);
+            .Modifiers.Any(i => i.IsKind(SyntaxKind.StaticKeyword));
 
         return _originalInvocation
             .Ancestors().OfType<ClassDeclarationSyntax>()
@@ -88,7 +88,7 @@ public class SwitchToAnsiConsoleAction : CodeAction
             .OfType<FieldDeclarationSyntax>()
             .FirstOrDefault(i =>
                 i.Declaration.Type.NormalizeWhitespace().ToString() == "IAnsiConsole" &&
-                (!isStatic ^ i.Modifiers.Any(modifier => modifier.Kind() == SyntaxKind.StaticKeyword)))
+                (!isStatic ^ i.Modifiers.Any(modifier => modifier.IsKind(SyntaxKind.StaticKeyword))))
             ?.Declaration.Variables.First().Identifier.Text;
     }
 

--- a/src/Spectre.Console.Analyzer/Fixes/FixProviders/StaticAnsiConsoleToInstanceFix.cs
+++ b/src/Spectre.Console.Analyzer/Fixes/FixProviders/StaticAnsiConsoleToInstanceFix.cs
@@ -18,9 +18,9 @@ public class StaticAnsiConsoleToInstanceFix : CodeFixProvider
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        var methodDeclaration = root.FindNode(context.Span).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+        var methodDeclaration = root!.FindNode(context.Span).FirstAncestorOrSelf<InvocationExpressionSyntax>();
         context.RegisterCodeFix(
-            new SwitchToAnsiConsoleAction(context.Document, methodDeclaration, "Convert static AnsiConsole calls to local instance."),
+            new SwitchToAnsiConsoleAction(context.Document, methodDeclaration!, "Convert static AnsiConsole calls to local instance."),
             context.Diagnostics);
     }
 }

--- a/src/Spectre.Console.Analyzer/Fixes/FixProviders/SystemConsoleToAnsiConsoleFix.cs
+++ b/src/Spectre.Console.Analyzer/Fixes/FixProviders/SystemConsoleToAnsiConsoleFix.cs
@@ -18,9 +18,9 @@ public class SystemConsoleToAnsiConsoleFix : CodeFixProvider
     public override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        var methodDeclaration = root.FindNode(context.Span).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+        var methodDeclaration = root!.FindNode(context.Span).FirstAncestorOrSelf<InvocationExpressionSyntax>();
         context.RegisterCodeFix(
-            new SwitchToAnsiConsoleAction(context.Document, methodDeclaration, "Convert static call to AnsiConsole to Spectre.Console.AnsiConsole"),
+            new SwitchToAnsiConsoleAction(context.Document, methodDeclaration!, "Convert static call to AnsiConsole to Spectre.Console.AnsiConsole"),
             context.Diagnostics);
     }
 }

--- a/src/Spectre.Console.Analyzer/Spectre.Console.Analyzer.csproj
+++ b/src/Spectre.Console.Analyzer/Spectre.Console.Analyzer.csproj
@@ -15,9 +15,9 @@
     </ItemGroup>
     
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.6.1" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" PrivateAssets="all" />
     </ItemGroup>
     
     <ItemGroup>

--- a/test/Spectre.Console.Analyzer.Tests/Spectre.Console.Analyzer.Tests.csproj
+++ b/test/Spectre.Console.Analyzer.Tests/Spectre.Console.Analyzer.Tests.csproj
@@ -10,9 +10,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/test/Spectre.Console.Tests/Spectre.Console.Tests.csproj
+++ b/test/Spectre.Console.Tests/Spectre.Console.Tests.csproj
@@ -19,9 +19,9 @@
 
   <ItemGroup>
     <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="Spectre.Verify.Extensions" Version="0.3.0" />


### PR DESCRIPTION
* Microsoft.CodeAnalysis.Analyzers to 3.3.3
* Microsoft.CodeAnalysis.CSharp to 4.1.0
* Microsoft.CodeAnalysis.CSharp.Workspaces to 4.1.0
* Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit to 1.1.1
* Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit to 1.1.1

Afterwards fixed warnings in the code that resulted from the updates.