### PR TITLE
Allow `PACKET` key on MultiSelectionPrompt

### DIFF
--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -160,7 +160,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
             return ListPromptInputResult.Submit;
         }
 
-        if (key.Key == ConsoleKey.Spacebar)
+        if (key.Key == ConsoleKey.Spacebar || key.Key == ConsoleKey.Packet)
         {
             var current = state.Items[state.Index];
             var select = !current.IsSelected;

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -93,7 +93,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     /// <inheritdoc/>
     ListPromptInputResult IListPromptStrategy<T>.HandleInput(ConsoleKeyInfo key, ListPromptState<T> state)
     {
-        if (key.Key == ConsoleKey.Enter || key.Key == ConsoleKey.Spacebar)
+        if (key.Key == ConsoleKey.Enter || key.Key == ConsoleKey.Spacebar || key.Key == ConsoleKey.Packet)
         {
             // Selecting a non leaf in "leaf mode" is not allowed
             if (state.Current.IsGroup && Mode == SelectionMode.Leaf)


### PR DESCRIPTION
When use mobile RD Client, can not toggle items through `<SPACE>`, it actually `<PACKET>` key. (I tested iOS, not sure 
 about other platforms)

Here is my test:

![SCTest](https://user-images.githubusercontent.com/20772925/195251336-c2170dc0-f1e4-4eec-a2ab-47f8c61e4576.gif)

To toggle items, must use Screen Keyboard...
