### PR TITLE
Check for null in TextPrompt

### DIFF
--- a/src/Spectre.Console/Prompts/TextPrompt.cs
+++ b/src/Spectre.Console/Prompts/TextPrompt.cs
@@ -85,7 +85,7 @@ public sealed class TextPrompt<T> : IPrompt<T>
     /// <param name="comparer">The comparer used for choices.</param>
     public TextPrompt(string prompt, StringComparer? comparer = null)
     {
-        _prompt = prompt;
+        _prompt = prompt ?? throw new System.ArgumentNullException(nameof(prompt));
         _comparer = comparer;
     }
 


### PR DESCRIPTION
Should be slightly easier to debug.

```csharp
// Would throw "System.NullReferenceException : Object reference not set to an instance of an object."
AnsiConsole.Ask<string>(null);
// Now throws  "System.ArgumentNullException : Value cannot be null. (Parameter 'prompt')"
```

Matches ConfirmationPrompt:

https://github.com/spectreconsole/spectre.console/blob/564c7b8f4e44d4f83b89f1fdd1edf44da1d91da1/src/Spectre.Console/Prompts/ConfirmationPrompt.cs#L48