### PR TITLE
Set the DevelopmentDependency flag on the Spectre.Console.Analyzer project

### DIFF
--- a/src/Spectre.Console.Analyzer/Spectre.Console.Analyzer.csproj
+++ b/src/Spectre.Console.Analyzer/Spectre.Console.Analyzer.csproj
@@ -4,6 +4,7 @@
         <Description>Best practice analyzers for Spectre.Console.</Description>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IsPackable>true</IsPackable>
+        <DevelopmentDependency>true</DevelopmentDependency>
         <IncludeBuildOutput>false</IncludeBuildOutput>
         <Nullable>enable</Nullable>
         <NoPackageAnalysis>true</NoPackageAnalysis>

--- a/src/Spectre.Console/Spectre.Console.csproj
+++ b/src/Spectre.Console/Spectre.Console.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
-    <DevelopmentDependency>true</DevelopmentDependency>
     <NoWarn>SA1633</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
It was applied by mistake on Spectre.Console in #938.