### PR TITLE
Custom mask for secret

### DIFF
--- a/docs/input/prompts/text.md
+++ b/docs/input/prompts/text.md
@@ -65,6 +65,23 @@ What's the secret number? _
 Enter password: ************_
 ```
 
+## Masks
+
+<?# Example symbol="M:Prompt.Program.AskPasswordWithCustomMask" project="Prompt" /?>
+
+
+```text
+Enter password: ------------_
+```
+
+You can utilize a null character to completely hide input.
+
+<?# Example symbol="M:Prompt.Program.AskPasswordWithNullMask" project="Prompt" /?>
+
+```text
+Enter password: _
+```
+
 ## Optional
 
 <?# Example symbol="M:Prompt.Program.AskColor" project="Prompt" /?>

--- a/examples/Console/Prompt/Program.cs
+++ b/examples/Console/Prompt/Program.cs
@@ -160,8 +160,7 @@ namespace Prompt
             return AnsiConsole.Prompt(
                 new TextPrompt<string>("Enter [green]password[/]?")
                     .PromptStyle("red")
-                    .Secret()
-                    .Mask('-'));
+                    .Secret('-'));
         }
 
         public static string AskPasswordWithNullMask()
@@ -169,8 +168,7 @@ namespace Prompt
             return AnsiConsole.Prompt(
                 new TextPrompt<string>("Enter [green]password[/]?")
                     .PromptStyle("red")
-                    .Secret()
-                    .Mask(null));
+                    .Secret(null));
         }
 
         public static string AskColor()

--- a/examples/Console/Prompt/Program.cs
+++ b/examples/Console/Prompt/Program.cs
@@ -35,6 +35,12 @@ namespace Prompt
             WriteDivider("Secrets");
             var password = AskPassword();
 
+            WriteDivider("Mask");
+            var mask = AskPasswordWithCustomMask();
+
+            WriteDivider("Null Mask");
+            var nullMask = AskPasswordWithNullMask();
+
             WriteDivider("Optional");
             var color = AskColor();
 
@@ -49,6 +55,8 @@ namespace Prompt
                 .AddRow("[grey]Favorite sport[/]", sport)
                 .AddRow("[grey]Age[/]", age.ToString())
                 .AddRow("[grey]Password[/]", password)
+                .AddRow("[grey]Mask[/]", mask)
+                .AddRow("[grey]Null Mask[/]", nullMask)
                 .AddRow("[grey]Favorite color[/]", string.IsNullOrEmpty(color) ? "Unknown" : color));
         }
 
@@ -145,6 +153,24 @@ namespace Prompt
                 new TextPrompt<string>("Enter [green]password[/]?")
                     .PromptStyle("red")
                     .Secret());
+        }
+
+        public static string AskPasswordWithCustomMask()
+        {
+            return AnsiConsole.Prompt(
+                new TextPrompt<string>("Enter [green]password[/]?")
+                    .PromptStyle("red")
+                    .Secret()
+                    .Mask('-'));
+        }
+
+        public static string AskPasswordWithNullMask()
+        {
+            return AnsiConsole.Prompt(
+                new TextPrompt<string>("Enter [green]password[/]?")
+                    .PromptStyle("red")
+                    .Secret()
+                    .Mask(null));
         }
 
         public static string AskColor()

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
@@ -5,7 +5,7 @@ namespace Spectre.Console;
 /// </summary>
 public static partial class AnsiConsoleExtensions
 {
-    internal static async Task<string> ReadLine(this IAnsiConsole console, Style? style, bool secret, IEnumerable<string>? items = null, CancellationToken cancellationToken = default)
+    internal static async Task<string> ReadLine(this IAnsiConsole console, Style? style, bool secret, char? mask, IEnumerable<string>? items = null, CancellationToken cancellationToken = default)
     {
         if (console is null)
         {
@@ -58,7 +58,8 @@ public static partial class AnsiConsoleExtensions
             if (!char.IsControl(key.KeyChar))
             {
                 text += key.KeyChar.ToString();
-                console.Write(secret ? "*" : key.KeyChar.ToString(), style);
+                var output = key.KeyChar.ToString();
+                console.Write(secret ? output.Mask(mask) : output, style);
             }
         }
     }

--- a/src/Spectre.Console/Extensions/StringExtensions.cs
+++ b/src/Spectre.Console/Extensions/StringExtensions.cs
@@ -197,6 +197,11 @@ public static class StringExtensions
     {
         var output = string.Empty;
 
+        if (mask is null)
+        {
+            return output;
+        }
+
         foreach (var c in value)
         {
             output += mask;

--- a/src/Spectre.Console/Extensions/StringExtensions.cs
+++ b/src/Spectre.Console/Extensions/StringExtensions.cs
@@ -186,4 +186,22 @@ public static class StringExtensions
         return text.Contains(value, StringComparison.Ordinal);
 #endif
     }
+
+    /// <summary>
+    /// "Masks" every character in a string.
+    /// </summary>
+    /// <param name="value">String value to mask.</param>
+    /// <param name="mask">Character to use for masking.</param>
+    /// <returns>Masked string.</returns>
+    public static string Mask(this string value, char? mask)
+    {
+        var output = string.Empty;
+
+        foreach (var c in value)
+        {
+            output += mask;
+        }
+
+        return output;
+    }
 }

--- a/src/Spectre.Console/Prompts/TextPrompt.cs
+++ b/src/Spectre.Console/Prompts/TextPrompt.cs
@@ -125,14 +125,15 @@ public sealed class TextPrompt<T> : IPrompt<T>
 
             while (true)
             {
-                var input = await console.ReadLine(promptStyle, IsSecret, choices, cancellationToken).ConfigureAwait(false);
+                var input = await console.ReadLine(promptStyle, IsSecret, Mask, choices, cancellationToken).ConfigureAwait(false);
 
                 // Nothing entered?
                 if (string.IsNullOrWhiteSpace(input))
                 {
                     if (DefaultValue != null)
                     {
-                        console.Write(IsSecret ? "******" : converter(DefaultValue.Value), promptStyle);
+                        var defaultValue = converter(DefaultValue.Value);
+                        console.Write(IsSecret ? defaultValue.Mask(Mask) : defaultValue, promptStyle);
                         console.WriteLine();
                         return DefaultValue.Value;
                     }
@@ -208,12 +209,13 @@ public sealed class TextPrompt<T> : IPrompt<T>
             appendSuffix = true;
             var converter = Converter ?? TypeConverterHelper.ConvertToString;
             var defaultValueStyle = DefaultValueStyle?.ToMarkup() ?? "green";
+            var defaultValue = converter(DefaultValue.Value);
 
             builder.AppendFormat(
                 CultureInfo.InvariantCulture,
                 " [{0}]({1})[/]",
                 defaultValueStyle,
-                IsSecret ? "******" : converter(DefaultValue.Value));
+                IsSecret ? defaultValue.Mask(Mask) : defaultValue);
         }
 
         var markup = builder.ToString().Trim();

--- a/src/Spectre.Console/Prompts/TextPrompt.cs
+++ b/src/Spectre.Console/Prompts/TextPrompt.cs
@@ -31,6 +31,12 @@ public sealed class TextPrompt<T> : IPrompt<T>
     public bool IsSecret { get; set; }
 
     /// <summary>
+    /// Gets or sets the character to use while masking
+    /// a secret prompt.
+    /// </summary>
+    public char? Mask { get; set; } = '*';
+
+    /// <summary>
     /// Gets or sets the validation error message.
     /// </summary>
     public string ValidationErrorMessage { get; set; } = "[red]Invalid input[/]";

--- a/src/Spectre.Console/Prompts/TextPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/TextPromptExtensions.cs
@@ -289,6 +289,24 @@ public static class TextPromptExtensions
     }
 
     /// <summary>
+    /// Sets the character used when masking secret input.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="mask">The character to use.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static TextPrompt<T> Mask<T>(this TextPrompt<T> obj, char? mask)
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        obj.Mask = mask;
+        return obj;
+    }
+
+    /// <summary>
     /// Sets the function to create a display string for a given choice.
     /// </summary>
     /// <typeparam name="T">The prompt type.</typeparam>

--- a/src/Spectre.Console/Prompts/TextPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/TextPromptExtensions.cs
@@ -289,19 +289,20 @@ public static class TextPromptExtensions
     }
 
     /// <summary>
-    /// Sets the character used when masking secret input.
+    /// Replaces prompt user input with mask in the console.
     /// </summary>
-    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <typeparam name="T">The prompt type.</typeparam>
     /// <param name="obj">The prompt.</param>
-    /// <param name="mask">The character to use.</param>
+    /// <param name="mask">The masking character to use for the secret.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static TextPrompt<T> Mask<T>(this TextPrompt<T> obj, char? mask)
+    public static TextPrompt<T> Secret<T>(this TextPrompt<T> obj, char? mask)
     {
         if (obj is null)
         {
             throw new ArgumentNullException(nameof(obj));
         }
 
+        obj.IsSecret = true;
         obj.Mask = mask;
         return obj;
     }

--- a/test/Spectre.Console.Tests/Expectations/Prompts/Text/SecretDefaultValueCustomMask.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Prompts/Text/SecretDefaultValueCustomMask.Output.verified.txt
@@ -1,0 +1,1 @@
+Favorite fruit? (------): ------

--- a/test/Spectre.Console.Tests/Expectations/Prompts/Text/SecretDefaultValueNullMask.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Prompts/Text/SecretDefaultValueNullMask.Output.verified.txt
@@ -1,0 +1,1 @@
+Favorite fruit? (): 

--- a/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -227,7 +227,7 @@ public sealed class TextPromptTests
 
     [Fact]
     [Expectation("SecretDefaultValueCustomMask")]
-    public Task Should_Choose_Custom_Masked_Default_Value_If_Nothing_Is_Entered_And_Prompt_Is_Secret()
+    public Task Should_Choose_Custom_Masked_Default_Value_If_Nothing_Is_Entered_And_Prompt_Is_Secret_And_Mask_Is_Custom()
     {
         // Given
         var console = new TestConsole();
@@ -239,6 +239,25 @@ public sealed class TextPromptTests
                 .Secret()
                 .DefaultValue("Banana")
                 .Mask('-'));
+
+        // Then
+        return Verifier.Verify(console.Output);
+    }
+
+    [Fact]
+    [Expectation("SecretDefaultValueNullMask")]
+    public Task Should_Choose_Empty_Masked_Default_Value_If_Nothing_Is_Entered_And_Prompt_Is_Secret_And_Mask_Is_Null()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        console.Prompt(
+            new TextPrompt<string>("Favorite fruit?")
+                .Secret()
+                .DefaultValue("Banana")
+                .Mask(null));
 
         // Then
         return Verifier.Verify(console.Output);

--- a/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -209,7 +209,7 @@ public sealed class TextPromptTests
 
     [Fact]
     [Expectation("SecretDefaultValue")]
-    public Task Should_Chose_Masked_Default_Value_If_Nothing_Is_Entered_And_Prompt_Is_Secret()
+    public Task Should_Choose_Masked_Default_Value_If_Nothing_Is_Entered_And_Prompt_Is_Secret()
     {
         // Given
         var console = new TestConsole();
@@ -220,6 +220,25 @@ public sealed class TextPromptTests
             new TextPrompt<string>("Favorite fruit?")
                 .Secret()
                 .DefaultValue("Banana"));
+
+        // Then
+        return Verifier.Verify(console.Output);
+    }
+
+    [Fact]
+    [Expectation("SecretDefaultValueCustomMask")]
+    public Task Should_Choose_Custom_Masked_Default_Value_If_Nothing_Is_Entered_And_Prompt_Is_Secret()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        console.Prompt(
+            new TextPrompt<string>("Favorite fruit?")
+                .Secret()
+                .DefaultValue("Banana")
+                .Mask('-'));
 
         // Then
         return Verifier.Verify(console.Output);

--- a/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -236,9 +236,8 @@ public sealed class TextPromptTests
         // When
         console.Prompt(
             new TextPrompt<string>("Favorite fruit?")
-                .Secret()
-                .DefaultValue("Banana")
-                .Mask('-'));
+                .Secret('-')
+                .DefaultValue("Banana"));
 
         // Then
         return Verifier.Verify(console.Output);
@@ -255,9 +254,8 @@ public sealed class TextPromptTests
         // When
         console.Prompt(
             new TextPrompt<string>("Favorite fruit?")
-                .Secret()
-                .DefaultValue("Banana")
-                .Mask(null));
+                .Secret(null)
+                .DefaultValue("Banana"));
 
         // Then
         return Verifier.Verify(console.Output);


### PR DESCRIPTION
Implemented functionality for https://github.com/spectreconsole/spectre.console/issues/943.

- Added char? to text prompt to hold character used for masking secrets.
- Added string extension to replace each char in string with mask.
- Replaced all hardcoded asterisks for secrets with new mask.