### PR TITLE
Pin SDK due to bug in .NET 6.0.401

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,5 @@
 {
-  "projects": [ "src", "tests" ],
   "sdk": {
-    "version": "6.0.300",
-    "rollForward": "latestFeature"
+    "version": "6.0.400"
   }
 }


### PR DESCRIPTION
Restoring tools seems to fail due to an AbandonedMutexException.
Pinning the SDK to a previous version should work.

Resolves #1009