### PR TITLE
fix: Missing API reference pages for Spectre.Console.Cli

### DIFF
--- a/docs/Program.cs
+++ b/docs/Program.cs
@@ -22,6 +22,7 @@ namespace Docs
                 .AddSetting(Constants.SourceFiles, new List<string>
                 {
                     "../../src/Spectre.Console/**/{!bin,!obj,!packages,!*.Tests,}/**/*.cs",
+                    "../../src/Spectre.Console.Cli/**/{!bin,!obj,!packages,!*.Tests,}/**/*.cs",
                     "../../src/Spectre.Console.ImageSharp/**/{!bin,!obj,!packages,!*.Tests,}/**/*.cs"
                 })
                 .AddSetting(Constants.ExampleSourceFiles, new List<string>


### PR DESCRIPTION
This commit fixes #833.

`Spectre.Console.Cli` was moved into its own project, and the path to the new project was not added to the list of source files when building the documentation.