### PR TITLE
Enhanced unit tests covering CommandContext.Remaining.Parsed/Raw behaviour

### DIFF
--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
@@ -53,18 +53,21 @@ public sealed partial class CommandAppTests
             var result = app.Run(new[]
             {
                 "animal", "4", "dog", "12", "--",
-                "--foo", "bar", "-bar", "\"baz\"", "qux",
+                "--foo", "bar", "--foo", "baz",
+                "-bar", "\"baz\"", "qux",
                 "foo bar baz qux",
             });
 
             // Then
-            result.Context.Remaining.Raw.Count.ShouldBe(6);
+            result.Context.Remaining.Raw.Count.ShouldBe(8);
             result.Context.Remaining.Raw[0].ShouldBe("--foo");
             result.Context.Remaining.Raw[1].ShouldBe("bar");
-            result.Context.Remaining.Raw[2].ShouldBe("-bar");
+            result.Context.Remaining.Raw[2].ShouldBe("--foo");
             result.Context.Remaining.Raw[3].ShouldBe("baz");
-            result.Context.Remaining.Raw[4].ShouldBe("qux");
-            result.Context.Remaining.Raw[5].ShouldBe("foo bar baz qux");
+            result.Context.Remaining.Raw[4].ShouldBe("-bar");
+            result.Context.Remaining.Raw[5].ShouldBe("baz");
+            result.Context.Remaining.Raw[6].ShouldBe("qux");
+            result.Context.Remaining.Raw[7].ShouldBe("foo bar baz qux");
         }
     }
 }

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
@@ -23,16 +23,16 @@ public sealed partial class CommandAppTests
             {
                 "animal", "4", "dog", "12", "--",
                 "--foo", "bar", "--foo", "baz",
-                "-bar", "\"baz\"", "qux",
+                "-xyz", "\"baz\"", "qux",
                 "foo bar baz qux",
             });
 
             // Then
             result.Context.Remaining.Parsed.Count.ShouldBe(4);
             result.Context.ShouldHaveRemainingArgument("foo", values: new[] { "bar", "baz" });
-            result.Context.ShouldHaveRemainingArgument("b", values: new[] { (string)null });
-            result.Context.ShouldHaveRemainingArgument("a", values: new[] { (string)null });
-            result.Context.ShouldHaveRemainingArgument("r", values: new[] { (string)null });
+            result.Context.ShouldHaveRemainingArgument("x", values: new[] { (string)null });
+            result.Context.ShouldHaveRemainingArgument("y", values: new[] { (string)null });
+            result.Context.ShouldHaveRemainingArgument("z", values: new[] { (string)null });
         }
 
         [Fact]
@@ -54,7 +54,7 @@ public sealed partial class CommandAppTests
             {
                 "animal", "4", "dog", "12", "--",
                 "--foo", "bar", "--foo", "baz",
-                "-bar", "\"baz\"", "qux",
+                "-xyz", "\"baz\"", "qux",
                 "foo bar baz qux",
             });
 
@@ -64,7 +64,7 @@ public sealed partial class CommandAppTests
             result.Context.Remaining.Raw[1].ShouldBe("bar");
             result.Context.Remaining.Raw[2].ShouldBe("--foo");
             result.Context.Remaining.Raw[3].ShouldBe("baz");
-            result.Context.Remaining.Raw[4].ShouldBe("-bar");
+            result.Context.Remaining.Raw[4].ShouldBe("-xyz");
             result.Context.Remaining.Raw[5].ShouldBe("baz");
             result.Context.Remaining.Raw[6].ShouldBe("qux");
             result.Context.Remaining.Raw[7].ShouldBe("foo bar baz qux");

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
@@ -25,6 +25,7 @@ public sealed partial class CommandAppTests
                 "--foo", "bar", "--foo", "baz",
                 "-xyz", "\"baz\"", "qux",
                 "foo bar baz qux",
+                "cmd", "/c", "set && pause",
             });
 
             // Then
@@ -56,10 +57,11 @@ public sealed partial class CommandAppTests
                 "--foo", "bar", "--foo", "baz",
                 "-xyz", "\"baz\"", "qux",
                 "foo bar baz qux",
+                "cmd", "/c", "set && pause",
             });
 
             // Then
-            result.Context.Remaining.Raw.Count.ShouldBe(8);
+            result.Context.Remaining.Raw.Count.ShouldBe(11);
             result.Context.Remaining.Raw[0].ShouldBe("--foo");
             result.Context.Remaining.Raw[1].ShouldBe("bar");
             result.Context.Remaining.Raw[2].ShouldBe("--foo");
@@ -68,6 +70,9 @@ public sealed partial class CommandAppTests
             result.Context.Remaining.Raw[5].ShouldBe("baz");
             result.Context.Remaining.Raw[6].ShouldBe("qux");
             result.Context.Remaining.Raw[7].ShouldBe("foo bar baz qux");
+            result.Context.Remaining.Raw[8].ShouldBe("cmd");
+            result.Context.Remaining.Raw[9].ShouldBe("/c");
+            result.Context.Remaining.Raw[10].ShouldBe("set && pause");
         }
     }
 }


### PR DESCRIPTION
Whilst spectre.console issue https://github.com/spectreconsole/spectre.console/issues/190 seems no longer reproducible, the existing unit tests covering the Parsed/Raw collections would not currently pick up a regression if (somehow) issue 190 became active again. This PR tidies up the applicable unit tests to become more self-readable, and then includes the command line args provided in Issue 190 along with asserting the expected behaviour.