### PR TITLE
feat: optional cancellationtoken for asynchronous commands

### DIFF
--- a/src/Spectre.Console.Cli/CommandApp.cs
+++ b/src/Spectre.Console.Cli/CommandApp.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Spectre.Console.Cli;
 
 /// <summary>
@@ -52,7 +54,7 @@ public sealed class CommandApp : ICommandApp
     /// <returns>The exit code from the executed command.</returns>
     public int Run(IEnumerable<string> args)
     {
-        return RunAsync(args).GetAwaiter().GetResult();
+        return RunAsync(args, null).GetAwaiter().GetResult();
     }
 
     /// <summary>
@@ -61,6 +63,17 @@ public sealed class CommandApp : ICommandApp
     /// <param name="args">The arguments.</param>
     /// <returns>The exit code from the executed command.</returns>
     public async Task<int> RunAsync(IEnumerable<string> args)
+    {
+        return await RunAsync(args, null);
+    }
+
+    /// <summary>
+    /// Runs the command line application with specified arguments.
+    /// </summary>
+    /// <param name="args">The arguments.</param>
+    /// <param name="token">Optional cancellation token.</param>
+    /// <returns>The exit code from the executed command.</returns>
+    public async Task<int> RunAsync(IEnumerable<string> args, CancellationToken? token = null)
     {
         try
         {
@@ -79,7 +92,7 @@ public sealed class CommandApp : ICommandApp
             }
 
             return await _executor
-                .Execute(_configurator, args)
+                .Execute(_configurator, args, token)
                 .ConfigureAwait(false);
         }
         catch (Exception ex)

--- a/src/Spectre.Console.Cli/CommandApp.cs
+++ b/src/Spectre.Console.Cli/CommandApp.cs
@@ -64,7 +64,7 @@ public sealed class CommandApp : ICommandApp
     /// <returns>The exit code from the executed command.</returns>
     public async Task<int> RunAsync(IEnumerable<string> args)
     {
-        return await RunAsync(args, null);
+        return await RunAsync(args);
     }
 
     /// <summary>

--- a/src/Spectre.Console.Cli/CommandApp.cs
+++ b/src/Spectre.Console.Cli/CommandApp.cs
@@ -54,7 +54,7 @@ public sealed class CommandApp : ICommandApp
     /// <returns>The exit code from the executed command.</returns>
     public int Run(IEnumerable<string> args)
     {
-        return RunAsync(args, null).GetAwaiter().GetResult();
+        return RunAsync(args).GetAwaiter().GetResult();
     }
 
     /// <summary>

--- a/src/Spectre.Console.Cli/CommandAppOfT.cs
+++ b/src/Spectre.Console.Cli/CommandAppOfT.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Spectre.Console.Cli;
 
 /// <summary>
@@ -46,5 +48,16 @@ public sealed class CommandApp<TDefaultCommand> : ICommandApp
     public Task<int> RunAsync(IEnumerable<string> args)
     {
         return _app.RunAsync(args);
+    }
+
+    /// <summary>
+    /// Runs the command line application with specified arguments.
+    /// </summary>
+    /// <param name="args">The arguments.</param>
+    /// <param name="token">A cancellation token.</param>
+    /// <returns>The exit code from the executed command.</returns>
+    public Task<int> RunAsync(IEnumerable<string> args, CancellationToken? token)
+    {
+        return _app.RunAsync(args, token);
     }
 }

--- a/src/Spectre.Console.Cli/CommandContext.cs
+++ b/src/Spectre.Console.Cli/CommandContext.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Spectre.Console.Cli;
 
 /// <summary>
@@ -30,15 +32,23 @@ public sealed class CommandContext
     public object? Data { get; }
 
     /// <summary>
+    /// Gets the cancellation token for async commands.
+    /// </summary>
+    /// <value>The token.</value>
+    public CancellationToken? Token { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CommandContext"/> class.
     /// </summary>
     /// <param name="remaining">The remaining arguments.</param>
     /// <param name="name">The command name.</param>
     /// <param name="data">The command data.</param>
-    public CommandContext(IRemainingArguments remaining, string name, object? data)
+    /// <param name="token">The cancellation token.</param>
+    public CommandContext(IRemainingArguments remaining, string name, object? data, CancellationToken? token)
     {
         Remaining = remaining ?? throw new System.ArgumentNullException(nameof(remaining));
         Name = name ?? throw new System.ArgumentNullException(nameof(name));
         Data = data;
+        Token = token;
     }
 }

--- a/src/Spectre.Console.Cli/ICommandApp.cs
+++ b/src/Spectre.Console.Cli/ICommandApp.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Spectre.Console.Cli;
 
 /// <summary>
@@ -24,4 +26,12 @@ public interface ICommandApp
     /// <param name="args">The arguments.</param>
     /// <returns>The exit code from the executed command.</returns>
     Task<int> RunAsync(IEnumerable<string> args);
+
+    /// <summary>
+    /// Runs the command line application with specified arguments.
+    /// </summary>
+    /// <param name="args">The arguments.</param>
+    /// <param name="token">A cancellation token.</param>
+    /// <returns>The exit code from the executed command.</returns>
+    Task<int> RunAsync(IEnumerable<string> args, CancellationToken? token);
 }

--- a/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
@@ -1,3 +1,5 @@
+using System.Threading;
+
 namespace Spectre.Console.Cli;
 
 internal sealed class CommandExecutor
@@ -10,7 +12,7 @@ internal sealed class CommandExecutor
         _registrar.Register(typeof(DefaultPairDeconstructor), typeof(DefaultPairDeconstructor));
     }
 
-    public async Task<int> Execute(IConfiguration configuration, IEnumerable<string> args)
+    public async Task<int> Execute(IConfiguration configuration, IEnumerable<string> args, CancellationToken? token)
     {
         if (configuration == null)
         {
@@ -72,7 +74,7 @@ internal sealed class CommandExecutor
         // Create the resolver and the context.
         using (var resolver = new TypeResolverAdapter(_registrar.Build()))
         {
-            var context = new CommandContext(parsedResult.Remaining, leaf.Command.Name, leaf.Command.Data);
+            var context = new CommandContext(parsedResult.Remaining, leaf.Command.Name, leaf.Command.Data, token);
 
             // Execute the command tree.
             return await Execute(leaf, parsedResult.Tree, context, resolver, configuration).ConfigureAwait(false);


### PR DESCRIPTION
Our internal tooling using spectre has commands that can run quite long, and we execute the commandapp within an input loop. Ctrl+c currently closes the application and we have to restart it in 'interactive mode'
Our preference would be to make ctrl+c cancel the command when running by passing a cancellationtoken.