### PR TITLE
Support command description localization

### DIFF
--- a/src/Spectre.Console.Cli/Annotations/LocalizationAttribute.cs
+++ b/src/Spectre.Console.Cli/Annotations/LocalizationAttribute.cs
@@ -1,0 +1,15 @@
+﻿namespace Spectre.Console.Cli;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
+public class LocalizationAttribute : Attribute
+{
+    /// <summary>
+    ///     A strongly-typed resource class, for looking up localized strings, etc.
+    /// </summary>
+    public Type ResourceClass { get; set; }
+
+    public LocalizationAttribute(Type resourceClass)
+    {
+        ResourceClass = resourceClass;
+    }
+}

--- a/src/Spectre.Console.Cli/Annotations/LocalizationAttribute.cs
+++ b/src/Spectre.Console.Cli/Annotations/LocalizationAttribute.cs
@@ -1,13 +1,22 @@
-﻿namespace Spectre.Console.Cli;
+namespace Spectre.Console.Cli;
 
+/// <summary>
+/// Indicates that a "Description" feature should display its localization description
+/// </summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Class)]
 public class LocalizationAttribute : Attribute
 {
     /// <summary>
-    ///     A strongly-typed resource class, for looking up localized strings, etc.
+    ///   Gets or Sets a strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
     public Type ResourceClass { get; set; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LocalizationAttribute"/> class.
+    /// </summary>
+    /// <param name="resourceClass">
+    ///      The type of the resource manager
+    /// </param>
     public LocalizationAttribute(Type resourceClass)
     {
         ResourceClass = resourceClass;

--- a/src/Spectre.Console.Cli/Internal/Extensions/LocalizationExtensions.cs
+++ b/src/Spectre.Console.Cli/Internal/Extensions/LocalizationExtensions.cs
@@ -1,0 +1,21 @@
+﻿namespace Spectre.Console.Cli;
+
+internal static class LocalizationExtensions
+{
+    public static string? LocalizedDescription(this MemberInfo me)
+    {
+        var description = me.GetCustomAttribute<DescriptionAttribute>();
+        if (description is null)
+        {
+            return null;
+        }
+
+        var localization = me.GetCustomAttribute<LocalizationAttribute>();
+        string? localizedText;
+        return (localizedText = localization?.ResourceClass
+            .GetProperty(description.Description)?
+            .GetValue(default) as string) != null
+            ? localizedText
+            : description.Description;
+    }
+}

--- a/src/Spectre.Console.Cli/Internal/Modelling/CommandInfo.cs
+++ b/src/Spectre.Console.Cli/Internal/Modelling/CommandInfo.cs
@@ -39,10 +39,10 @@ internal sealed class CommandInfo : ICommandContainer
 
         if (CommandType != null && string.IsNullOrWhiteSpace(Description))
         {
-            var description = CommandType.GetCustomAttribute<DescriptionAttribute>();
+            var description = CommandType.LocalizedDescription();
             if (description != null)
             {
-                Description = description.Description;
+                Description = description;
             }
         }
     }

--- a/src/Spectre.Console.Cli/Internal/Modelling/CommandModelBuilder.cs
+++ b/src/Spectre.Console.Cli/Internal/Modelling/CommandModelBuilder.cs
@@ -173,7 +173,7 @@ internal static class CommandModelBuilder
 
     private static CommandOption BuildOptionParameter(PropertyInfo property, CommandOptionAttribute attribute)
     {
-        var description = property.GetCustomAttribute<DescriptionAttribute>();
+        var description = property.LocalizedDescription();
         var converter = property.GetCustomAttribute<TypeConverterAttribute>();
         var deconstructor = property.GetCustomAttribute<PairDeconstructorAttribute>();
         var valueProvider = property.GetCustomAttribute<ParameterValueProviderAttribute>();
@@ -188,14 +188,14 @@ internal static class CommandModelBuilder
         }
 
         return new CommandOption(property.PropertyType, kind,
-            property, description?.Description, converter, deconstructor,
+            property, description, converter, deconstructor,
             attribute, valueProvider, validators, defaultValue,
             attribute.ValueIsOptional);
     }
 
     private static CommandArgument BuildArgumentParameter(PropertyInfo property, CommandArgumentAttribute attribute)
     {
-        var description = property.GetCustomAttribute<DescriptionAttribute>();
+        var description = property.LocalizedDescription();
         var converter = property.GetCustomAttribute<TypeConverterAttribute>();
         var defaultValue = property.GetCustomAttribute<DefaultValueAttribute>();
         var valueProvider = property.GetCustomAttribute<ParameterValueProviderAttribute>();
@@ -205,7 +205,7 @@ internal static class CommandModelBuilder
 
         return new CommandArgument(
             property.PropertyType, kind, property,
-            description?.Description, converter,
+            description, converter,
             defaultValue, attribute, valueProvider,
             validators);
     }


### PR DESCRIPTION
eg.
[CommandOption("-a|--args")]
[Description(nameof(Str.GitArgs))]
[Localization(typeof(Str))]
public string Args { get; set; }

The program will go to the autogenerated class "Str.designer.cs" of the Resx file, to looking for local value of the the resource symbol "GitArgs" , instead of displaying the original: "GitArgs"