### PR TITLE
Command line argument parsing improvements

### DIFF
--- a/src/Spectre.Console.Cli/CommandParseException.cs
+++ b/src/Spectre.Console.Cli/CommandParseException.cs
@@ -91,11 +91,6 @@ public sealed class CommandParseException : CommandRuntimeException
         return CommandLineParseExceptionFactory.Create(reader.Original, token, "Invalid long option name.", "Invalid character.");
     }
 
-    internal static CommandParseException UnterminatedQuote(string input, CommandTreeToken token)
-    {
-        return CommandLineParseExceptionFactory.Create(input, token, $"Encountered unterminated quoted string '{token.Value}'.", "Did you forget the closing quotation mark?");
-    }
-
     internal static CommandParseException UnknownCommand(CommandModel model, CommandTree? node, IEnumerable<string> args, CommandTreeToken token)
     {
         var suggestion = CommandSuggestor.Suggest(model, node?.Command, token.Value);

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs
@@ -315,12 +315,28 @@ internal class CommandTreeParser
                         {
                             if (!CliConstants.AcceptedBooleanValues.Contains(valueToken.Value, StringComparer.OrdinalIgnoreCase))
                             {
-                                // Flags cannot be assigned a value.
-                                throw CommandParseException.CannotAssignValueToFlag(context.Arguments, token);
+                                if (!valueToken.HadSeparator)
+                                {
+                                    // Do nothing
+                                    // - assume valueToken is unrelated to the flag parameter (ie. we've parsed it unnecessarily)
+                                    // - rely on the "No value?" code below to set the flag to its default value
+                                    // - valueToken will be handled on the next pass of the parser
+                                }
+                                else
+                                {
+                                    // Flags cannot be assigned a value.
+                                    throw CommandParseException.CannotAssignValueToFlag(context.Arguments, token);
+                                }
+                            }
+                            else
+                            {
+                                value = stream.Consume(CommandTreeToken.Kind.String)?.Value;
                             }
                         }
-
-                        value = stream.Consume(CommandTreeToken.Kind.String)?.Value;
+                        else
+                        {
+                            value = stream.Consume(CommandTreeToken.Kind.String)?.Value;
+                        }
                     }
                     else
                     {

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeToken.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeToken.cs
@@ -8,6 +8,11 @@ internal sealed class CommandTreeToken
     public string Representation { get; }
     public bool IsGrouped { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a separater was encountered immediately before the <see cref="CommandTreeToken.Value"/>.
+    /// </summary>
+    public bool HadSeparator { get; set; }
+
     public enum Kind
     {
         String,

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
@@ -235,12 +235,38 @@ internal static class CommandTreeTokenizer
                     ? new CommandTreeToken(CommandTreeToken.Kind.ShortOption, position, value, $"-{value}")
                     : new CommandTreeToken(CommandTreeToken.Kind.ShortOption, position + result.Count, value, value));
             }
+            else if (result.Count == 0 && char.IsDigit(current))
+            {
+                // We require short options to be named with letters. Short options that start with a number
+                // ("-1", "-2ab", "-3..7") may actually mean values (either for options or arguments) and will
+                // be tokenized as strings. This block handles parsing those cases, but we only allow this
+                // when the digit is the first character in the token (i.e. "-a1" is always an error), hence the
+                // result.Count == 0 check above.
+                string value = string.Empty;
+
+                while (!reader.ReachedEnd)
+                {
+                    char c = reader.Peek();
+
+                    if (char.IsWhiteSpace(c))
+                    {
+                        break;
+                    }
+
+                    value += c.ToString(CultureInfo.InvariantCulture);
+                    reader.Read();
+                }
+
+                value = "-" + value; // Prefix with the minus sign that we originally thought to mean a short option
+                result.Add(new CommandTreeToken(CommandTreeToken.Kind.String, position, value, value));
+            }
             else
             {
                 // Create a token representing the short option.
+                var representation = current.ToString(CultureInfo.InvariantCulture);
                 var tokenPosition = position + 1 + result.Count;
-                var represntation = current.ToString(CultureInfo.InvariantCulture);
-                var token = new CommandTreeToken(CommandTreeToken.Kind.ShortOption, tokenPosition, represntation, represntation);
+                var token = new CommandTreeToken(CommandTreeToken.Kind.ShortOption, tokenPosition, representation, representation);
+
                 throw CommandParseException.InvalidShortOptionName(reader.Original, token);
             }
         }

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
@@ -201,7 +201,9 @@ internal static class CommandTreeTokenizer
                     throw CommandParseException.OptionValueWasExpected(reader.Original, token);
                 }
 
-                result.Add(ScanString(context, reader));
+                var tokenValue = ScanString(context, reader);
+                tokenValue.HadSeparator = true;
+                result.Add(tokenValue);
             }
         }
 

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
@@ -30,7 +30,7 @@ internal static class CommandTreeTokenizer
 
         foreach (var arg in args)
         {
-            if (arg == string.Empty)
+            if (string.IsNullOrEmpty(arg))
             {
                 // Null strings in the args array are still represented as tokens
                 tokens.Add(new CommandTreeToken(CommandTreeToken.Kind.String, position, string.Empty, string.Empty));

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
@@ -30,6 +30,13 @@ internal static class CommandTreeTokenizer
 
         foreach (var arg in args)
         {
+            if (arg == string.Empty)
+            {
+                // Null strings in the args array are still represented as tokens
+                tokens.Add(new CommandTreeToken(CommandTreeToken.Kind.String, position, string.Empty, string.Empty));
+                continue;
+            }
+
             var start = position;
             var reader = new TextBuffer(previousReader, arg);
 
@@ -49,36 +56,27 @@ internal static class CommandTreeTokenizer
 
     private static int ParseToken(CommandTreeTokenizerContext context, TextBuffer reader, int position, int start, List<CommandTreeToken> tokens)
     {
-        while (reader.Peek() != -1)
+        if (!reader.ReachedEnd && reader.Peek() == '-')
         {
-            if (reader.ReachedEnd)
+            // Option
+            tokens.AddRange(ScanOptions(context, reader));
+        }
+        else
+        {
+            // Command or argument
+            while (reader.Peek() != -1)
             {
-                position += reader.Position - start;
-                break;
-            }
+                if (reader.ReachedEnd)
+                {
+                    position += reader.Position - start;
+                    break;
+                }
 
-            var character = reader.Peek();
-
-            // Eat whitespace
-            if (char.IsWhiteSpace(character))
-            {
-                reader.Consume();
-                continue;
-            }
-
-            if (character == '-')
-            {
-                // Option
-                tokens.AddRange(ScanOptions(context, reader));
-            }
-            else
-            {
-                // Command or argument
                 tokens.Add(ScanString(context, reader));
-            }
 
-            // Flush remaining tokens
-            context.FlushRemaining();
+                // Flush remaining tokens
+                context.FlushRemaining();
+            }
         }
 
         return position;
@@ -89,15 +87,6 @@ internal static class CommandTreeTokenizer
         TextBuffer reader,
         char[]? stop = null)
     {
-        if (reader.TryPeek(out var character))
-        {
-            // Is this a quoted string?
-            if (character == '\"')
-            {
-                return ScanQuotedString(context, reader);
-            }
-        }
-
         var position = reader.Position;
         var builder = new StringBuilder();
         while (!reader.ReachedEnd)
@@ -114,47 +103,7 @@ internal static class CommandTreeTokenizer
         }
 
         var value = builder.ToString();
-        return new CommandTreeToken(CommandTreeToken.Kind.String, position, value.Trim(), value);
-    }
-
-    private static CommandTreeToken ScanQuotedString(CommandTreeTokenizerContext context, TextBuffer reader)
-    {
-        var position = reader.Position;
-
-        context.FlushRemaining();
-        reader.Consume('\"');
-
-        var builder = new StringBuilder();
-        var terminated = false;
-        while (!reader.ReachedEnd)
-        {
-            var character = reader.Peek();
-            if (character == '\"')
-            {
-                terminated = true;
-                reader.Read();
-                break;
-            }
-
-            builder.Append(reader.Read());
-        }
-
-        if (!terminated)
-        {
-            var unterminatedQuote = builder.ToString();
-            var token = new CommandTreeToken(CommandTreeToken.Kind.String, position, unterminatedQuote, $"\"{unterminatedQuote}");
-            throw CommandParseException.UnterminatedQuote(reader.Original, token);
-        }
-
-        var quotedString = builder.ToString();
-
-        // Add to the context
-        context.AddRemaining(quotedString);
-
-        return new CommandTreeToken(
-            CommandTreeToken.Kind.String,
-            position, quotedString,
-            quotedString);
+        return new CommandTreeToken(CommandTreeToken.Kind.String, position, value, value);
     }
 
     private static IEnumerable<CommandTreeToken> ScanOptions(CommandTreeTokenizerContext context, TextBuffer reader)
@@ -166,7 +115,7 @@ internal static class CommandTreeTokenizer
         reader.Consume('-');
         context.AddRemaining('-');
 
-        if (!reader.TryPeek(out var character))
+        if (!reader.TryPeek(out var character) || character == ' ')
         {
             var token = new CommandTreeToken(CommandTreeToken.Kind.ShortOption, position, "-", "-");
             throw CommandParseException.OptionHasNoName(reader.Original, token);
@@ -299,7 +248,7 @@ internal static class CommandTreeTokenizer
         var name = ScanString(context, reader, new[] { '=', ':' });
 
         // Perform validation of the name.
-        if (name.Value.Length == 0)
+        if (name.Value == " ")
         {
             throw CommandParseException.LongOptionNameIsMissing(reader, position);
         }

--- a/test/Spectre.Console.Cli.Tests/Expectations/Parsing/CannotAssignValueToFlag/Test_1.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Parsing/CannotAssignValueToFlag/Test_1.Output.verified.txt
@@ -1,4 +1,4 @@
 Error: Flags cannot be assigned a value.
 
-       dog --alive foo
+       dog --alive=indeterminate foo
            ^^^^^^^ Can't assign value

--- a/test/Spectre.Console.Cli.Tests/Expectations/Parsing/CannotAssignValueToFlag/Test_2.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Parsing/CannotAssignValueToFlag/Test_2.Output.verified.txt
@@ -1,4 +1,4 @@
 Error: Flags cannot be assigned a value.
 
-       dog -a foo
+       dog -a=indeterminate foo
            ^^ Can't assign value

--- a/test/Spectre.Console.Cli.Tests/Expectations/Parsing/Quoted_Strings.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Parsing/Quoted_Strings.Output.verified.txt
@@ -1,3 +1,0 @@
-# Raw
-/c
-set && pause

--- a/test/Spectre.Console.Cli.Tests/Expectations/Parsing/UnterminatedQuote/Test_1.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Parsing/UnterminatedQuote/Test_1.Output.verified.txt
@@ -1,4 +1,0 @@
-Error: Encountered unterminated quoted string 'Rufus'.
-
-       --name "Rufus
-              ^^^^^^ Did you forget the closing quotation mark?

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Parsing.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Parsing.cs
@@ -15,17 +15,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_When_Command_Is_Unknown()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(config =>
+                var app = new CommandAppTester();
+                app.Configure(config =>
                 {
                     config.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("cat", "14");
+                var result = app.Run("cat", "14");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -33,17 +33,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Unknown_Command_When_Current_Command_Has_No_Arguments()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<EmptyCommand>("empty");
                 });
 
                 // When
-                var result = fixture.Run("empty", "other");
+                var result = app.Run("empty", "other");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -51,8 +51,8 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_With_Suggestion_When_Command_Followed_By_Argument_Is_Unknown_And_Distance_Is_Small()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(config =>
+                var app = new CommandAppTester();
+                app.Configure(config =>
                 {
                     config.AddBranch<CommandSettings>("dog", a =>
                     {
@@ -61,10 +61,10 @@ public sealed partial class CommandAppTests
                 });
 
                 // When
-                var result = fixture.Run("dog", "bat", "14");
+                var result = app.Run("dog", "bat", "14");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -72,17 +72,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_With_Suggestion_When_Root_Command_Followed_By_Argument_Is_Unknown_And_Distance_Is_Small()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(config =>
+                var app = new CommandAppTester();
+                app.Configure(config =>
                 {
                     config.AddCommand<CatCommand>("cat");
                 });
 
                 // When
-                var result = fixture.Run("bat", "14");
+                var result = app.Run("bat", "14");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -90,18 +90,18 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_With_Suggestion_And_No_Arguments_When_Root_Command_Is_Unknown_And_Distance_Is_Small()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.WithDefaultCommand<GenericCommand<EmptyCommandSettings>>();
-                fixture.Configure(config =>
+                var app = new CommandAppTester();
+                app.SetDefaultCommand<GenericCommand<EmptyCommandSettings>>();
+                app.Configure(config =>
                 {
                     config.AddCommand<GenericCommand<EmptyCommandSettings>>("cat");
                 });
 
                 // When
-                var result = fixture.Run("bat");
+                var result = app.Run("bat");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -109,9 +109,9 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_With_Suggestion_And_No_Arguments_When_Command_Is_Unknown_And_Distance_Is_Small()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.WithDefaultCommand<GenericCommand<EmptyCommandSettings>>();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.SetDefaultCommand<GenericCommand<EmptyCommandSettings>>();
+                app.Configure(configurator =>
                 {
                     configurator.AddBranch<CommandSettings>("dog", a =>
                     {
@@ -120,10 +120,10 @@ public sealed partial class CommandAppTests
                 });
 
                 // When
-                var result = fixture.Run("dog", "bat");
+                var result = app.Run("dog", "bat");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -131,18 +131,18 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_With_Suggestion_When_Root_Command_After_Argument_Is_Unknown_And_Distance_Is_Small()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.WithDefaultCommand<GenericCommand<FooCommandSettings>>();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.SetDefaultCommand<GenericCommand<FooCommandSettings>>();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<GenericCommand<BarCommandSettings>>("bar");
                 });
 
                 // When
-                var result = fixture.Run("qux", "bat");
+                var result = app.Run("qux", "bat");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -150,8 +150,8 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_With_Suggestion_When_Command_After_Argument_Is_Unknown_And_Distance_Is_Small()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddBranch<FooCommandSettings>("foo", a =>
                     {
@@ -160,10 +160,10 @@ public sealed partial class CommandAppTests
                 });
 
                 // When
-                var result = fixture.Run("foo", "qux", "bat");
+                var result = app.Run("foo", "qux", "bat");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -176,17 +176,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Long_Option()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", "--alive", "foo");
+                var result = app.Run("dog", "--alive=indeterminate", "foo");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -194,17 +194,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Short_Option()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", "-a", "foo");
+                var result = app.Run("dog", "-a=indeterminate", "foo");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -217,17 +217,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Long_Option()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", "--name");
+                var result = app.Run("dog", "--name");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -235,17 +235,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Short_Option()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", "-n");
+                var result = app.Run("dog", "-n");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -258,17 +258,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<GiraffeCommand>("giraffe");
                 });
 
                 // When
-                var result = fixture.Run("giraffe", "foo", "bar", "baz");
+                var result = app.Run("giraffe", "foo", "bar", "baz");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -281,17 +281,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Long_Option()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("--foo");
+                var result = app.Run("--foo");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -299,17 +299,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Short_Option()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("-f");
+                var result = app.Run("-f");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -322,18 +322,18 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Long_Option_If_Strict_Mode_Is_Enabled()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.UseStrictParsing();
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", "--unknown");
+                var result = app.Run("dog", "--unknown");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -341,18 +341,18 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Short_Option_If_Strict_Mode_Is_Enabled()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.UseStrictParsing();
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", "-u");
+                var result = app.Run("dog", "-u");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -365,17 +365,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("--name", "\"Rufus");
+                var result = app.Run("--name", "\"Rufus");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -388,17 +388,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Short_Option()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", "-", " ");
+                var result = app.Run("dog", "-", " ");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -406,17 +406,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Missing_Long_Option_Value_With_Equality_Separator()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", $"--foo=");
+                var result = app.Run("dog", $"--foo=");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -424,17 +424,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Missing_Long_Option_Value_With_Colon_Separator()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", $"--foo:");
+                var result = app.Run("dog", $"--foo:");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -442,17 +442,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Missing_Short_Option_Value_With_Equality_Separator()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", $"-f=");
+                var result = app.Run("dog", $"-f=");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Fact]
@@ -460,17 +460,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text_For_Missing_Short_Option_Value_With_Colon_Separator()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", $"-f:");
+                var result = app.Run("dog", $"-f:");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -483,17 +483,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", $"-f0o");
+                var result = app.Run("dog", $"-f0o");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -506,17 +506,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", $"--f");
+                var result = app.Run("dog", $"--f");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -529,17 +529,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", $"-- ");
+                var result = app.Run("dog", $"-- ");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -552,17 +552,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", $"--1foo");
+                var result = app.Run("dog", $"--1foo");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
         }
 
@@ -575,17 +575,17 @@ public sealed partial class CommandAppTests
             public Task Should_Return_Correct_Text()
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", $"--f€oo");
+                var result = app.Run("dog", $"--f€oo");
 
                 // Then
-                return Verifier.Verify(result);
+                return Verifier.Verify(result.Output);
             }
 
             [Theory]
@@ -596,17 +596,17 @@ public sealed partial class CommandAppTests
             public void Should_Allow_Special_Symbols_In_Name(string option)
             {
                 // Given
-                var fixture = new Fixture();
-                fixture.Configure(configurator =>
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
                 {
                     configurator.AddCommand<DogCommand>("dog");
                 });
 
                 // When
-                var result = fixture.Run("dog", option);
+                var result = app.Run("dog", option);
 
                 // Then
-                result.ShouldBe("Error: Command 'dog' is missing required argument 'AGE'.");
+                result.Output.ShouldBe("Error: Command 'dog' is missing required argument 'AGE'.");
             }
         }
 
@@ -615,52 +615,17 @@ public sealed partial class CommandAppTests
         public Task Should_Parse_Quoted_Strings_Correctly()
         {
             // Given
-            var fixture = new Fixture();
-            fixture.Configure(configurator =>
+            var app = new CommandAppTester();
+            app.Configure(configurator =>
             {
                 configurator.AddCommand<DumpRemainingCommand>("foo");
             });
 
             // When
-            var result = fixture.Run("foo", "--", "/c", "\"set && pause\"");
+            var result = app.Run("foo", "--", "/c", "\"set && pause\"");
 
             // Then
-            return Verifier.Verify(result);
-        }
-    }
-
-    internal sealed class Fixture
-    {
-        private Action<CommandApp> _appConfiguration = _ => { };
-        private Action<IConfigurator> _configuration;
-
-        public void WithDefaultCommand<T>()
-            where T : class, ICommand
-        {
-            _appConfiguration = (app) => app.SetDefaultCommand<T>();
-        }
-
-        public void Configure(Action<IConfigurator> action)
-        {
-            _configuration = action;
-        }
-
-        public string Run(params string[] args)
-        {
-            using (var console = new TestConsole())
-            {
-                var app = new CommandApp();
-                _appConfiguration?.Invoke(app);
-
-                app.Configure(_configuration);
-                app.Configure(c => c.ConfigureConsole(console));
-                app.Run(args);
-
-                return console.Output
-                    .NormalizeLineEndings()
-                    .TrimLines()
-                    .Trim();
-            }
+            return Verifier.Verify(result.Output);
         }
     }
 }

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Parsing.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Parsing.cs
@@ -357,29 +357,6 @@ public sealed partial class CommandAppTests
         }
 
         [UsesVerify]
-        [ExpectationPath("UnterminatedQuote")]
-        public sealed class UnterminatedQuote
-        {
-            [Fact]
-            [Expectation("Test_1")]
-            public Task Should_Return_Correct_Text()
-            {
-                // Given
-                var app = new CommandAppTester();
-                app.Configure(configurator =>
-                {
-                    configurator.AddCommand<DogCommand>("dog");
-                });
-
-                // When
-                var result = app.Run("--name", "\"Rufus");
-
-                // Then
-                return Verifier.Verify(result.Output);
-            }
-        }
-
-        [UsesVerify]
         [ExpectationPath("OptionWithoutName")]
         public sealed class OptionWithoutName
         {
@@ -608,24 +585,6 @@ public sealed partial class CommandAppTests
                 // Then
                 result.Output.ShouldBe("Error: Command 'dog' is missing required argument 'AGE'.");
             }
-        }
-
-        [Fact]
-        [Expectation("Quoted_Strings")]
-        public Task Should_Parse_Quoted_Strings_Correctly()
-        {
-            // Given
-            var app = new CommandAppTester();
-            app.Configure(configurator =>
-            {
-                configurator.AddCommand<DumpRemainingCommand>("foo");
-            });
-
-            // When
-            var result = app.Run("foo", "--", "/c", "\"set && pause\"");
-
-            // Then
-            return Verifier.Verify(result.Output);
         }
     }
 }

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
@@ -62,9 +62,38 @@ public sealed partial class CommandAppTests
             result.Context.Remaining.Raw[0].ShouldBe("--foo");
             result.Context.Remaining.Raw[1].ShouldBe("bar");
             result.Context.Remaining.Raw[2].ShouldBe("-bar");
-            result.Context.Remaining.Raw[3].ShouldBe("baz");
+            result.Context.Remaining.Raw[3].ShouldBe("\"baz\"");
             result.Context.Remaining.Raw[4].ShouldBe("qux");
             result.Context.Remaining.Raw[5].ShouldBe("foo bar baz qux");
+        }
+
+        [Fact]
+        public void Should_Preserve_Quotes_Hyphen_Delimiters()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.AddCommand<DogCommand>("dog");
+                });
+            });
+
+            // When
+            var result = app.Run(new[]
+            {
+                "animal", "4", "dog", "12", "--",
+                "/c", "\"set && pause\"",
+                "Name=\" -Rufus --' ",
+            });
+
+            // Then
+            result.Context.Remaining.Raw.Count.ShouldBe(3);
+            result.Context.Remaining.Raw[0].ShouldBe("/c");
+            result.Context.Remaining.Raw[1].ShouldBe("\"set && pause\"");
+            result.Context.Remaining.Raw[2].ShouldBe("Name=\" -Rufus --' ");
         }
     }
 }

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.cs
@@ -223,6 +223,38 @@ public sealed partial class CommandAppTests
     }
 
     [Fact]
+    public void Should_Preserve_Quotes_Hyphen_Delimiters_Spaces()
+    {
+        // Given
+        var app = new CommandAppTester();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddCommand<DogCommand>("dog");
+        });
+
+        // When
+        var result = app.Run(new[]
+        {
+            "dog", "12", "4",
+            "--name=\" -Rufus --' ",
+            "--",
+            "--order-by", "\"-size\"",
+            "--order-by", " ",
+            "--order-by", string.Empty,
+        });
+
+        // Then
+        result.ExitCode.ShouldBe(0);
+        result.Settings.ShouldBeOfType<DogSettings>().And(dog =>
+        {
+            dog.Name.ShouldBe("\" -Rufus --' ");
+        });
+        result.Context.Remaining.Parsed.Count.ShouldBe(1);
+        result.Context.ShouldHaveRemainingArgument("order-by", values: new[] { "\"-size\"", " ", string.Empty });
+    }
+
+    [Fact]
     public void Should_Be_Able_To_Use_Command_Alias()
     {
         // Given
@@ -1013,7 +1045,7 @@ public sealed partial class CommandAppTests
             result.Context.Remaining.Raw[0].ShouldBe("--foo");
             result.Context.Remaining.Raw[1].ShouldBe("bar");
             result.Context.Remaining.Raw[2].ShouldBe("-bar");
-            result.Context.Remaining.Raw[3].ShouldBe("baz");
+            result.Context.Remaining.Raw[3].ShouldBe("\"baz\"");
             result.Context.Remaining.Raw[4].ShouldBe("qux");
         }
     }

--- a/test/Spectre.Console.Cli.Tests/Unit/Parsing/CommandTreeTokenizerTests.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/Parsing/CommandTreeTokenizerTests.cs
@@ -1,0 +1,314 @@
+namespace Spectre.Console.Tests.Unit.Cli.Parsing;
+
+public class CommandTreeTokenizerTests
+{
+    public sealed class ScanString
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        [InlineData("\t")]
+        [InlineData("\r\n\t")]
+        [InlineData("👋🏻")]
+        [InlineData("🐎👋🏻🔥❤️")]
+        [InlineData("\"🐎👋🏻🔥❤️\" is an emoji sequence")]
+        public void Should_Preserve_Edgecase_Inputs(string actualAndExpected)
+        {
+            // Given
+
+            // When
+            var result = CommandTreeTokenizer.Tokenize(new string[] { actualAndExpected });
+
+            // Then
+            result.Tokens.Count.ShouldBe(1);
+            result.Tokens[0].Value.ShouldBe(actualAndExpected);
+            result.Tokens[0].TokenKind.ShouldBe(CommandTreeToken.Kind.String);
+        }
+
+        [Theory]
+
+        // Double-quote handling
+        [InlineData("\"")]
+        [InlineData("\"\"")]
+        [InlineData("\"Rufus\"")]
+        [InlineData("\" Rufus\"")]
+        [InlineData("\"-R\"")]
+        [InlineData("\"-Rufus\"")]
+        [InlineData("\" -Rufus\"")]
+
+        // Single-quote handling
+        [InlineData("'")]
+        [InlineData("''")]
+        [InlineData("'Rufus'")]
+        [InlineData("' Rufus'")]
+        [InlineData("'-R'")]
+        [InlineData("'-Rufus'")]
+        [InlineData("' -Rufus'")]
+        public void Should_Preserve_Quotes(string actualAndExpected)
+        {
+            // Given
+
+            // When
+            var result = CommandTreeTokenizer.Tokenize(new string[] { actualAndExpected });
+
+            // Then
+            result.Tokens.Count.ShouldBe(1);
+            result.Tokens[0].Value.ShouldBe(actualAndExpected);
+            result.Tokens[0].TokenKind.ShouldBe(CommandTreeToken.Kind.String);
+        }
+
+        [Theory]
+        [InlineData("Rufus-")]
+        [InlineData("Rufus--")]
+        [InlineData("R-u-f-u-s")]
+        public void Should_Preserve_Hyphen_Delimiters(string actualAndExpected)
+        {
+            // Given
+
+            // When
+            var result = CommandTreeTokenizer.Tokenize(new string[] { actualAndExpected });
+
+            // Then
+            result.Tokens.Count.ShouldBe(1);
+            result.Tokens[0].Value.ShouldBe(actualAndExpected);
+            result.Tokens[0].TokenKind.ShouldBe(CommandTreeToken.Kind.String);
+        }
+
+        [Theory]
+        [InlineData(" Rufus")]
+        [InlineData("Rufus ")]
+        [InlineData(" Rufus ")]
+        public void Should_Preserve_Spaces(string actualAndExpected)
+        {
+            // Given
+
+            // When
+            var result = CommandTreeTokenizer.Tokenize(new string[] { actualAndExpected });
+
+            // Then
+            result.Tokens.Count.ShouldBe(1);
+            result.Tokens[0].Value.ShouldBe(actualAndExpected);
+            result.Tokens[0].TokenKind.ShouldBe(CommandTreeToken.Kind.String);
+        }
+
+        [Theory]
+        [InlineData(" \" -Rufus -- ")]
+        [InlineData("Name=\" -Rufus --' ")]
+        public void Should_Preserve_Quotes_Hyphen_Delimiters_Spaces(string actualAndExpected)
+        {
+            // Given
+
+            // When
+            var result = CommandTreeTokenizer.Tokenize(new string[] { actualAndExpected });
+
+            // Then
+            result.Tokens.Count.ShouldBe(1);
+            result.Tokens[0].Value.ShouldBe(actualAndExpected);
+            result.Tokens[0].TokenKind.ShouldBe(CommandTreeToken.Kind.String);
+        }
+    }
+
+    public sealed class ScanLongOption
+    {
+        [Theory]
+        [InlineData("--Name-", "Name-")]
+        [InlineData("--Name_", "Name_")]
+        public void Should_Allow_Hyphens_And_Underscores_In_Option_Name(string actual, string expected)
+        {
+            // Given
+
+            // When
+            var result = CommandTreeTokenizer.Tokenize(new string[] { actual });
+
+            // Then
+            result.Tokens.Count.ShouldBe(1);
+            result.Tokens[0].Value.ShouldBe(expected);
+            result.Tokens[0].TokenKind.ShouldBe(CommandTreeToken.Kind.LongOption);
+        }
+
+        [Theory]
+        [InlineData("-- ")]
+        [InlineData("--Name ")]
+        [InlineData("--Name\"")]
+        [InlineData("--Nam\"e")]
+        public void Should_Throw_On_Invalid_Option_Name(string actual)
+        {
+            // Given
+
+            // When
+            var result = Record.Exception(() => CommandTreeTokenizer.Tokenize(new string[] { actual }));
+
+            // Then
+            result.ShouldBeOfType<CommandParseException>().And(ex =>
+            {
+                ex.Message.ShouldBe("Invalid long option name.");
+            });
+        }
+    }
+
+    public sealed class ScanShortOptions
+    {
+        [Fact]
+        public void Should_Accept_Option_Without_Value()
+        {
+            // Given
+
+            // When
+            var result = CommandTreeTokenizer.Tokenize(new[] { "-a" });
+
+            // Then
+            result.Remaining.ShouldBeEmpty();
+            result.Tokens.ShouldHaveSingleItem();
+
+            var t = result.Tokens[0];
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.ShortOption);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(0);
+            t.Value.ShouldBe("a");
+            t.Representation.ShouldBe("-a");
+        }
+
+        [Theory]
+        [InlineData("-a:foo")]
+        [InlineData("-a=foo")]
+        public void Should_Accept_Option_With_Value(string param)
+        {
+            // Given
+
+            // When
+            var result = CommandTreeTokenizer.Tokenize(new[] { param });
+
+            // Then
+            result.Remaining.ShouldBeEmpty();
+            result.Tokens.Count.ShouldBe(2);
+
+            var t = result.Tokens.Consume();
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.ShortOption);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(0);
+            t.Value.ShouldBe("a");
+            t.Representation.ShouldBe("-a");
+
+            t = result.Tokens.Consume();
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.String);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(3);
+            t.Value.ShouldBe("foo");
+            t.Representation.ShouldBe("foo");
+        }
+
+        [Theory]
+
+        // Positive values
+        [InlineData("-a:1.5", null, "1.5")]
+        [InlineData("-a=1.5", null, "1.5")]
+        [InlineData("-a", "1.5", "1.5")]
+
+        // Negative values
+        [InlineData("-a:-1.5", null, "-1.5")]
+        [InlineData("-a=-1.5", null, "-1.5")]
+        [InlineData("-a", "-1.5", "-1.5")]
+        public void Should_Accept_Option_With_Numeric_Value(string firstArg, string secondArg, string expectedValue)
+        {
+            // Given
+            List<string> args = new List<string>();
+            args.Add(firstArg);
+            if (secondArg != null)
+            {
+                args.Add(secondArg);
+            }
+
+            // When
+            var result = CommandTreeTokenizer.Tokenize(args);
+
+            // Then
+            result.Remaining.ShouldBeEmpty();
+            result.Tokens.Count.ShouldBe(2);
+
+            var t = result.Tokens.Consume();
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.ShortOption);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(0);
+            t.Value.ShouldBe("a");
+            t.Representation.ShouldBe("-a");
+
+            t = result.Tokens.Consume();
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.String);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(3);
+            t.Value.ShouldBe(expectedValue);
+            t.Representation.ShouldBe(expectedValue);
+        }
+
+        [Fact]
+        public void Should_Accept_Option_With_Negative_Numeric_Prefixed_String_Value()
+        {
+            // Given
+
+            // When
+            var result = CommandTreeTokenizer.Tokenize(new[] { "-6..2 " });
+
+            // Then
+            result.Remaining.ShouldBeEmpty();
+            result.Tokens.ShouldHaveSingleItem();
+
+            var t = result.Tokens[0];
+            t.TokenKind.ShouldBe(CommandTreeToken.Kind.String);
+            t.IsGrouped.ShouldBe(false);
+            t.Position.ShouldBe(0);
+            t.Value.ShouldBe("-6..2");
+            t.Representation.ShouldBe("-6..2");
+        }
+
+        [Theory]
+        [InlineData("-N ", "N")]
+        public void Should_Remove_Trailing_Spaces_In_Option_Name(string actual, string expected)
+        {
+            // Given
+
+            // When
+            var result = CommandTreeTokenizer.Tokenize(new string[] { actual });
+
+            // Then
+            result.Tokens.Count.ShouldBe(1);
+            result.Tokens[0].Value.ShouldBe(expected);
+            result.Tokens[0].TokenKind.ShouldBe(CommandTreeToken.Kind.ShortOption);
+        }
+
+        [Theory]
+        [InlineData("-N-")]
+        [InlineData("-N\"")]
+        [InlineData("-a1")]
+        public void Should_Throw_On_Invalid_Option_Name(string actual)
+        {
+            // Given
+
+            // When
+            var result = Record.Exception(() => CommandTreeTokenizer.Tokenize(new string[] { actual }));
+
+            // Then
+            result.ShouldBeOfType<CommandParseException>().And(ex =>
+            {
+                ex.Message.ShouldBe("Short option does not have a valid name.");
+            });
+        }
+    }
+
+    [Theory]
+    [InlineData("-")]
+    [InlineData("- ")]
+    public void Should_Throw_On_Missing_Option_Name(string actual)
+    {
+        // Given
+
+        // When
+        var result = Record.Exception(() => CommandTreeTokenizer.Tokenize(new string[] { actual }));
+
+        // Then
+        result.ShouldBeOfType<CommandParseException>().And(ex =>
+        {
+            ex.Message.ShouldBe("Option does not have a name.");
+        });
+    }
+}

--- a/test/Spectre.Console.Tests/Expectations/Cli/Parsing/Quoted_Strings.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Cli/Parsing/Quoted_Strings.Output.verified.txt
@@ -1,3 +1,0 @@
-# Raw
-/c
-set && pause

--- a/test/Spectre.Console.Tests/Expectations/Cli/Parsing/UnterminatedQuote/Test_1.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Cli/Parsing/UnterminatedQuote/Test_1.Output.verified.txt
@@ -1,4 +1,0 @@
-Error: Encountered unterminated quoted string 'Rufus'.
-
-       --name "Rufus
-              ^^^^^^ Did you forget the closing quotation mark?


### PR DESCRIPTION
The following three PR's, when taken jointly, represent a significant enhancement to existing command line parsing behaviour: https://github.com/spectreconsole/spectre.console/pull/1036, https://github.com/spectreconsole/spectre.console/pull/1029, https://github.com/spectreconsole/spectre.console/pull/1040

However, they all make changes to CommandTreeTokenizer and introduce their own unit tests specifically for the CommandTreeTokenizer, and as such, merge conflicts will arise once any one of the PR's has been merged.

This PR encompasses all three PR's, successfully merged and with all conflicts resolved. The respective git histories have also been squashed so the changes for each issue can be more clearly examined. 

All issues addressed by this single combined PR are: https://github.com/spectreconsole/spectre.console/issues/959, https://github.com/spectreconsole/spectre.console/issues/842, https://github.com/spectreconsole/spectre.console/issues/890, https://github.com/spectreconsole/spectre.console/issues/193 (and its open duplicate, https://github.com/spectreconsole/spectre.console/issues/825), https://github.com/spectreconsole/spectre.console/issues/587

As it's quite a big change, I'm happy to help in any way required @patriksvensson for you to accept in full, in part, with or without amendment etc.