### PR TITLE
Detect non-interactive console via Console.IsInputRedirected instead of Environment.UserInteractive

### DIFF
--- a/src/Spectre.Console/AnsiConsoleFactory.cs
+++ b/src/Spectre.Console/AnsiConsoleFactory.cs
@@ -40,7 +40,7 @@ public sealed class AnsiConsoleFactory
         var interactive = settings.Interactive == InteractionSupport.Yes;
         if (settings.Interactive == InteractionSupport.Detect)
         {
-            interactive = Environment.UserInteractive;
+            interactive = !System.Console.IsInputRedirected;
         }
 
         var profile = new Profile(output, encoding);


### PR DESCRIPTION
`Environment.UserInteractive` is `false` for SSH sessions on Windows, even though they are interactive. Detecting non-interactive sessions via redirected stdin instead seems more robust.