### PR TITLE
Blog date fix

### DIFF
--- a/docs/input/blog/posts/2021-07-11-hello-world.md
+++ b/docs/input/blog/posts/2021-07-11-hello-world.md
@@ -1,6 +1,6 @@
 Title: Hello, World
 Description: To help track new releases, updates and planning for Spectre.Console, we've added a new blog to the documentation.
-Published: 20210711
+Published: 2021-07-11
 Category: News
 ---
 

--- a/docs/input/blog/posts/2021-07-19-spectre-console-0.41-released.md
+++ b/docs/input/blog/posts/2021-07-19-spectre-console-0.41-released.md
@@ -1,6 +1,6 @@
 Title: Spectre.Console 0.41 released!
 Description: In this release we (mostly Phil) have been focusing on getting the new fancy Roslyn Analyzers out the door...
-Published: 20210719
+Published: 2021-07-19
 Category: Release Notes
 Excluded: false
 ---

--- a/docs/input/blog/posts/2021-12-16-spectre-console-0.43-released.md
+++ b/docs/input/blog/posts/2021-12-16-spectre-console-0.43-released.md
@@ -1,6 +1,6 @@
 Title: Spectre.Console 0.43 released!
 Description: Now with .NET 6 support... and more!
-Published: 20211216
+Published: 2021-12-16
 Category: Release Notes
 Excluded: false
 ---

--- a/docs/input/blog/posts/2022-03-27-spectre-console-0.44-released.md
+++ b/docs/input/blog/posts/2022-03-27-spectre-console-0.44-released.md
@@ -1,6 +1,6 @@
 Title: Spectre.Console 0.44 released!
 Description: Alternate screen buffers, better exception rendering... and more!
-Published: 20220327
+Published: 2022-03-27
 Category: Release Notes
 Excluded: false
 ---

--- a/docs/input/blog/posts/2022-09-10-spectre-console-0.45-released.md
+++ b/docs/input/blog/posts/2022-09-10-spectre-console-0.45-released.md
@@ -1,6 +1,6 @@
 Title: Spectre.Console 0.45 released!
 Description: .NET 5 dropped, Spectre.Console.Cli moved to separate NuGet package
-Published: 20220910
+Published: 2022-09-10
 Category: Release Notes
 Excluded: false
 ---

--- a/docs/input/blog/posts/BLOG_TEMPLATE.md
+++ b/docs/input/blog/posts/BLOG_TEMPLATE.md
@@ -1,6 +1,6 @@
 Title: Short title, less than 50 characters
 Description: Longer description, with optional *bold* and **italic** characters. Shouldn't be TOO long but can span multiple lines.
-Published: 20210710
+Published: 2021-07-10
 Category: Release Notes | News | or whatever
 Excluded: true
 ---

--- a/docs/src/SocialCards/index.cshtml
+++ b/docs/src/SocialCards/index.cshtml
@@ -15,7 +15,7 @@
 
   <div id="container">
     <div id="console">
-        <div class="line"><span style="color:var(--brightBlack)">╭─</span><span style="color:var(--folder)">&#xe0b2;</span><span style="background-color:var(--folder);color:var(--black)"> ~/spectre.console</span><span style="color:var(--folder);background-color:var(--dotnet)">&#xe0b0;</span><span style="background-color:var(--blue)"> .NET 5.0 </span><span style="color:var(--dotnet);background-color:var(--git)">&#xe0b0;</span><span style="background-color:var(--git);color:var(--background)"> &#xe0a0; main </span><span style="color:var(--git)">&#xe0b4;</span></div>
+        <div class="line"><span style="color:var(--brightBlack)">╭─</span><span style="color:var(--folder)">&#xe0b2;</span><span style="background-color:var(--folder);color:var(--black)"> ~/spectre.console</span><span style="color:var(--folder);background-color:var(--dotnet)">&#xe0b0;</span><span style="background-color:var(--blue)"> .NET 6.0 </span><span style="color:var(--dotnet);background-color:var(--git)">&#xe0b0;</span><span style="background-color:var(--git);color:var(--background)"> &#xe0a0; main </span><span style="color:var(--git)">&#xe0b4;</span></div>
         <div class="line"><span style="color:var(--brightBlack)">╰─</span> dotnet run</div>
         <div class="line"></div>
         <div class="line">╭────────────────────────────────────────────────────────╮</div>


### PR DESCRIPTION
* Tries to be more explicit about date formats for blog posts
* Updates the social card image to be .NET 6 while I'm in here

Trying to solve #962. Unfortunately I can't reproduce this locally, I suspect the culture set on the GH CI servers is guessing wrong on the format so hopefully a better date format will help it along...