### PR TITLE
modified tokenizer to not break on on ]]] at the end of a style

### DIFF
--- a/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Markup.cs
+++ b/test/Spectre.Console.Tests/Unit/AnsiConsoleTests.Markup.cs
@@ -154,5 +154,25 @@ public partial class AnsiConsoleTests
             // Then
             console.Output.ShouldBe("[grey][white]");
         }
+
+        [Theory]
+        [InlineData("[white][[[/][white]]][/]", "[]")]
+        [InlineData("[white][[[/]", "[")]
+        [InlineData("[white]]][/]", "]")]
+        [InlineData("[black on white link=https://www.gooole.com/q=]]]Search for a bracket[/]", "Search for a bracket")]
+        [InlineData("[link=https://www.gooole.com/q=]] black on white]Search for a bracket[/]", "Search for a bracket")]
+        [InlineData("[link]https://www.gooole.com/q=]][/]", "https://www.gooole.com/q=]")]
+        public void Should_Not_Fail_As_In_GH1024(string markup, string expected)
+        {
+            // Given
+            var console = new TestConsole();
+            console.EmitAnsiSequences = false;
+
+            // When
+            console.Markup(markup);
+
+            // Then
+            console.Output.ShouldBe(expected);
+        }
     }
 }


### PR DESCRIPTION
@patriksvensson, @phil-scott-78 can't say I like this change, but it gets the job done for the moment.

There are two things I don't like in particular:
- This is the first time the tokenizer gains knowledge about styles and how they work. Not sure if that's a good thing.
- Running `StringBuilder.ToString()` in a loop feels weird. Not sure if it would easier/better/more performant to drop the `StringBuilder` here and simply concatenate the chars together.

I'd appreciate any input.