### PR TITLE
Allow letter keys (A-Z) to cycle indexes in Prompts

### DIFF
--- a/src/Spectre.Console/Prompts/List/ListPromptState.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptState.cs
@@ -21,15 +21,49 @@ internal sealed class ListPromptState<T>
 
     public bool Update(ConsoleKey key)
     {
-        var index = key switch
+        var index = Index;
+
+        // if user presses a letter key
+        if (key >= ConsoleKey.A && key <= ConsoleKey.Z)
         {
-            ConsoleKey.UpArrow => Index - 1,
-            ConsoleKey.DownArrow => Index + 1,
+            var keyStruck = new string((char)key, 1);
+
+            // find indexes of items that start with the letter
+            int[] indexes = Items.Select((item, idx) => (item, idx))
+                               .Where(k => k.item.Data.ToString()?.StartsWith(keyStruck, StringComparison.InvariantCultureIgnoreCase) ?? false)
+                               .Select(k => k.idx)
+                               .ToArray();
+
+            // if there are items begining with this letter
+            if (indexes.Length > 0)
+            {
+                // is one of them currently selected?
+                var currentlySelected = Array.IndexOf(indexes, index);
+
+                if (currentlySelected == -1)
+                {
+                    // we are not currently selecting any item begining with the struck key
+                    // so jump to first item in list that begins with the letter
+                    index = indexes[0];
+                }
+                else
+                {
+                    // cycle to next (circular)
+                    index = indexes[(currentlySelected + 1) % indexes.Length];
+
+                }
+            }
+        }
+
+        index = key switch
+        {
+            ConsoleKey.UpArrow => index - 1,
+            ConsoleKey.DownArrow => index + 1,
             ConsoleKey.Home => 0,
             ConsoleKey.End => ItemCount - 1,
-            ConsoleKey.PageUp => Index - PageSize,
-            ConsoleKey.PageDown => Index + PageSize,
-            _ => Index,
+            ConsoleKey.PageUp => index - PageSize,
+            ConsoleKey.PageDown => index + PageSize,
+            _ => index,
         };
 
         index = WrapAround

--- a/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
@@ -34,6 +34,42 @@ public sealed class ListPromptStateTests
         state.Index.ShouldBe(index + 1);
     }
 
+    [Fact]
+    public void LetterJumpToSelection()
+    {
+        // Given
+        var state = new ListPromptState<string>(
+            new[]
+            {
+                new ListPromptItem<string>("apple"),
+                new ListPromptItem<string>("bannana"),
+                new ListPromptItem<string>("fish"),
+                new ListPromptItem<string>("flamingo"),
+            }
+            .ToList(), 3, true);
+
+        // First item should be selected
+        state.Index.ShouldBe(0);
+
+        // When user presses F
+        state.Update(ConsoleKey.F);
+
+        // Then should jump to fish
+        state.Index.ShouldBe(2);
+                
+        // When user presses F again
+        state.Update(ConsoleKey.F);
+
+        // Then should jump to flamingo
+        state.Index.ShouldBe(3);
+
+        // When user presses F third time
+        state.Update(ConsoleKey.F);
+
+        // Then should cycle back to fish
+        state.Index.ShouldBe(2);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]


### PR DESCRIPTION
Adds the ability to press letter keys (A-Z) to cycle selection to next item beginning with that letter in Prompt.

I have made changes only to `ListPromptState.cs` as this is where Up and Down are being handled.  Let me know if there is a better place for it or if this isn't a feature you want to incorporate.

![loopWithLetters](https://user-images.githubusercontent.com/31306100/194012822-50154b2d-9a65-46fb-accd-5b1554398186.gif)
_Check up/down works then pressing 'M' repeatedly then 'L' then End followed by clycling 'O'_