### PR TITLE
build: set nuget package as dev dependency

### DIFF
--- a/src/Spectre.Console/Spectre.Console.csproj
+++ b/src/Spectre.Console/Spectre.Console.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
+    <DevelopmentDependency>true</DevelopmentDependency>
     <NoWarn>SA1633</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
[Reference](https://github.com/NuGet/Home/wiki/DevelopmentDependency-support-for-PackageReference)

closes: #932