### PR TITLE
(#922) fixed ArgumentNullException on .NET Framework

### DIFF
--- a/src/Spectre.Console/Spectre.Console.csproj
+++ b/src/Spectre.Console/Spectre.Console.csproj
@@ -8,10 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
-  </ItemGroup>
-
-  <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" Link="Properties/stylecop.json" />
     <EmbeddedResource Include="Widgets\Figlet\Fonts\Standard.flf" />
     <None Remove="Widgets\Figlet\Fonts\Standard.flf" />

--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
@@ -221,9 +221,9 @@ internal static class ExceptionFormatter
         return true;
     }
 
-    private static IEnumerable<StackFrame> FilterStackFrames(this IEnumerable<StackFrame?> frames)
+    private static IEnumerable<StackFrame> FilterStackFrames(this IEnumerable<StackFrame?>? frames)
     {
-        var allFrames = frames.ToArray();
+        var allFrames = frames?.ToArray() ?? Array.Empty<StackFrame>();
         var numberOfFrames = allFrames.Length;
 
         for (var i = 0; i < numberOfFrames; i++)


### PR DESCRIPTION
It seems, when Spectre.Console is compiled for
netstandard2.0, StackTrace.GetFrames() returns null
instead of an empty array.