### PR TITLE
Added Suckless Simple Terminal (st) to list of ansi terminals

### DIFF
--- a/src/Spectre.Console/Internal/Backends/Ansi/AnsiDetector.cs
+++ b/src/Spectre.Console/Internal/Backends/Ansi/AnsiDetector.cs
@@ -24,6 +24,7 @@ internal static class AnsiDetector
         new Regex("linux"), // Linux console
         new Regex("konsole"), // Konsole
         new Regex("bvterm"), // Bitvise SSH Client
+        new Regex("^st-256color"), // Suckless Simple Terminal, st
     };
 
     public static (bool SupportsAnsi, bool LegacyConsole) Detect(bool stdError, bool upgrade)


### PR DESCRIPTION
The suckless simple terminal (st) wasn't recognized as na compatible ansi terminal. I've added it to the _regexes array in AnsiDetector.cs