### PR TITLE
Add asynchronous AlternateScreen method

### DIFF
--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Screen.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Screen.cs
@@ -41,4 +41,42 @@ public static partial class AnsiConsoleExtensions
             console.Write(new ControlCode("\u001b[?1049l"));
         }
     }
+
+    /// <summary>
+    /// Switches to an alternate screen buffer asynchronously if the terminal supports it.
+    /// </summary>
+    /// <param name="console">The console.</param>
+    /// <param name="action">The action to execute within the alternate screen buffer.</param>
+    /// <returns>The result of the function.</returns>
+    public static async Task AlternateScreenAsync(this IAnsiConsole console, Func<Task> action)
+    {
+        if (console is null)
+        {
+            throw new ArgumentNullException(nameof(console));
+        }
+
+        if (!console.Profile.Capabilities.Ansi)
+        {
+            throw new NotSupportedException("Alternate buffers are not supported since your terminal does not support ANSI.");
+        }
+
+        if (!console.Profile.Capabilities.AlternateBuffer)
+        {
+            throw new NotSupportedException("Alternate buffers are not supported by your terminal.");
+        }
+
+        // Switch to alternate screen
+        console.Write(new ControlCode("\u001b[?1049h\u001b[H"));
+
+        try
+        {
+            // Execute custom action
+            await action();
+        }
+        finally
+        {
+            // Switch back to primary screen
+            console.Write(new ControlCode("\u001b[?1049l"));
+        }
+    }
 }


### PR DESCRIPTION
This begins the implementation of `AnsiConsoleAlternateScreenAsync`, an asynchronous variant of `AnsiConsole.AlternateScreen` from [#1079](https://github.com/spectreconsole/spectre.console/issues/1079)