### PR TITLE
Add new and transferred issues to backlog project

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: ["bug", "needs triage"]
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: enhancement
+labels: ["feature", "needs triage"]
 assignees: ''
 
 ---

--- a/.github/workflows/backlog.yaml
+++ b/.github/workflows/backlog.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Add issues/PRs to backlog automatically
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+
+jobs:
+  add-to-project:
+    name: Add issue to backlog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/spectreconsole/projects/1
+          github-token: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: Continuous Integration
+name: Pull Request
 on: pull_request
 
 env:


### PR DESCRIPTION
When a new issue is created, or an issue is transferred
from another project, we add the issue to the Spectre.Console project
(https://github.com/orgs/spectreconsole/projects/1).