### PR TITLE
Modified MarkupTokenizer, so that escaped markup inside markup is valid

### DIFF
--- a/src/Spectre.Console/Internal/Text/Markup/MarkupTokenizer.cs
+++ b/src/Spectre.Console/Internal/Text/Markup/MarkupTokenizer.cs
@@ -59,7 +59,7 @@ internal sealed class MarkupTokenizer : IDisposable
                 if (encounteredClosing)
                 {
                     throw new InvalidOperationException(
-                        $"Encountered unescaped ']' token at position {_reader.Position}.");
+                        $"Encountered unescaped ']' token at position {_reader.Position}");
                 }
             }
 
@@ -68,7 +68,7 @@ internal sealed class MarkupTokenizer : IDisposable
 
         if (encounteredClosing)
         {
-            throw new InvalidOperationException($"Encountered unescaped ']' token at position {_reader.Position}.");
+            throw new InvalidOperationException($"Encountered unescaped ']' token at position {_reader.Position}");
         }
 
         Current = new MarkupToken(MarkupTokenKind.Text, builder.ToString(), position);

--- a/src/Spectre.Console/Internal/Text/Markup/MarkupTokenizer.cs
+++ b/src/Spectre.Console/Internal/Text/Markup/MarkupTokenizer.cs
@@ -113,7 +113,7 @@ internal sealed class MarkupTokenizer : IDisposable
                     if (encounteredClosing)
                     {
                         throw new InvalidOperationException(
-                            $"Encountered unescaped ']' token at position {_reader.Position}");
+                            $"Encountered unescaped ']' token at position {_reader.Position}.");
                     }
                 }
 
@@ -122,7 +122,7 @@ internal sealed class MarkupTokenizer : IDisposable
 
             if (encounteredClosing)
             {
-                throw new InvalidOperationException($"Encountered unescaped ']' token at position {_reader.Position}");
+                throw new InvalidOperationException($"Encountered unescaped ']' token at position {_reader.Position}.");
             }
 
             Current = new MarkupToken(MarkupTokenKind.Text, builder.ToString(), position);

--- a/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Markup.cs
+++ b/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Markup.cs
@@ -49,6 +49,36 @@ public partial class AnsiConsoleTests
             console.Output.ShouldMatch("]8;id=[0-9]*;https:\\/\\/patriksvensson\\.se\\\\https:\\/\\/patriksvensson\\.se]8;;\\\\");
         }
 
+        [Fact]
+        public void Should_Output_Expected_Ansi_For_Link_With_Bracket_In_Url_Only()
+        {
+            // Given
+            var console = new TestConsole()
+                .EmitAnsiSequences();
+
+            // When
+            const string Path = "file://c:/temp/[x].txt";
+            console.Markup($"[link]{Path.EscapeMarkup()}[/]");
+
+            // Then
+            console.Output.ShouldMatch("]8;id=[0-9]*;file:\\/\\/c:\\/temp\\/\\[x\\].txt\\\\file:\\/\\/c:\\/temp\\/\\[x\\].txt]8;;\\\\");
+        }
+
+        [Fact]
+        public void Should_Output_Expected_Ansi_For_Link_With_Bracket_In_Url()
+        {
+            // Given
+            var console = new TestConsole()
+                .EmitAnsiSequences();
+
+            // When
+            const string Path = "file://c:/temp/[x].txt";
+            console.Markup($"[link={Path.EscapeMarkup()}]{Path.EscapeMarkup()}[/]");
+
+            // Then
+            console.Output.ShouldMatch("]8;id=[0-9]*;file:\\/\\/c:\\/temp\\/\\[x\\].txt\\\\file:\\/\\/c:\\/temp\\/\\[x\\].txt]8;;\\\\");
+        }
+
         [Theory]
         [InlineData("[yellow]Hello [[ World[/]", "[93mHello [ World[0m")]
         public void Should_Be_Able_To_Escape_Tags(string markup, string expected)

--- a/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Markup.cs
+++ b/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Markup.cs
@@ -100,6 +100,7 @@ public partial class AnsiConsoleTests
         [InlineData("[yellow]Hello[/", "Encountered malformed markup tag at position 15.")]
         [InlineData("[yellow]Hello[/foo", "Encountered malformed markup tag at position 15.")]
         [InlineData("[yellow Hello", "Encountered malformed markup tag at position 13.")]
+        [InlineData("[yellow[green]]Hello", "Encountered malformed markup tag at position 7.")]
         public void Should_Throw_If_Encounters_Malformed_Tag(string markup, string expected)
         {
             // Given

--- a/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Markup.cs
+++ b/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Markup.cs
@@ -141,5 +141,18 @@ public partial class AnsiConsoleTests
             result.ShouldBeOfType<InvalidOperationException>()
                 .Message.ShouldBe("Encountered closing tag when none was expected near position 5.");
         }
+
+        [Fact]
+        public void Should_Not_Get_Confused_When_Mixing_Escaped_And_Unescaped()
+        {
+            // Given
+            var console = new TestConsole();
+
+            // When
+            console.Markup("[grey][[grey]][/][white][[white]][/]");
+
+            // Then
+            console.Output.ShouldBe("[grey][white]");
+        }
     }
 }

--- a/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.MarkupInterpolated.cs
+++ b/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.MarkupInterpolated.cs
@@ -1,0 +1,40 @@
+namespace Spectre.Console.Tests.Unit;
+
+public partial class AnsiConsoleTests
+{
+    public sealed class MarkupInterpolated
+    {
+        [Fact]
+        public void Should_Print_Simple_Interpolated_Strings()
+        {
+            // Given
+            var console = new TestConsole()
+                .Colors(ColorSystem.Standard)
+                .EmitAnsiSequences();
+
+            // When
+            const string Path = "file://c:/temp/[x].txt";
+            console.MarkupInterpolated($"[Green]{Path}[/]");
+
+            // Then
+            console.Output.ShouldBe($"[32m{Path}[0m");
+        }
+
+        [Fact]
+        public void Should_Not_Throw_Error_On_Links_Brackets()
+        {
+            // Given
+            var console = new TestConsole()
+                .Colors(ColorSystem.Standard)
+                .EmitAnsiSequences();
+
+            // When
+            const string Path = "file://c:/temp/[x].txt";
+            console.MarkupInterpolated($"[link={Path}]{Path}[/]");
+
+            // Then
+            var pathAsRegEx = Regex.Replace(Path, "([/\\[\\]\\\\])", "\\$1", RegexOptions.Compiled|RegexOptions.IgnoreCase);
+            console.Output.ShouldMatch($"\\]8;id=[0-9]+;{pathAsRegEx}\\\\{pathAsRegEx}\\]8;;\\\\");
+        }
+    }
+}

--- a/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.MarkupInterpolated.cs
+++ b/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.MarkupInterpolated.cs
@@ -33,7 +33,7 @@ public partial class AnsiConsoleTests
             console.MarkupInterpolated($"[link={Path}]{Path}[/]");
 
             // Then
-            var pathAsRegEx = Regex.Replace(Path, "([/\\[\\]\\\\])", "\\$1", RegexOptions.Compiled|RegexOptions.IgnoreCase);
+            var pathAsRegEx = Regex.Replace(Path, "([/\\[\\]\\\\])", "\\$1", RegexOptions.Compiled | RegexOptions.IgnoreCase);
             console.Output.ShouldMatch($"\\]8;id=[0-9]+;{pathAsRegEx}\\\\{pathAsRegEx}\\]8;;\\\\");
         }
     }

--- a/test/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
@@ -107,7 +107,7 @@ public sealed class MarkupTests
         // Then
         result.ShouldNotBeNull();
         result.ShouldBeOfType<InvalidOperationException>();
-        result.Message.ShouldBe("Encountered unescaped ']' token at position 16.");
+        result.Message.ShouldBe("Encountered unescaped ']' token at position 16");
     }
 
     [Fact]

--- a/test/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
@@ -107,7 +107,7 @@ public sealed class MarkupTests
         // Then
         result.ShouldNotBeNull();
         result.ShouldBeOfType<InvalidOperationException>();
-        result.Message.ShouldBe("Encountered unescaped ']' token at position 16");
+        result.Message.ShouldBe("Encountered unescaped ']' token at position 16.");
     }
 
     [Fact]


### PR DESCRIPTION
fixes #903 