### PR TITLE
Make word wrapping consider initial paragraph spacing as a margin

### DIFF
--- a/src/Spectre.Console/Rendering/SegmentLineIterator.cs
+++ b/src/Spectre.Console/Rendering/SegmentLineIterator.cs
@@ -15,6 +15,11 @@ public sealed class SegmentLineIterator : IEnumerator<Segment>
     /// </summary>
     public Segment Current { get; private set; }
 
+    /// <summary>
+    /// Gets the current line.
+    /// </summary>
+    public SegmentLine? CurrentLine { get; private set; }
+
     /// <inheritdoc/>
     object? IEnumerator.Current => Current;
 
@@ -34,6 +39,7 @@ public sealed class SegmentLineIterator : IEnumerator<Segment>
         _lines = new List<SegmentLine>(lines);
 
         Current = Segment.Empty;
+        CurrentLine = null;
     }
 
     /// <inheritdoc/>
@@ -100,6 +106,7 @@ public sealed class SegmentLineIterator : IEnumerator<Segment>
         // Reset the flag
         _lineBreakEmitted = false;
 
+        CurrentLine = _lines[_currentLine];
         Current = _lines[_currentLine][_currentIndex];
         return true;
     }

--- a/src/Spectre.Console/Widgets/Paragraph.cs
+++ b/src/Spectre.Console/Widgets/Paragraph.cs
@@ -197,6 +197,8 @@ public sealed class Paragraph : Renderable, IAlignable, IOverflowable
 
         var lines = new List<SegmentLine>();
         var line = new SegmentLine();
+        var lineSeed = (Segment?)null;
+        var currentLine = (SegmentLine?)null;
 
         var newLine = true;
 
@@ -213,6 +215,11 @@ public sealed class Paragraph : Renderable, IAlignable, IOverflowable
                 }
 
                 current = iterator.Current;
+                if (currentLine != (currentLine = iterator.CurrentLine))
+                {
+                    var lineFirstSegment = currentLine?.First() ?? Segment.Empty;
+                    lineSeed = lineFirstSegment.IsWhiteSpace ? lineFirstSegment : null;
+                }
             }
             else
             {
@@ -266,7 +273,7 @@ public sealed class Paragraph : Renderable, IAlignable, IOverflowable
                 {
                     line.Add(Segment.Empty);
                     lines.Add(line);
-                    line = new SegmentLine();
+                    line = lineSeed is null ? new SegmentLine() : new SegmentLine(new[] { lineSeed });
                     newLine = true;
                 }
             }


### PR DESCRIPTION
Hey there!

What I'm trying to achieve is to keep paragraph indentation, even when word wrapping is applied.

So, using the following code:

```c#
using Spectre.Console;

var tab = new string(' ', 4);

var oneTab = tab + """
    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ultrices lorem sit amet quam malesuada, quis cursus lacus posuere. Aenean id felis a lorem molestie eleifend. Mauris vehicula convallis sagittis.
    """;

var twoTabs = tab + tab + """
    Donec ut rutrum quam, ut pretium magna. Nunc lacinia in enim sit amet semper. Phasellus sed ante id nibh tincidunt pulvinar id vel erat. Mauris elementum ut orci at blandit. Praesent in dictum magna. Donec tincidunt ornare enim. 
    """;

AnsiConsole.MarkupLine(oneTab);
AnsiConsole.MarkupLine(twoTabs);
AnsiConsole.MarkupLine(oneTab);
```

I'd like to have this (PR): 
![BI6DSS92c3](https://user-images.githubusercontent.com/56183397/197527119-e43f9215-fedc-4801-a4ba-5605c98ea32e.jpg)

But not this (current implementation):
![1Apgjk9lVK](https://user-images.githubusercontent.com/56183397/197527148-d78fb070-d541-4719-bd2e-d7e6f38be596.jpg)

So this is what this PR is about. 
It'll break default behavior, so some Console flags might be added for such feature.