### PR TITLE
Issue 411 - Alias for branches

### DIFF
--- a/src/Spectre.Console.Cli/ConfiguratorExtensions.cs
+++ b/src/Spectre.Console.Cli/ConfiguratorExtensions.cs
@@ -181,7 +181,8 @@ public static class ConfiguratorExtensions
     /// <param name="configurator">The configurator.</param>
     /// <param name="name">The name of the command branch.</param>
     /// <param name="action">The command branch configuration.</param>
-    public static void AddBranch(
+    /// <returns>A branch configurator that can be used to configure the command further.</returns>
+    public static IBranchConfigurator AddBranch(
         this IConfigurator configurator,
         string name,
         Action<IConfigurator<CommandSettings>> action)
@@ -191,7 +192,7 @@ public static class ConfiguratorExtensions
             throw new ArgumentNullException(nameof(configurator));
         }
 
-        configurator.AddBranch(name, action);
+        return configurator.AddBranch(name, action);
     }
 
     /// <summary>
@@ -201,7 +202,8 @@ public static class ConfiguratorExtensions
     /// <param name="configurator">The configurator.</param>
     /// <param name="name">The name of the command branch.</param>
     /// <param name="action">The command branch configuration.</param>
-    public static void AddBranch<TSettings>(
+    /// <returns>A branch configurator that can be used to configure the command further.</returns>
+    public static IBranchConfigurator AddBranch<TSettings>(
         this IConfigurator<TSettings> configurator,
         string name,
         Action<IConfigurator<TSettings>> action)
@@ -212,7 +214,7 @@ public static class ConfiguratorExtensions
             throw new ArgumentNullException(nameof(configurator));
         }
 
-        configurator.AddBranch(name, action);
+        return configurator.AddBranch(name, action);
     }
 
     /// <summary>

--- a/src/Spectre.Console.Cli/ConfiguratorExtensions.cs
+++ b/src/Spectre.Console.Cli/ConfiguratorExtensions.cs
@@ -181,7 +181,7 @@ public static class ConfiguratorExtensions
     /// <param name="configurator">The configurator.</param>
     /// <param name="name">The name of the command branch.</param>
     /// <param name="action">The command branch configuration.</param>
-    /// <returns>A branch configurator that can be used to configure the command further.</returns>
+    /// <returns>A branch configurator that can be used to configure the branch further.</returns>
     public static IBranchConfigurator AddBranch(
         this IConfigurator configurator,
         string name,
@@ -202,7 +202,7 @@ public static class ConfiguratorExtensions
     /// <param name="configurator">The configurator.</param>
     /// <param name="name">The name of the command branch.</param>
     /// <param name="action">The command branch configuration.</param>
-    /// <returns>A branch configurator that can be used to configure the command further.</returns>
+    /// <returns>A branch configurator that can be used to configure the branch further.</returns>
     public static IBranchConfigurator AddBranch<TSettings>(
         this IConfigurator<TSettings> configurator,
         string name,

--- a/src/Spectre.Console.Cli/IBranchConfigurator.cs
+++ b/src/Spectre.Console.Cli/IBranchConfigurator.cs
@@ -1,7 +1,7 @@
-﻿namespace Spectre.Console.Cli;
+namespace Spectre.Console.Cli;
 
 /// <summary>
-/// Represents a command configurator.
+/// Represents a branch configurator.
 /// </summary>
 public interface IBranchConfigurator
 {

--- a/src/Spectre.Console.Cli/IBranchConfigurator.cs
+++ b/src/Spectre.Console.Cli/IBranchConfigurator.cs
@@ -1,0 +1,14 @@
+﻿namespace Spectre.Console.Cli;
+
+/// <summary>
+/// Represents a command configurator.
+/// </summary>
+public interface IBranchConfigurator
+{
+    /// <summary>
+    /// Adds an alias (an alternative name) to the branch being configured.
+    /// </summary>
+    /// <param name="name">The alias to add to the branch being configured.</param>
+    /// <returns>The same <see cref="IBranchConfigurator"/> instance so that multiple calls can be chained.</returns>
+    IBranchConfigurator WithAlias(string name);
+}

--- a/src/Spectre.Console.Cli/IConfigurator.cs
+++ b/src/Spectre.Console.Cli/IConfigurator.cs
@@ -41,6 +41,7 @@ public interface IConfigurator
     /// <typeparam name="TSettings">The command setting type.</typeparam>
     /// <param name="name">The name of the command branch.</param>
     /// <param name="action">The command branch configurator.</param>
-    void AddBranch<TSettings>(string name, Action<IConfigurator<TSettings>> action)
+    /// <returns>A branch configurator that can be used to configure the branch further.</returns>
+    IBranchConfigurator AddBranch<TSettings>(string name, Action<IConfigurator<TSettings>> action)
         where TSettings : CommandSettings;
 }

--- a/src/Spectre.Console.Cli/IConfiguratorOfT.cs
+++ b/src/Spectre.Console.Cli/IConfiguratorOfT.cs
@@ -51,6 +51,7 @@ public interface IConfigurator<in TSettings>
     /// <typeparam name="TDerivedSettings">The derived command setting type.</typeparam>
     /// <param name="name">The name of the command branch.</param>
     /// <param name="action">The command branch configuration.</param>
+    /// <returns>A branch configurator that can be used to configure the branch further.</returns>
     IBranchConfigurator AddBranch<TDerivedSettings>(string name, Action<IConfigurator<TDerivedSettings>> action)
         where TDerivedSettings : TSettings;
 }

--- a/src/Spectre.Console.Cli/IConfiguratorOfT.cs
+++ b/src/Spectre.Console.Cli/IConfiguratorOfT.cs
@@ -51,6 +51,6 @@ public interface IConfigurator<in TSettings>
     /// <typeparam name="TDerivedSettings">The derived command setting type.</typeparam>
     /// <param name="name">The name of the command branch.</param>
     /// <param name="action">The command branch configuration.</param>
-    void AddBranch<TDerivedSettings>(string name, Action<IConfigurator<TDerivedSettings>> action)
+    IBranchConfigurator AddBranch<TDerivedSettings>(string name, Action<IConfigurator<TDerivedSettings>> action)
         where TDerivedSettings : TSettings;
 }

--- a/src/Spectre.Console.Cli/Internal/Configuration/BranchConfigurator.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/BranchConfigurator.cs
@@ -1,0 +1,17 @@
+﻿namespace Spectre.Console.Cli;
+
+internal sealed class BranchConfigurator : IBranchConfigurator
+{
+    public ConfiguredCommand Command { get; }
+
+    public BranchConfigurator(ConfiguredCommand command)
+    {
+        Command = command;
+    }
+
+    public IBranchConfigurator WithAlias(string alias)
+    {
+        Command.Aliases.Add(alias);
+        return this;
+    }
+}

--- a/src/Spectre.Console.Cli/Internal/Configuration/Configurator.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/Configurator.cs
@@ -47,12 +47,13 @@ internal sealed class Configurator : IUnsafeConfigurator, IConfigurator, IConfig
         return new CommandConfigurator(command);
     }
 
-    public void AddBranch<TSettings>(string name, Action<IConfigurator<TSettings>> action)
+    public IBranchConfigurator AddBranch<TSettings>(string name, Action<IConfigurator<TSettings>> action)
         where TSettings : CommandSettings
     {
         var command = ConfiguredCommand.FromBranch<TSettings>(name);
         action(new Configurator<TSettings>(command, _registrar));
-        Commands.Add(command);
+        var added = Commands.AddAndReturn(command);
+        return new BranchConfigurator(added);
     }
 
     ICommandConfigurator IUnsafeConfigurator.AddCommand(string name, Type command)
@@ -73,7 +74,7 @@ internal sealed class Configurator : IUnsafeConfigurator, IConfigurator, IConfig
         return result;
     }
 
-    void IUnsafeConfigurator.AddBranch(string name, Type settings, Action<IUnsafeBranchConfigurator> action)
+    IBranchConfigurator IUnsafeConfigurator.AddBranch(string name, Type settings, Action<IUnsafeBranchConfigurator> action)
     {
         var command = ConfiguredCommand.FromBranch(settings, name);
 
@@ -85,6 +86,7 @@ internal sealed class Configurator : IUnsafeConfigurator, IConfigurator, IConfig
         }
 
         action(configurator);
-        Commands.Add(command);
+        var added = Commands.AddAndReturn(command);
+        return new BranchConfigurator(added);
     }
 }

--- a/src/Spectre.Console.Cli/Internal/Configuration/ConfiguratorOfT.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/ConfiguratorOfT.cs
@@ -47,12 +47,13 @@ internal sealed class Configurator<TSettings> : IUnsafeBranchConfigurator, IConf
         return new CommandConfigurator(command);
     }
 
-    public void AddBranch<TDerivedSettings>(string name, Action<IConfigurator<TDerivedSettings>> action)
+    public IBranchConfigurator AddBranch<TDerivedSettings>(string name, Action<IConfigurator<TDerivedSettings>> action)
         where TDerivedSettings : TSettings
     {
         var command = ConfiguredCommand.FromBranch<TDerivedSettings>(name);
         action(new Configurator<TDerivedSettings>(command, _registrar));
-        _command.Children.Add(command);
+        var added = _command.Children.AddAndReturn(command);
+        return new BranchConfigurator(added);
     }
 
     ICommandConfigurator IUnsafeConfigurator.AddCommand(string name, Type command)
@@ -73,7 +74,7 @@ internal sealed class Configurator<TSettings> : IUnsafeBranchConfigurator, IConf
         return result;
     }
 
-    void IUnsafeConfigurator.AddBranch(string name, Type settings, Action<IUnsafeBranchConfigurator> action)
+    IBranchConfigurator IUnsafeConfigurator.AddBranch(string name, Type settings, Action<IUnsafeBranchConfigurator> action)
     {
         var command = ConfiguredCommand.FromBranch(settings, name);
 
@@ -85,6 +86,7 @@ internal sealed class Configurator<TSettings> : IUnsafeBranchConfigurator, IConf
         }
 
         action(configurator);
-        _command.Children.Add(command);
+        var added = _command.Children.AddAndReturn(command);
+        return new BranchConfigurator(added);
     }
 }

--- a/src/Spectre.Console.Cli/Unsafe/IUnsafeConfigurator.cs
+++ b/src/Spectre.Console.Cli/Unsafe/IUnsafeConfigurator.cs
@@ -19,5 +19,5 @@ public interface IUnsafeConfigurator
     /// <param name="name">The name of the command branch.</param>
     /// <param name="settings">The command setting type.</param>
     /// <param name="action">The command branch configurator.</param>
-    void AddBranch(string name, Type settings, Action<IUnsafeBranchConfigurator> action);
+    IBranchConfigurator AddBranch(string name, Type settings, Action<IUnsafeBranchConfigurator> action);
 }

--- a/src/Spectre.Console.Cli/Unsafe/IUnsafeConfigurator.cs
+++ b/src/Spectre.Console.Cli/Unsafe/IUnsafeConfigurator.cs
@@ -19,5 +19,6 @@ public interface IUnsafeConfigurator
     /// <param name="name">The name of the command branch.</param>
     /// <param name="settings">The command setting type.</param>
     /// <param name="action">The command branch configurator.</param>
+    /// <returns>A branch configurator that can be used to configure the branch further.</returns>
     IBranchConfigurator AddBranch(string name, Type settings, Action<IUnsafeBranchConfigurator> action);
 }


### PR DESCRIPTION
Hello there!

Fixes #411 - Adding aliases to branches

Sample usage
```csharp
var app = new CommandApp();
app.Configure(config =>
{
    config.AddBranch<AnimalSettings>("animal", animal =>
    {
        animal.AddCommand<DogCommand>("dog");
        animal.AddCommand<HorseCommand>("horse");
    }).WithAlias("a");
});
```

First PR here (and ever in open source). Any help or guidance appreciated