### PR TITLE
187 Allow default command configuration for a branch

### DIFF
--- a/src/Spectre.Console.Cli/CommandApp.cs
+++ b/src/Spectre.Console.Cli/CommandApp.cs
@@ -113,7 +113,7 @@ public sealed class CommandApp : ICommandApp
         }
     }
 
-    internal Configurator GetConfigurator()
+    internal IConfigurator GetConfigurator()
     {
         return _configurator;
     }

--- a/src/Spectre.Console.Cli/IConfigurator.cs
+++ b/src/Spectre.Console.Cli/IConfigurator.cs
@@ -17,6 +17,16 @@ public interface IConfigurator
     void AddExample(string[] args);
 
     /// <summary>
+    /// Adds a default command.
+    /// </summary>
+    /// <remarks>
+    /// This is the command that will run if the user doesn't specify one on the command line.
+    /// </remarks>
+    /// <typeparam name="TDefaultCommand">The default command type.</typeparam>
+    void SetDefaultCommand<TDefaultCommand>()
+        where TDefaultCommand : class, ICommand;
+
+    /// <summary>
     /// Adds a command.
     /// </summary>
     /// <typeparam name="TCommand">The command type.</typeparam>

--- a/src/Spectre.Console.Cli/IConfiguratorOfT.cs
+++ b/src/Spectre.Console.Cli/IConfiguratorOfT.cs
@@ -20,6 +20,18 @@ public interface IConfigurator<in TSettings>
     void AddExample(string[] args);
 
     /// <summary>
+    /// Adds a default command.
+    /// </summary>
+    /// <remarks>
+    /// This is the command that will run if the user doesn't specify one on the command line.
+    /// It must be able to execute successfully by itself ie. without requiring any command line
+    /// arguments, flags or option values.
+    /// </remarks>
+    /// <typeparam name="TDefaultCommand">The default command type.</typeparam>
+    void SetDefaultCommand<TDefaultCommand>()
+        where TDefaultCommand : class, ICommandLimiter<TSettings>;
+
+    /// <summary>
     /// Marks the branch as hidden.
     /// Hidden branches do not show up in help documentation or
     /// generated XML models.

--- a/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
@@ -86,8 +86,11 @@ internal sealed class CommandExecutor
         var tokenizerResult = CommandTreeTokenizer.Tokenize(args);
         var parsedResult = parser.Parse(parserContext, tokenizerResult);
 
-        var lastParsedCommand = parsedResult?.Tree?.GetLeafCommand()?.Command;
-        if (lastParsedCommand != null && lastParsedCommand.IsBranch && lastParsedCommand.DefaultCommand != null)
+        var lastParsedLeaf = parsedResult?.Tree?.GetLeafCommand();
+        var lastParsedCommand = lastParsedLeaf?.Command;
+        if (lastParsedLeaf != null && lastParsedCommand != null &&
+            lastParsedCommand.IsBranch && !lastParsedLeaf.ShowHelp &&
+            lastParsedCommand.DefaultCommand != null)
         {
             // Insert this branch's default command into the command line
             // arguments and try again to see if it will parse.

--- a/src/Spectre.Console.Cli/Internal/Configuration/Configurator.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/Configurator.cs
@@ -35,7 +35,7 @@ internal sealed class Configurator : IUnsafeConfigurator, IConfigurator, IConfig
     public ICommandConfigurator AddCommand<TCommand>(string name)
         where TCommand : class, ICommand
     {
-        var command = Commands.AddAndReturn(ConfiguredCommand.FromType<TCommand>(name, false));
+        var command = Commands.AddAndReturn(ConfiguredCommand.FromType<TCommand>(name, isDefaultCommand: false));
         return new CommandConfigurator(command);
     }
 

--- a/src/Spectre.Console.Cli/Internal/Configuration/ConfiguratorOfT.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/ConfiguratorOfT.cs
@@ -22,6 +22,15 @@ internal sealed class Configurator<TSettings> : IUnsafeBranchConfigurator, IConf
         _command.Examples.Add(args);
     }
 
+    public void SetDefaultCommand<TDefaultCommand>()
+        where TDefaultCommand : class, ICommandLimiter<TSettings>
+    {
+        var defaultCommand = ConfiguredCommand.FromType<TDefaultCommand>(
+            CliConstants.DefaultCommandName, isDefaultCommand: true);
+
+        _command.Children.Add(defaultCommand);
+    }
+
     public void HideBranch()
     {
         _command.IsHidden = true;
@@ -30,7 +39,7 @@ internal sealed class Configurator<TSettings> : IUnsafeBranchConfigurator, IConf
     public ICommandConfigurator AddCommand<TCommand>(string name)
         where TCommand : class, ICommandLimiter<TSettings>
     {
-        var command = ConfiguredCommand.FromType<TCommand>(name);
+        var command = ConfiguredCommand.FromType<TCommand>(name, isDefaultCommand: false);
         var configurator = new CommandConfigurator(command);
 
         _command.Children.Add(command);

--- a/src/Spectre.Console.Cli/Internal/Configuration/ConfiguredCommand.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/ConfiguredCommand.cs
@@ -29,6 +29,9 @@ internal sealed class ConfiguredCommand
         Delegate = @delegate;
         IsDefaultCommand = isDefaultCommand;
 
+        // Default commands are always created as hidden.
+        IsHidden = IsDefaultCommand;
+
         Children = new List<ConfiguredCommand>();
         Examples = new List<string[]>();
     }

--- a/src/Spectre.Console.Cli/Internal/Extensions/TypeRegistrarExtensions.cs
+++ b/src/Spectre.Console.Cli/Internal/Extensions/TypeRegistrarExtensions.cs
@@ -6,10 +6,6 @@ internal static class TypeRegistrarExtensions
     {
         var stack = new Stack<CommandInfo>();
         model.Commands.ForEach(c => stack.Push(c));
-        if (model.DefaultCommand != null)
-        {
-            stack.Push(model.DefaultCommand);
-        }
 
         while (stack.Count > 0)
         {

--- a/src/Spectre.Console.Cli/Internal/Modelling/CommandInfo.cs
+++ b/src/Spectre.Console.Cli/Internal/Modelling/CommandInfo.cs
@@ -10,7 +10,6 @@ internal sealed class CommandInfo : ICommandContainer
     public Type SettingsType { get; }
     public Func<CommandContext, CommandSettings, int>? Delegate { get; }
     public bool IsDefaultCommand { get; }
-    public bool IsHidden { get; }
     public CommandInfo? Parent { get; }
     public IList<CommandInfo> Children { get; }
     public IList<CommandParameter> Parameters { get; }
@@ -18,6 +17,10 @@ internal sealed class CommandInfo : ICommandContainer
 
     public bool IsBranch => CommandType == null && Delegate == null;
     IList<CommandInfo> ICommandContainer.Commands => Children;
+
+    // only branches can have a default command
+    public CommandInfo? DefaultCommand => IsBranch ? Children.FirstOrDefault(c => c.IsDefaultCommand) : null;
+    public bool IsHidden { get; }
 
     public CommandInfo(CommandInfo? parent, ConfiguredCommand prototype)
     {

--- a/src/Spectre.Console.Cli/Internal/Modelling/CommandModel.cs
+++ b/src/Spectre.Console.Cli/Internal/Modelling/CommandModel.cs
@@ -4,21 +4,20 @@ internal sealed class CommandModel : ICommandContainer
 {
     public string? ApplicationName { get; }
     public ParsingMode ParsingMode { get; }
-    public CommandInfo? DefaultCommand { get; }
     public IList<CommandInfo> Commands { get; }
     public IList<string[]> Examples { get; }
     public bool TrimTrailingPeriod { get; }
 
+    public CommandInfo? DefaultCommand => Commands.FirstOrDefault(c => c.IsDefaultCommand);
+
     public CommandModel(
         CommandAppSettings settings,
-        CommandInfo? defaultCommand,
         IEnumerable<CommandInfo> commands,
         IEnumerable<string[]> examples)
     {
         ApplicationName = settings.ApplicationName;
         ParsingMode = settings.ParsingMode;
         TrimTrailingPeriod = settings.TrimTrailingPeriod;
-        DefaultCommand = defaultCommand;
         Commands = new List<CommandInfo>(commands ?? Array.Empty<CommandInfo>());
         Examples = new List<string[]>(examples ?? Array.Empty<string[]>());
     }

--- a/src/Spectre.Console.Cli/Internal/Modelling/CommandModelBuilder.cs
+++ b/src/Spectre.Console.Cli/Internal/Modelling/CommandModelBuilder.cs
@@ -1,3 +1,7 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Spectre.Console.Cli.Tests")]
+
 namespace Spectre.Console.Cli;
 
 internal static class CommandModelBuilder
@@ -25,18 +29,19 @@ internal static class CommandModelBuilder
             result.Add(Build(null, command));
         }
 
-        var defaultCommand = default(CommandInfo);
         if (configuration.DefaultCommand != null)
         {
             // Add the examples from the configuration to the default command.
             configuration.DefaultCommand.Examples.AddRange(configuration.Examples);
 
             // Build the default command.
-            defaultCommand = Build(null, configuration.DefaultCommand);
+            var defaultCommand = Build(null, configuration.DefaultCommand);
+
+            result.Add(defaultCommand);
         }
 
         // Create the command model and validate it.
-        var model = new CommandModel(configuration.Settings, defaultCommand, result, configuration.Examples);
+        var model = new CommandModel(configuration.Settings, result, configuration.Examples);
         CommandModelValidator.Validate(model, configuration.Settings);
 
         return model;

--- a/src/Spectre.Console.Cli/Internal/Modelling/CommandModelValidator.cs
+++ b/src/Spectre.Console.Cli/Internal/Modelling/CommandModelValidator.cs
@@ -14,7 +14,7 @@ internal static class CommandModelValidator
             throw new ArgumentNullException(nameof(settings));
         }
 
-        if (model.Commands.Count == 0 && model.DefaultCommand == null)
+        if (model.Commands.Count == 0)
         {
             throw CommandConfigurationException.NoCommandConfigured();
         }
@@ -31,7 +31,6 @@ internal static class CommandModelValidator
             }
         }
 
-        Validate(model.DefaultCommand);
         foreach (var command in model.Commands)
         {
             Validate(command);
@@ -147,7 +146,7 @@ internal static class CommandModelValidator
         {
             try
             {
-                var parser = new CommandTreeParser(model, settings, ParsingMode.Strict);
+                var parser = new CommandTreeParser(model, settings.CaseSensitivity, ParsingMode.Strict);
                 parser.Parse(example);
             }
             catch (Exception ex)

--- a/src/Spectre.Console.Cli/Internal/Modelling/ICommandContainer.cs
+++ b/src/Spectre.Console.Cli/Internal/Modelling/ICommandContainer.cs
@@ -9,4 +9,12 @@ internal interface ICommandContainer
     /// Gets all commands in the container.
     /// </summary>
     IList<CommandInfo> Commands { get; }
+
+    /// <summary>
+    /// Gets the default command for the container.
+    /// </summary>
+    /// <remarks>
+    /// Returns null if a default command has not been set.
+    /// </remarks>
+    CommandInfo? DefaultCommand { get; }
 }

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs
@@ -1,3 +1,5 @@
+using static Spectre.Console.Cli.CommandTreeTokenizer;
+
 namespace Spectre.Console.Cli;
 
 internal class CommandTreeParser
@@ -14,25 +16,25 @@ internal class CommandTreeParser
         Remaining = 1,
     }
 
-    public CommandTreeParser(CommandModel configuration, ICommandAppSettings settings, ParsingMode? parsingMode = null)
+    public CommandTreeParser(CommandModel configuration, CaseSensitivity caseSensitivity, ParsingMode? parsingMode = null)
     {
-        if (settings is null)
-        {
-            throw new ArgumentNullException(nameof(settings));
-        }
-
-        _configuration = configuration;
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _parsingMode = parsingMode ?? _configuration.ParsingMode;
         _help = new CommandOptionAttribute("-h|--help");
 
-        CaseSensitivity = settings.CaseSensitivity;
+        CaseSensitivity = caseSensitivity;
     }
 
     public CommandTreeParserResult Parse(IEnumerable<string> args)
     {
-        var context = new CommandTreeParserContext(args, _parsingMode);
+        var parserContext = new CommandTreeParserContext(args, _parsingMode);
+        var tokenizerResult = CommandTreeTokenizer.Tokenize(args);
 
-        var tokenizerResult = CommandTreeTokenizer.Tokenize(context.Arguments);
+        return Parse(parserContext, tokenizerResult);
+    }
+
+    public CommandTreeParserResult Parse(CommandTreeParserContext context, CommandTreeTokenizerResult tokenizerResult)
+    {
         var tokens = tokenizerResult.Tokens;
         var rawRemaining = tokenizerResult.Remaining;
 

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenStream.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenStream.cs
@@ -6,6 +6,7 @@ internal sealed class CommandTreeTokenStream : IReadOnlyList<CommandTreeToken>
     private int _position;
 
     public int Count => _tokens.Count;
+    public int Position => _position;
 
     public CommandTreeToken this[int index] => _tokens[index];
 

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
@@ -1,0 +1,351 @@
+namespace Spectre.Console.Tests.Unit.Cli;
+
+public sealed partial class CommandAppTests
+{
+    public sealed class Branches
+    {
+        [Fact]
+        public void Should_Run_The_Default_Command_On_Branch()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.SetDefaultCommand<CatCommand>();
+                });
+            });
+
+            // When
+            var result = app.Run(new[]
+            {
+                "animal", "4",
+            });
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<CatSettings>();
+        }
+
+        [Fact]
+        public void Should_Throw_When_No_Default_Command_On_Branch()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal => { });
+            });
+
+            // When
+            var result = Record.Exception(() =>
+            {
+                app.Run(new[]
+                {
+                    "animal", "4",
+                });
+            });
+
+            // Then
+            result.ShouldBeOfType<CommandConfigurationException>().And(ex =>
+            {
+                ex.Message.ShouldBe("The branch 'animal' does not define any commands.");
+            });
+        }
+
+        [SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1515:SingleLineCommentMustBePrecededByBlankLine", Justification = "Helps to illustrate the expected behaviour of this unit test.")]
+        [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1005:SingleLineCommentsMustBeginWithSingleSpace", Justification = "Helps to illustrate the expected behaviour of this unit test.")]
+        [Fact]
+        public void Should_Be_Unable_To_Parse_Default_Command_Arguments_Relaxed_Parsing()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.SetDefaultCommand<CatCommand>();
+                });
+            });
+
+            // When
+            var result = app.Run(new[]
+            {
+                // The CommandTreeParser should be unable to determine which command line
+                // arguments belong to the branch and which belong to the branch's
+                // default command (once inserted).
+                "animal", "4", "--name", "Kitty",
+            });
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<CatSettings>().And(cat =>
+            {
+                cat.Legs.ShouldBe(4);
+                //cat.Name.ShouldBe("Kitty"); //<-- Should normally be correct, but instead name will be added to the remaining arguments (see below).
+            });
+            result.Context.Remaining.Parsed.Count.ShouldBe(1);
+            result.Context.ShouldHaveRemainingArgument("name", values: new[] { "Kitty", });
+        }
+
+        [Fact]
+        public void Should_Be_Unable_To_Parse_Default_Command_Arguments_Strict_Parsing()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.UseStrictParsing();
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.SetDefaultCommand<CatCommand>();
+                });
+            });
+
+            // When
+            var result = Record.Exception(() =>
+            {
+                app.Run(new[]
+                {
+                    // The CommandTreeParser should be unable to determine which command line
+                    // arguments belong to the branch and which belong to the branch's
+                    // default command (once inserted).
+                    "animal", "4", "--name", "Kitty",
+                });
+            });
+
+            // Then
+            result.ShouldBeOfType<CommandParseException>().And(ex =>
+            {
+                ex.Message.ShouldBe("Unknown option 'name'.");
+            });
+        }
+
+        [Fact]
+        public void Should_Run_The_Default_Command_On_Branch_On_Branch()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.AddBranch<MammalSettings>("mammal", mammal =>
+                    {
+                        mammal.SetDefaultCommand<CatCommand>();
+                    });
+                });
+            });
+
+            // When
+            var result = app.Run(new[]
+            {
+                "animal", "4", "mammal",
+            });
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<CatSettings>();
+        }
+
+        [Fact]
+        public void Should_Run_The_Default_Command_On_Branch_On_Branch_With_Arguments()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.AddBranch<MammalSettings>("mammal", mammal =>
+                    {
+                        mammal.SetDefaultCommand<CatCommand>();
+                    });
+                });
+            });
+
+            // When
+            var result = app.Run(new[]
+            {
+                "animal", "4", "mammal", "--name", "Kitty",
+            });
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<CatSettings>().And(cat =>
+            {
+                cat.Legs.ShouldBe(4);
+                cat.Name.ShouldBe("Kitty");
+            });
+        }
+
+        [Fact]
+        public void Should_Run_The_Default_Command_Not_The_Named_Command_On_Branch()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.AddCommand<DogCommand>("dog");
+
+                    animal.SetDefaultCommand<CatCommand>();
+                });
+            });
+
+            // When
+            var result = app.Run(new[]
+            {
+                "animal", "4",
+            });
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<CatSettings>();
+        }
+
+        [Fact]
+        public void Should_Run_The_Named_Command_Not_The_Default_Command_On_Branch()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.AddCommand<DogCommand>("dog");
+
+                    animal.SetDefaultCommand<LionCommand>();
+                });
+            });
+
+            // When
+            var result = app.Run(new[]
+            {
+                "animal", "4", "dog", "12", "--good-boy", "--name", "Rufus",
+            });
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<DogSettings>().And(dog =>
+            {
+                dog.Legs.ShouldBe(4);
+                dog.Age.ShouldBe(12);
+                dog.GoodBoy.ShouldBe(true);
+                dog.Name.ShouldBe("Rufus");
+            });
+        }
+
+        [Fact]
+        public void Should_Allow_Multiple_Branches_Multiple_Commands()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.AddBranch<MammalSettings>("mammal", mammal =>
+                    {
+                        mammal.AddCommand<DogCommand>("dog");
+                        mammal.AddCommand<CatCommand>("cat");
+                    });
+                });
+            });
+
+            // When
+            var result = app.Run(new[]
+            {
+                "animal", "--alive", "mammal", "--name",
+                "Rufus", "dog", "12", "--good-boy",
+            });
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<DogSettings>().And(dog =>
+            {
+                dog.Age.ShouldBe(12);
+                dog.GoodBoy.ShouldBe(true);
+                dog.Name.ShouldBe("Rufus");
+                dog.IsAlive.ShouldBe(true);
+            });
+        }
+
+        [Fact]
+        public void Should_Allow_Single_Branch_Multiple_Commands()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.AddCommand<DogCommand>("dog");
+                    animal.AddCommand<CatCommand>("cat");
+                });
+            });
+
+            // When
+            var result = app.Run(new[]
+            {
+                "animal", "dog", "12", "--good-boy",
+                "--name", "Rufus",
+            });
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<DogSettings>().And(dog =>
+            {
+                dog.Age.ShouldBe(12);
+                dog.GoodBoy.ShouldBe(true);
+                dog.Name.ShouldBe("Rufus");
+                dog.IsAlive.ShouldBe(false);
+            });
+        }
+
+        [Fact]
+        public void Should_Allow_Single_Branch_Single_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddBranch<AnimalSettings>("animal", animal =>
+                {
+                    animal.AddCommand<DogCommand>("dog");
+                });
+            });
+
+            // When
+            var result = app.Run(new[]
+            {
+                "animal", "4", "dog", "12", "--good-boy",
+                "--name", "Rufus",
+            });
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<DogSettings>().And(dog =>
+            {
+                dog.Legs.ShouldBe(4);
+                dog.Age.ShouldBe(12);
+                dog.GoodBoy.ShouldBe(true);
+                dog.IsAlive.ShouldBe(false);
+                dog.Name.ShouldBe("Rufus");
+            });
+        }
+    }
+}

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.cs
@@ -10,50 +10,14 @@ public sealed partial class CommandAppTests
         app.Configure(config =>
         {
             config.PropagateExceptions();
-            config.AddBranch<AnimalSettings>("animal", animal =>
-            {
-                animal.AddBranch<MammalSettings>("mammal", mammal =>
-                {
-                    mammal.AddCommand<DogCommand>("dog");
-                    mammal.AddCommand<HorseCommand>("horse");
-                });
-            });
-        });
-
-        // When
-        var result = app.Run(new[]
-        {
-            "animal", "--alive", "mammal", "--name",
-            "Rufus", "dog", "12", "--good-boy",
-        });
-
-        // Then
-        result.ExitCode.ShouldBe(0);
-        result.Settings.ShouldBeOfType<DogSettings>().And(dog =>
-        {
-            dog.Age.ShouldBe(12);
-            dog.GoodBoy.ShouldBe(true);
-            dog.Name.ShouldBe("Rufus");
-            dog.IsAlive.ShouldBe(true);
-        });
-    }
-
-    [Fact]
-    public void Should_Pass_Case_2()
-    {
-        // Given
-        var app = new CommandAppTester();
-        app.Configure(config =>
-        {
-            config.PropagateExceptions();
             config.AddCommand<DogCommand>("dog");
         });
 
         // When
         var result = app.Run(new[]
         {
-            "dog", "12", "4", "--good-boy",
-            "--name", "Rufus", "--alive",
+                "dog", "12", "4", "--good-boy",
+                "--name", "Rufus", "--alive",
         });
 
         // Then
@@ -69,106 +33,7 @@ public sealed partial class CommandAppTests
     }
 
     [Fact]
-    public void Should_Pass_Case_3()
-    {
-        // Given
-        var app = new CommandAppTester();
-        app.Configure(config =>
-        {
-            config.PropagateExceptions();
-            config.AddBranch<AnimalSettings>("animal", animal =>
-            {
-                animal.AddCommand<DogCommand>("dog");
-                animal.AddCommand<HorseCommand>("horse");
-            });
-        });
-
-        // When
-        var result = app.Run(new[]
-        {
-            "animal", "dog", "12", "--good-boy",
-            "--name", "Rufus",
-        });
-
-        // Then
-        result.ExitCode.ShouldBe(0);
-        result.Settings.ShouldBeOfType<DogSettings>().And(dog =>
-        {
-            dog.Age.ShouldBe(12);
-            dog.GoodBoy.ShouldBe(true);
-            dog.Name.ShouldBe("Rufus");
-            dog.IsAlive.ShouldBe(false);
-        });
-    }
-
-    [Fact]
-    public void Should_Pass_Case_4()
-    {
-        // Given
-        var app = new CommandAppTester();
-        app.Configure(config =>
-        {
-            config.PropagateExceptions();
-            config.AddBranch<AnimalSettings>("animal", animal =>
-            {
-                animal.AddCommand<DogCommand>("dog");
-            });
-        });
-
-        // When
-        var result = app.Run(new[]
-        {
-            "animal", "4", "dog", "12", "--good-boy",
-            "--name", "Rufus",
-        });
-
-        // Then
-        result.ExitCode.ShouldBe(0);
-        result.Settings.ShouldBeOfType<DogSettings>().And(dog =>
-        {
-            dog.Legs.ShouldBe(4);
-            dog.Age.ShouldBe(12);
-            dog.GoodBoy.ShouldBe(true);
-            dog.IsAlive.ShouldBe(false);
-            dog.Name.ShouldBe("Rufus");
-        });
-    }
-
-    [Fact]
-    public void Should_Pass_Case_5()
-    {
-        // Given
-        var app = new CommandAppTester();
-        app.Configure(config =>
-        {
-            config.PropagateExceptions();
-            config.AddBranch<AnimalSettings>("animal", animal =>
-            {
-                animal.AddCommand<DogCommand>("dog");
-            });
-        });
-
-        // When
-        var result = app.Run(new[]
-        {
-            "animal", "--alive", "4", "dog", "--good-boy", "12",
-            "--name", "Rufus",
-        });
-
-        // Then
-        result.ExitCode.ShouldBe(0);
-        result.Settings.ShouldBeOfType<DogSettings>().And(dog =>
-        {
-            dog.Legs.ShouldBe(4);
-            dog.Age.ShouldBe(12);
-            dog.GoodBoy.ShouldBe(true);
-            dog.IsAlive.ShouldBe(true);
-            dog.Name.ShouldBe("Rufus");
-        });
-    }
-
-    [Fact]
-    public void Should_Pass_Case_6()
+    public void Should_Pass_Case_2()
     {
         // Given
         var app = new CommandAppTester();
@@ -197,7 +62,7 @@ public sealed partial class CommandAppTests
     }
 
     [Fact]
-    public void Should_Pass_Case_7()
+    public void Should_Pass_Case_3()
     {
         // Given
         var app = new CommandAppTester();
@@ -846,7 +711,7 @@ public sealed partial class CommandAppTests
     }
 
     [Fact]
-    public void Should_Be_Able_To_Set_The_Default_Command()
+    public void Should_Run_The_Default_Command()
     {
         // Given
         var app = new CommandAppTester();
@@ -866,6 +731,62 @@ public sealed partial class CommandAppTests
             dog.Age.ShouldBe(12);
             dog.GoodBoy.ShouldBe(true);
             dog.Name.ShouldBe("Rufus");
+        });
+    }
+
+    [Fact]
+    public void Should_Run_The_Default_Command_Not_The_Named_Command()
+    {
+        // Given
+        var app = new CommandAppTester();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddCommand<HorseCommand>("horse");
+        });
+        app.SetDefaultCommand<DogCommand>();
+
+        // When
+        var result = app.Run(new[]
+        {
+            "4", "12", "--good-boy", "--name", "Rufus",
+        });
+
+        // Then
+        result.ExitCode.ShouldBe(0);
+        result.Settings.ShouldBeOfType<DogSettings>().And(dog =>
+        {
+            dog.Legs.ShouldBe(4);
+            dog.Age.ShouldBe(12);
+            dog.GoodBoy.ShouldBe(true);
+            dog.Name.ShouldBe("Rufus");
+        });
+    }
+
+    [Fact]
+    public void Should_Run_The_Named_Command_Not_The_Default_Command()
+    {
+        // Given
+        var app = new CommandAppTester();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+            config.AddCommand<HorseCommand>("horse");
+        });
+        app.SetDefaultCommand<DogCommand>();
+
+        // When
+        var result = app.Run(new[]
+        {
+            "horse", "4", "--name", "Arkle",
+        });
+
+        // Then
+        result.ExitCode.ShouldBe(0);
+        result.Settings.ShouldBeOfType<MammalSettings>().And(horse =>
+        {
+            horse.Legs.ShouldBe(4);
+            horse.Name.ShouldBe("Arkle");
         });
     }
 

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandModelBuilderTests.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandModelBuilderTests.cs
@@ -1,0 +1,210 @@
+namespace Spectre.Console.Cli.Tests.Unit;
+
+public sealed class CommandModelBuilderTests
+{
+    [Fact]
+    public void Should_Build_CommandModel_Single_Command()
+    {
+        // Given
+        var registrar = new DefaultTypeRegistrar();
+        var configuration = new Configurator(registrar);
+        configuration.AddCommand<EmptyCommand>("empty");
+
+        // When
+        var commandModel = CommandModelBuilder.Build(configuration);
+
+        // Then
+        commandModel.Commands.ShouldHaveSingleItem();
+        commandModel.Commands[0].Name.ShouldBe("empty");
+        commandModel.Commands[0].CommandType.ShouldBe(typeof(EmptyCommand));
+        commandModel.Commands[0].IsDefaultCommand.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_Build_CommandModel_Default_Command()
+    {
+        // Given
+        var registrar = new DefaultTypeRegistrar();
+        var configuration = new Configurator(registrar);
+        configuration.SetDefaultCommand<EmptyCommand>();
+
+        // When
+        var commandModel = CommandModelBuilder.Build(configuration);
+
+        // Then
+        commandModel.Commands.ShouldHaveSingleItem();
+        commandModel.Commands[0].ShouldNotBeNull();
+        commandModel.Commands[0].Name.ShouldBe(CliConstants.DefaultCommandName);
+        commandModel.Commands[0].CommandType.ShouldBe(typeof(EmptyCommand));
+        commandModel.Commands[0].IsDefaultCommand.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Should_Build_CommandModel_Single_Branch_Single_Command()
+    {
+        // Given
+        var registrar = new DefaultTypeRegistrar();
+        var configuration = new Configurator(registrar);
+        configuration.AddBranch<AnimalSettings>("animal", animal =>
+        {
+            animal.AddCommand<DogCommand>("dog");
+        });
+
+        // When
+        var commandModel = CommandModelBuilder.Build(configuration);
+
+        // Then
+        commandModel.Commands.ShouldHaveSingleItem();
+        commandModel.Commands[0].Name.ShouldBe("animal");
+        commandModel.Commands[0].CommandType.ShouldBeNull();
+        commandModel.Commands[0].IsDefaultCommand.ShouldBeFalse();
+        commandModel.Commands[0].IsBranch.ShouldBeTrue();
+
+        commandModel.Commands[0].Children.ShouldHaveSingleItem();
+        commandModel.Commands[0].Children[0].Name.ShouldBe("dog");
+        commandModel.Commands[0].Children[0].CommandType.ShouldBe(typeof(DogCommand));
+        commandModel.Commands[0].Children[0].IsDefaultCommand.ShouldBeFalse();
+        commandModel.Commands[0].Children[0].IsBranch.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_Build_CommandModel_Single_Branch_Default_Command()
+    {
+        // Given
+        var registrar = new DefaultTypeRegistrar();
+        var configuration = new Configurator(registrar);
+        configuration.AddBranch<AnimalSettings>("animal", animal =>
+        {
+            animal.SetDefaultCommand<HorseCommand>();
+        });
+
+        // When
+        var commandModel = CommandModelBuilder.Build(configuration);
+
+        // Then
+        commandModel.Commands.ShouldHaveSingleItem();
+        commandModel.Commands[0].Name.ShouldBe("animal");
+        commandModel.Commands[0].CommandType.ShouldBeNull();
+        commandModel.Commands[0].IsDefaultCommand.ShouldBeFalse();
+        commandModel.Commands[0].IsBranch.ShouldBeTrue();
+
+        commandModel.Commands[0].Children.ShouldHaveSingleItem();
+        commandModel.Commands[0].Children[0].Name.ShouldBe(CliConstants.DefaultCommandName);
+        commandModel.Commands[0].Children[0].CommandType.ShouldBe(typeof(HorseCommand));
+        commandModel.Commands[0].Children[0].IsDefaultCommand.ShouldBeTrue();
+        commandModel.Commands[0].Children[0].IsBranch.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_Build_CommandModel_Single_Branch_Single_Branch_Default_Command()
+    {
+        // Given
+        var registrar = new DefaultTypeRegistrar();
+        var configuration = new Configurator(registrar);
+        configuration.AddBranch<AnimalSettings>("animal", animal =>
+        {
+            animal.AddBranch<MammalSettings>("mammal", mammal =>
+            {
+                mammal.SetDefaultCommand<HorseCommand>();
+            });
+        });
+
+        // When
+        var commandModel = CommandModelBuilder.Build(configuration);
+
+        // Then
+        commandModel.Commands.ShouldHaveSingleItem();
+        commandModel.Commands[0].Name.ShouldBe("animal");
+        commandModel.Commands[0].CommandType.ShouldBeNull();
+        commandModel.Commands[0].IsDefaultCommand.ShouldBeFalse();
+        commandModel.Commands[0].IsBranch.ShouldBeTrue();
+
+        commandModel.Commands[0].Children.ShouldHaveSingleItem();
+        commandModel.Commands[0].Children[0].Name.ShouldBe("mammal");
+        commandModel.Commands[0].Children[0].CommandType.ShouldBeNull();
+        commandModel.Commands[0].Children[0].IsDefaultCommand.ShouldBeFalse();
+        commandModel.Commands[0].Children[0].IsBranch.ShouldBeTrue();
+
+        commandModel.Commands[0].Children[0].Children.ShouldHaveSingleItem();
+        commandModel.Commands[0].Children[0].Children[0].Name.ShouldBe(CliConstants.DefaultCommandName);
+        commandModel.Commands[0].Children[0].Children[0].CommandType.ShouldBe(typeof(HorseCommand));
+        commandModel.Commands[0].Children[0].Children[0].IsDefaultCommand.ShouldBeTrue();
+        commandModel.Commands[0].Children[0].Children[0].IsBranch.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_Build_CommandModel_Single_Branch_Single_Command_Default_Command()
+    {
+        // Given
+        var registrar = new DefaultTypeRegistrar();
+        var configuration = new Configurator(registrar);
+        configuration.AddBranch<AnimalSettings>("animal", animal =>
+        {
+            animal.AddCommand<DogCommand>("dog");
+
+            animal.SetDefaultCommand<HorseCommand>();
+        });
+
+        // When
+        var commandModel = CommandModelBuilder.Build(configuration);
+
+        // Then
+        commandModel.Commands.ShouldHaveSingleItem();
+        commandModel.Commands[0].Name.ShouldBe("animal");
+        commandModel.Commands[0].CommandType.ShouldBeNull();
+        commandModel.Commands[0].IsDefaultCommand.ShouldBeFalse();
+        commandModel.Commands[0].IsBranch.ShouldBeTrue();
+
+        commandModel.Commands[0].Children.Count.ShouldBe(2);
+        commandModel.Commands[0].Children[0].Name.ShouldBe("dog");
+        commandModel.Commands[0].Children[0].CommandType.ShouldBe(typeof(DogCommand));
+        commandModel.Commands[0].Children[0].IsDefaultCommand.ShouldBeFalse();
+        commandModel.Commands[0].Children[0].IsBranch.ShouldBeFalse();
+
+        commandModel.Commands[0].Children[1].Name.ShouldBe(CliConstants.DefaultCommandName);
+        commandModel.Commands[0].Children[1].CommandType.ShouldBe(typeof(HorseCommand));
+        commandModel.Commands[0].Children[1].IsDefaultCommand.ShouldBeTrue();
+        commandModel.Commands[0].Children[1].IsBranch.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_Build_CommandModel_Default_Command_Single_Branch_Single_Command_Default_Command()
+    {
+        // Given
+        var registrar = new DefaultTypeRegistrar();
+        var configuration = new Configurator(registrar);
+        configuration.AddBranch<AnimalSettings>("animal", animal =>
+        {
+            animal.AddCommand<DogCommand>("dog");
+
+            animal.SetDefaultCommand<HorseCommand>();
+        });
+        configuration.SetDefaultCommand<EmptyCommand>();
+
+        // When
+        var commandModel = CommandModelBuilder.Build(configuration);
+
+        // Then
+        commandModel.Commands.Count.ShouldBe(2);
+        commandModel.Commands[0].Name.ShouldBe("animal");
+        commandModel.Commands[0].CommandType.ShouldBeNull();
+        commandModel.Commands[0].IsDefaultCommand.ShouldBeFalse();
+        commandModel.Commands[0].IsBranch.ShouldBeTrue();
+
+        commandModel.Commands[0].Children.Count.ShouldBe(2);
+        commandModel.Commands[0].Children[0].Name.ShouldBe("dog");
+        commandModel.Commands[0].Children[0].CommandType.ShouldBe(typeof(DogCommand));
+        commandModel.Commands[0].Children[0].IsDefaultCommand.ShouldBeFalse();
+        commandModel.Commands[0].Children[0].IsBranch.ShouldBeFalse();
+
+        commandModel.Commands[0].Children[1].Name.ShouldBe(CliConstants.DefaultCommandName);
+        commandModel.Commands[0].Children[1].CommandType.ShouldBe(typeof(HorseCommand));
+        commandModel.Commands[0].Children[1].IsDefaultCommand.ShouldBeTrue();
+        commandModel.Commands[0].Children[1].IsBranch.ShouldBeFalse();
+
+        commandModel.Commands[1].ShouldNotBeNull();
+        commandModel.Commands[1].Name.ShouldBe(CliConstants.DefaultCommandName);
+        commandModel.Commands[1].CommandType.ShouldBe(typeof(EmptyCommand));
+        commandModel.Commands[1].IsDefaultCommand.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
This PR fully addresses #187, 'Allow default command configuration for a branch'.

Existing unit tests involving branch commands have been split out into a separate class, `CommandAppTests+Branches` and several new unit tests have been implemented to adequately cover the new default command configuration for a branch functionality.

Additionally, some unit test coverage of `CommandModelBuilder` (which didn't previously exist) has been added.

