### PR TITLE
Added command description to command help message

### DIFF
--- a/src/Spectre.Console.Cli/Internal/HelpWriter.cs
+++ b/src/Spectre.Console.Cli/Internal/HelpWriter.cs
@@ -75,6 +75,7 @@ internal static class HelpWriter
         var isDefaultCommand = command?.IsDefaultCommand ?? false;
 
         var result = new List<IRenderable>();
+        result.AddRange(GetDescription(command));
         result.AddRange(GetUsage(model, command));
         result.AddRange(GetExamples(model, command));
         result.AddRange(GetArguments(command));
@@ -82,6 +83,19 @@ internal static class HelpWriter
         result.AddRange(GetCommands(model, container, isDefaultCommand));
 
         return result;
+    }
+
+    private static IEnumerable<IRenderable> GetDescription(CommandInfo? command)
+    {
+        if (command?.Description == null)
+        {
+            yield break;
+        }
+
+        var composer = new Composer();
+        composer.Style("yellow", "DESCRIPTION:").LineBreak();
+        composer.Text(command.Description).LineBreak();
+        yield return composer.LineBreak();
     }
 
     private static IEnumerable<IRenderable> GetUsage(CommandModel model, CommandInfo? command)

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/Command.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/Command.Output.verified.txt
@@ -1,3 +1,6 @@
+﻿DESCRIPTION:
+Contains settings for a cat.
+
 USAGE:
     myapp cat [LEGS] [OPTIONS] <COMMAND>
 

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/CommandExamples.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/CommandExamples.Output.verified.txt
@@ -1,3 +1,6 @@
+﻿DESCRIPTION:
+The animal command.
+
 USAGE:
     myapp animal [LEGS] [OPTIONS] <COMMAND>
 

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/Default.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/Default.Output.verified.txt
@@ -1,3 +1,6 @@
+﻿DESCRIPTION:
+The lion command.
+
 USAGE:
     myapp <TEETH> [LEGS] [OPTIONS]
 

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/DefaultExamples.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/DefaultExamples.Output.verified.txt
@@ -1,3 +1,6 @@
+﻿DESCRIPTION:
+The lion command.
+
 USAGE:
     myapp <TEETH> [LEGS] [OPTIONS]
 

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/Leaf.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/Leaf.Output.verified.txt
@@ -1,3 +1,6 @@
+﻿DESCRIPTION:
+The lion command.
+
 USAGE:
     myapp cat [LEGS] lion <TEETH> [OPTIONS]
 


### PR DESCRIPTION
I guess command description should be available in command help message.

In current version to see command description user should open main help or branch help.
I offer add command decsription to command help message.