### PR TITLE
Proper CancellationToken handling for ListPrompt. Fixes #1076.

### DIFF
--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -48,6 +48,8 @@ internal sealed class ListPrompt<T>
 
             while (true)
             {
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var rawKey = await _console.Input.ReadKeyAsync(true, cancellationToken).ConfigureAwait(false);
                 if (rawKey == null)
                 {


### PR DESCRIPTION
Proper CancellationToken handling for ListPrompt.