### PR TITLE
Show help for default command

### DIFF
--- a/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
@@ -66,6 +66,14 @@ internal sealed class CommandExecutor
             return leaf.ShowHelp ? 0 : 1;
         }
 
+        // Is this the default and is it called without arguments when there are required arguments?
+        if (leaf.Command.IsDefaultCommand && args.Count() == 0 && leaf.Command.Parameters.Any(p => p.Required))
+        {
+            // Display help for default command.
+            configuration.Settings.Console.SafeRender(HelpWriter.WriteCommand(model, leaf.Command));
+            return 1;
+        }
+
         // Register the arguments with the container.
         _registrar.RegisterInstance(typeof(IRemainingArguments), parsedResult.Remaining);
 

--- a/test/Spectre.Console.Cli.Tests/Data/Commands/GreeterCommand.cs
+++ b/test/Spectre.Console.Cli.Tests/Data/Commands/GreeterCommand.cs
@@ -1,0 +1,17 @@
+using Spectre.Console;
+
+public class GreeterCommand : Command<OptionalArgumentWithDefaultValueSettings>
+{
+    private readonly IAnsiConsole _console;
+
+    public GreeterCommand(IAnsiConsole console)
+    {
+        _console = console;
+    }
+
+    public override int Execute([NotNull] CommandContext context, [NotNull] OptionalArgumentWithDefaultValueSettings settings)
+    {
+        _console.WriteLine(settings.Greeting);
+        return 0;
+    }
+}

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/Default_Without_Args.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/Default_Without_Args.Output.verified.txt
@@ -1,0 +1,16 @@
+﻿DESCRIPTION:
+The lion command.
+
+USAGE:
+    myapp <TEETH> [LEGS] [OPTIONS]
+
+ARGUMENTS:
+    <TEETH>    The number of teeth the lion has
+    [LEGS]     The number of legs
+
+OPTIONS:
+    -h, --help               Prints help information
+    -a, --alive              Indicates whether or not the animal is alive
+    -n, --name <VALUE>
+        --agility <VALUE>    The agility between 0 and 100
+    -c <CHILDREN>            The number of children the lion has

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/Default_Without_Args_Additional.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/Default_Without_Args_Additional.Output.verified.txt
@@ -1,0 +1,19 @@
+DESCRIPTION:
+The lion command.
+
+USAGE:
+    myapp <TEETH> [LEGS] [OPTIONS]
+
+ARGUMENTS:
+    <TEETH>    The number of teeth the lion has
+    [LEGS]     The number of legs
+
+OPTIONS:
+    -h, --help               Prints help information
+    -a, --alive              Indicates whether or not the animal is alive
+    -n, --name <VALUE>
+        --agility <VALUE>    The agility between 0 and 100
+    -c <CHILDREN>            The number of children the lion has
+
+COMMANDS:
+    giraffe <LENGTH>    The giraffe command

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/Greeter_Default.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/Greeter_Default.Output.verified.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/test/Spectre.Console.Cli.Tests/Spectre.Console.Cli.Tests.csproj
+++ b/test/Spectre.Console.Cli.Tests/Spectre.Console.Cli.Tests.csproj
@@ -31,4 +31,15 @@
     <ProjectReference Include="..\..\src\Spectre.Console\Spectre.Console.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Expectations\Help\Default_Without_Args_Additional.Output.verified.txt">
+      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
+      <DependentUpon>%(ParentFile).cs</DependentUpon>
+    </None>
+    <None Update="Expectations\Help\Greeter_Default.Output.verified.txt">
+      <ParentFile>$([System.String]::Copy('%(FileName)').Split('.')[0])</ParentFile>
+      <DependentUpon>%(ParentFile).cs</DependentUpon>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
@@ -116,6 +116,64 @@ public sealed partial class CommandAppTests
         }
 
         [Fact]
+        [Expectation("Default_Without_Args")]
+        public Task Should_Output_Default_Command_When_Command_Has_Required_Parameters_And_Is_Called_Without_Args()
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.SetDefaultCommand<LionCommand>();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationName("myapp");
+            });
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            return Verifier.Verify(result.Output);
+        }
+
+        [Fact]
+        [Expectation("Default_Without_Args_Additional")]
+        public Task Should_Output_Default_Command_And_Additional_Commands_When_Default_Command_Has_Required_Parameters_And_Is_Called_Without_Args()
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.SetDefaultCommand<LionCommand>();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationName("myapp");
+                configurator.AddCommand<GiraffeCommand>("giraffe");
+            });
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            return Verifier.Verify(result.Output);
+        }
+
+        [Fact]
+        [Expectation("Greeter_Default")]
+        public Task Should_Not_Output_Default_Command_When_Command_Has_No_Required_Parameters_And_Is_Called_Without_Args()
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.SetDefaultCommand<GreeterCommand>();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationName("myapp");
+            });
+
+            // When
+            var result = fixture.Run();
+
+            // Then
+            return Verifier.Verify(result.Output);
+        }
+
+        [Fact]
         [Expectation("RootExamples")]
         public Task Should_Output_Root_Examples_Defined_On_Root()
         {


### PR DESCRIPTION
Automatically show the default command's help:

When called without args:
- Default command with required params -> Show help
- Default command with required params and additional commands -> Show help including additional commands
- Default command without required params -> Execute command