### PR TITLE
Add culture option to TypeConverterHelper, TextPrompt and AnsiConsole

### DIFF
--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Prompt.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Prompt.cs
@@ -35,6 +35,21 @@ public static partial class AnsiConsoleExtensions
     }
 
     /// <summary>
+    /// Displays a prompt to the user.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="console">The console.</param>
+    /// <param name="prompt">The prompt markup text.</param>
+    /// <param name="culture">Specific CultureInfo to use when converting input.</param>
+    /// <returns>The prompt input result.</returns>
+    public static T Ask<T>(this IAnsiConsole console, string prompt, CultureInfo? culture)
+    {
+        var textPrompt = new TextPrompt<T>(prompt);
+        textPrompt.Culture = culture;
+        return textPrompt.Show(console);
+    }
+
+    /// <summary>
     /// Displays a prompt with two choices, yes or no.
     /// </summary>
     /// <param name="console">The console.</param>

--- a/src/Spectre.Console/Internal/TypeConverterHelper.cs
+++ b/src/Spectre.Console/Internal/TypeConverterHelper.cs
@@ -21,6 +21,28 @@ internal static class TypeConverterHelper
         }
     }
 
+    public static bool TryConvertFromStringWithCulture<T>(string input, CultureInfo? info, [MaybeNull] out T result)
+    {
+        try
+        {
+            if (info == null)
+            {
+                return TryConvertFromString<T>(input, out result);
+            }
+            else
+            {
+                result = (T)GetTypeConverter<T>().ConvertFromString(null!, info, input);
+            }
+
+            return true;
+        }
+        catch
+        {
+            result = default;
+            return false;
+        }
+    }
+
     public static TypeConverter GetTypeConverter<T>()
     {
         var converter = TypeDescriptor.GetConverter(typeof(T));

--- a/src/Spectre.Console/Prompts/TextPrompt.cs
+++ b/src/Spectre.Console/Prompts/TextPrompt.cs
@@ -4,7 +4,7 @@ namespace Spectre.Console;
 /// Represents a prompt.
 /// </summary>
 /// <typeparam name="T">The prompt result type.</typeparam>
-public sealed class TextPrompt<T> : IPrompt<T>
+public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
 {
     private readonly string _prompt;
     private readonly StringComparer? _comparer;
@@ -89,7 +89,6 @@ public sealed class TextPrompt<T> : IPrompt<T>
     /// </summary>
     internal DefaultPromptValue<T>? DefaultValue { get; set; }
 
-
     /// <summary>
     /// Initializes a new instance of the <see cref="TextPrompt{T}"/> class.
     /// </summary>
@@ -166,8 +165,7 @@ public sealed class TextPrompt<T> : IPrompt<T>
                         continue;
                     }
                 }
-                else if (!TypeConverterHelper.TryConvertFromStringWithCulture<T>(input, Culture, out result) || result == 
-                null)
+                else if (!TypeConverterHelper.TryConvertFromStringWithCulture<T>(input, Culture, out result) || result == null)
                 {
                     console.MarkupLine(ValidationErrorMessage);
                     WritePrompt(console);

--- a/src/Spectre.Console/Prompts/TextPrompt.cs
+++ b/src/Spectre.Console/Prompts/TextPrompt.cs
@@ -20,6 +20,11 @@ public sealed class TextPrompt<T> : IPrompt<T>
     public List<T> Choices { get; } = new List<T>();
 
     /// <summary>
+    /// Gets or sets the culture to use when converting input to object.
+    /// </summary>
+    public CultureInfo? Culture { get; set; }
+
+    /// <summary>
     /// Gets or sets the message for invalid choices.
     /// </summary>
     public string InvalidChoiceMessage { get; set; } = "[red]Please select one of the available options[/]";
@@ -83,6 +88,7 @@ public sealed class TextPrompt<T> : IPrompt<T>
     /// Gets or sets the default value.
     /// </summary>
     internal DefaultPromptValue<T>? DefaultValue { get; set; }
+
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TextPrompt{T}"/> class.
@@ -160,7 +166,8 @@ public sealed class TextPrompt<T> : IPrompt<T>
                         continue;
                     }
                 }
-                else if (!TypeConverterHelper.TryConvertFromString<T>(input, out result) || result == null)
+                else if (!TypeConverterHelper.TryConvertFromStringWithCulture<T>(input, Culture, out result) || result == 
+                null)
                 {
                     console.MarkupLine(ValidationErrorMessage);
                     WritePrompt(console);

--- a/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Prompt.cs
+++ b/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Prompt.cs
@@ -26,27 +26,29 @@ public partial class AnsiConsoleTests
         [Fact]
         public void Should_Return_Correct_DateTime_When_Asked_PL_Culture()
         {
-            var console = new TestConsole()
-                .Colors(ColorSystem.Standard)
-                .EmitAnsiSequences();
+            // Given
+            var console = new TestConsole().EmitAnsiSequences();
             console.Input.PushTextWithEnter("1/2/1998");
 
+            // When
             var dateTime = console.Ask<DateTime>(string.Empty, CultureInfo.GetCultureInfo("pl-PL"));
 
-            Assert.Equal(dateTime, new DateTime(1998, 2, 1));
+            // Then
+            dateTime.ShouldBe(new DateTime(1998, 2, 1));
         }
 
         [Fact]
         public void Should_Return_Correct_DateTime_When_Asked_US_Culture()
         {
-            var console = new TestConsole()
-                .Colors(ColorSystem.Standard)
-                .EmitAnsiSequences();
+            // Given
+            var console = new TestConsole().EmitAnsiSequences();
             console.Input.PushTextWithEnter("2/1/1998");
 
+            // When
             var dateTime = console.Ask<DateTime>(string.Empty, CultureInfo.GetCultureInfo("en-US"));
 
-            Assert.Equal(dateTime, new DateTime(1998, 2, 1));
+            // Then
+            dateTime.ShouldBe(new DateTime(1998, 2, 1));
         }
     }
 }

--- a/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Prompt.cs
+++ b/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Prompt.cs
@@ -20,4 +20,33 @@ public partial class AnsiConsoleTests
             result.ShouldBe(expected);
         }
     }
+
+    public sealed class Ask
+    {
+        [Fact]
+        public void Should_Return_Correct_DateTime_When_Asked_PL_Culture()
+        {
+            var console = new TestConsole()
+                .Colors(ColorSystem.Standard)
+                .EmitAnsiSequences();
+            console.Input.PushTextWithEnter("1/2/1998");
+
+            var dateTime = console.Ask<DateTime>(string.Empty, CultureInfo.GetCultureInfo("pl-PL"));
+
+            Assert.Equal(dateTime, new DateTime(1998, 2, 1));
+        }
+
+        [Fact]
+        public void Should_Return_Correct_DateTime_When_Asked_US_Culture()
+        {
+            var console = new TestConsole()
+                .Colors(ColorSystem.Standard)
+                .EmitAnsiSequences();
+            console.Input.PushTextWithEnter("2/1/1998");
+
+            var dateTime = console.Ask<DateTime>(string.Empty, CultureInfo.GetCultureInfo("en-US"));
+
+            Assert.Equal(dateTime, new DateTime(1998, 2, 1));
+        }
+    }
 }


### PR DESCRIPTION
Useful feature if you want to enforce culture specific formatting (ex. DateTime)
Solves #988