### PR TITLE
Added details for using links within markup.

### DIFF
--- a/docs/input/appendix/styles.md
+++ b/docs/input/appendix/styles.md
@@ -5,6 +5,7 @@ Highlights:
     - Bold, Italic, Underline, strikethrough
     - Dim, Invert
     - Conceal, slowblink, rapidblink
+    - Links
 ---
 
 Note that what styles that can be used is defined by the system or your terminal software, and may not appear as they should.
@@ -45,5 +46,9 @@ Note that what styles that can be used is defined by the system or your terminal
     <tr>
         <td><code>strikethrough</code></td>
         <td>Shows text with a horizontal line through the center</td>
+    </tr>
+    <tr>
+        <td><code>link</link></td>
+        <td>Creates a clickable link within text</td>
     </tr>
 </table>

--- a/docs/input/markup.md
+++ b/docs/input/markup.md
@@ -106,6 +106,15 @@ AnsiConsole.Markup("[rgb(255,0,0)]Baz[/] ");
 
 For a list of colors, see the [Colors](xref:colors) appendix section.
 
+## Links
+
+To output a clickable link, you can use the `[link]` style.
+
+```csharp
+AnsiConsole.Markup("[link]https://spectreconsole.net[/]");
+AnsiConsole.Markup("[link=https://spectreconsole.net]Spectre Console Documentation[/]");
+```
+
 ## Styles
 
 For a list of styles, see the [Styles](xref:styles) appendix section.


### PR DESCRIPTION
[Issue #958](https://github.com/spectreconsole/spectre.console/issues/958)

Additions:
- Links section on Markdown page.
- link row within Styles page table.