### PR TITLE
Update `.NET 5` -> `.NET 6` in docs

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -4,7 +4,7 @@ _[![Spectre.Console NuGet Version](https://img.shields.io/nuget/v/spectre.consol
 
 <div dir="rtl">
 
-یک کتابخانه NET Standard 2.0/.NET 5. که ایجاد Console Applicationهای زیبا و cross platform را آسان‌تر می‌کند.  
+یک کتابخانه NET Standard 2.0/.NET 6. که ایجاد Console Applicationهای زیبا و cross platform را آسان‌تر می‌کند.  
 از کتابخانه عالی [Rich](https://github.com/willmcgugan/rich)  برای پایتون، بسیار الهام گرفته شده است.
 
 ## فهرست

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 _[![Spectre.Console NuGet Version](https://img.shields.io/nuget/v/spectre.console.svg?style=flat&label=NuGet%3A%20Spectre.Console)](https://www.nuget.org/packages/spectre.console)_ [![Netlify Status](https://api.netlify.com/api/v1/badges/1eaf215a-eb9c-45e4-8c64-c90b62963149/deploy-status)](https://app.netlify.com/sites/spectreconsole/deploys)
 
-A .NET 5/.NET Standard 2.0 library that makes it easier to create beautiful, cross platform, console applications.  
+A .NET 6/.NET Standard 2.0 library that makes it easier to create beautiful, cross platform, console applications.  
 It is heavily inspired by the excellent [Rich library](https://github.com/willmcgugan/rich) 
 for Python.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -2,7 +2,7 @@
 
 _[![Spectre.Console NuGet Versão](https://img.shields.io/nuget/v/spectre.console.svg?style=flat&label=NuGet%3A%20Spectre.Console)](https://www.nuget.org/packages/spectre.console)_
 
-Uma biblioteca .NET 5/.NET Standard 2.0 que torna mais fácil criar aplicativos de console bonitos e multiplataforma. 
+Uma biblioteca .NET 6/.NET Standard 2.0 que torna mais fácil criar aplicativos de console bonitos e multiplataforma. 
 É fortemente inspirada na excelente [biblioteca Rich](https://github.com/willmcgugan/rich) 
 para Python.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,7 +2,7 @@
 
 _[![Spectre.Console NuGet Version](https://img.shields.io/nuget/v/spectre.console.svg?style=flat&label=NuGet%3A%20Spectre.Console)](https://www.nuget.org/packages/spectre.console)_
 
-`Spectre.Console`是一个 .NET 5/.NET Standard 2.0 的库，可以更轻松地创建美观的跨平台控制台应用程序。
+`Spectre.Console`是一个 .NET 6/.NET Standard 2.0 的库，可以更轻松地创建美观的跨平台控制台应用程序。
 
 深受 [Rich](https://github.com/willmcgugan/rich) 这个Python优秀库的启发。
 

--- a/src/Spectre.Console/Extensions/StringBuilderExtensions.cs
+++ b/src/Spectre.Console/Extensions/StringBuilderExtensions.cs
@@ -26,7 +26,7 @@ internal static class StringBuilderExtensions
     public static void AppendSpan(this StringBuilder builder, ReadOnlySpan<char> span)
     {
         // NetStandard 2 lacks the override for StringBuilder to add the span. We'll need to convert the span
-        // to a string for it, but for .NET 5.0 we'll use the override.
+        // to a string for it, but for .NET 5.0 or newer we'll use the override.
 #if NETSTANDARD2_0
         builder.Append(span.ToString());
 #else


### PR DESCRIPTION
I didn't dare to touch `README.jp.md` since I couldn't identify `.NET 5` string there.