### PR TITLE
1059 Ability to add command line values to remaining arguments if they cannot be set on the settings class

### DIFF
--- a/src/Spectre.Console.Cli/ICommandAppSettings.cs
+++ b/src/Spectre.Console.Cli/ICommandAppSettings.cs
@@ -47,6 +47,14 @@ public interface ICommandAppSettings
     bool StrictParsing { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether or not flags found on the commnd line
+    /// that would normally result in a <see cref="CommandParseException"/> being thrown
+    /// during parsing with the message "Flags cannot be assigned a value."
+    /// should instead be added to the remaining arguments collection.
+    /// </summary>
+    bool ConvertFlagsToRemainingArgumentsIfCannotBeAssigned { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether or not exceptions should be propagated.
     /// <para>Setting this to <c>true</c> will disable default Exception handling and
     /// any <see cref="ExceptionHandler"/>, if set.</para>

--- a/src/Spectre.Console.Cli/Internal/Configuration/CommandAppSettings.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/CommandAppSettings.cs
@@ -12,6 +12,7 @@ internal sealed class CommandAppSettings : ICommandAppSettings
     public bool ValidateExamples { get; set; }
     public bool TrimTrailingPeriod { get; set; } = true;
     public bool StrictParsing { get; set; }
+    public bool ConvertFlagsToRemainingArgumentsIfCannotBeAssigned { get; set; } = false;
 
     public ParsingMode ParsingMode =>
         StrictParsing ? ParsingMode.Strict : ParsingMode.Relaxed;

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParserContext.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParserContext.cs
@@ -30,15 +30,12 @@ internal class CommandTreeParserContext
 
     public void AddRemainingArgument(string key, string? value)
     {
-        if (State == CommandTreeParser.State.Remaining || ParsingMode == ParsingMode.Relaxed)
+        if (!_remaining.ContainsKey(key))
         {
-            if (!_remaining.ContainsKey(key))
-            {
-                _remaining.Add(key, new List<string?>());
-            }
-
-            _remaining[key].Add(value);
+            _remaining.Add(key, new List<string?>());
         }
+
+        _remaining[key].Add(value);
     }
 
     [SuppressMessage("Style", "IDE0004:Remove Unnecessary Cast", Justification = "Bug in analyzer?")]


### PR DESCRIPTION
This PR implements https://github.com/spectreconsole/spectre.console/issues/1059, 'Ability to add command line flags and their values to remaining arguments if they cannot be set on the settings class'

A configuration setting called ConvertFlagsToRemainingArgumentsIfCannotBeAssigned has been added to the CommandAppSettings interface/class, which determines whether this behaviour has been turned on (defaults to off to ensure backward compatibility). CommandTreeParser checks this setting prior to deciding whether to throw the Flags cannot be set. exception, or alternatively, to add the flag and its value to the remaining arguments collection.

This PR superceeds https://github.com/spectreconsole/spectre.console/pull/1060