### PR TITLE
Update percentage to handle division by zero

### DIFF
--- a/src/Spectre.Console/Live/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Live/Progress/ProgressTask.cs
@@ -224,6 +224,11 @@ public sealed class ProgressTask : IProgress<double>
 
     private double GetPercentage()
     {
+        if (MaxValue == 0)
+        {
+            return 0;
+        }
+
         var percentage = (Value / MaxValue) * 100;
         percentage = Math.Min(100, Math.Max(0, percentage));
         return percentage;

--- a/test/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
@@ -23,7 +23,6 @@ public sealed class ProgressTests
         progress.Start(ctx =>
         {
             task = ctx.AddTask("foo");
-            task.Increment(100);
             task.MaxValue = 0;
         });
 

--- a/test/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
@@ -5,7 +5,7 @@ namespace Spectre.Console.Tests.Unit;
 public sealed class ProgressTests
 {
     [Fact]
-    public void Setting_MaxValue_To_Zero_Should_Make_Percentage_Zero()
+    public void Setting_Max_Value_To_Zero_Should_Make_Percentage_Zero()
     {
         // Given
         var console = new TestConsole()

--- a/test/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
@@ -5,6 +5,34 @@ namespace Spectre.Console.Tests.Unit;
 public sealed class ProgressTests
 {
     [Fact]
+    public void Setting_MaxValue_To_Zero_Should_Make_Percentage_Zero()
+    {
+        // Given
+        var console = new TestConsole()
+            .Width(10)
+            .Interactive()
+            .EmitAnsiSequences();
+
+        var task = default(ProgressTask);
+        var progress = new Progress(console)
+            .Columns(new[] { new ProgressBarColumn() })
+            .AutoRefresh(false)
+            .AutoClear(true);
+
+        // When
+        progress.Start(ctx =>
+        {
+            task = ctx.AddTask("foo");
+            task.Increment(100);
+            task.MaxValue = 0;
+        });
+
+        // Then
+        task.Value.ShouldBe(0);
+        task.Percentage.ShouldBe(0);
+    }
+
+    [Fact]
     public void Should_Render_Task_Correctly()
     {
         // Given


### PR DESCRIPTION
This pull request is to fix the bug described in [this issue](https://github.com/spectreconsole/spectre.console/issues/981).

A check ensures that any calculation of percentage using a maximum value of 0 is evaluated as 0.

---
Please upvote :+1: this pull request if you are interested in it.