### PR TITLE
Can render command help and application version from inside a command

### DIFF
--- a/src/Spectre.Console.Cli/CommandContext.cs
+++ b/src/Spectre.Console.Cli/CommandContext.cs
@@ -3,7 +3,7 @@ namespace Spectre.Console.Cli;
 /// <summary>
 /// Represents a command context.
 /// </summary>
-public sealed class CommandContext
+public sealed class CommandContext : IHelpProvider
 {
     /// <summary>
     /// Gets the remaining arguments.
@@ -29,6 +29,14 @@ public sealed class CommandContext
     /// </value>
     public object? Data { get; }
 
+    /// <inheritdoc/>
+    public IEnumerable<IRenderable> Help { get; }
+
+    /// <summary>
+    /// Gets the application version.
+    /// </summary>
+    public string? ApplicationVersion { get; }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="CommandContext"/> class.
     /// </summary>
@@ -40,5 +48,24 @@ public sealed class CommandContext
         Remaining = remaining ?? throw new System.ArgumentNullException(nameof(remaining));
         Name = name ?? throw new System.ArgumentNullException(nameof(name));
         Data = data;
+        Help = Array.Empty<IRenderable>();
+        ApplicationVersion = string.Empty;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandContext"/> class.
+    /// </summary>
+    /// <param name="remaining">The remaining arguments.</param>
+    /// <param name="name">The command name.</param>
+    /// <param name="data">The command data.</param>
+    /// <param name="help">The help text for the command.</param>
+    /// <param name="applicationVersion">The application version.</param>
+    public CommandContext(IRemainingArguments remaining, string name, object? data, IEnumerable<IRenderable> help, string applicationVersion)
+    {
+        Remaining = remaining ?? throw new System.ArgumentNullException(nameof(remaining));
+        Name = name ?? throw new System.ArgumentNullException(nameof(name));
+        Data = data;
+        Help = help;
+        ApplicationVersion = applicationVersion;
     }
 }

--- a/src/Spectre.Console.Cli/IHelpProvider.cs
+++ b/src/Spectre.Console.Cli/IHelpProvider.cs
@@ -1,0 +1,15 @@
+namespace Spectre.Console.Cli;
+
+/// <summary>
+/// Represents the help provider.
+/// </summary>
+public interface IHelpProvider
+{
+    /// <summary>
+    /// Gets the help text.
+    /// </summary>
+    /// <remarks>
+    /// The help text is formatted and ready to be rendered.
+    /// </remarks>
+    IEnumerable<IRenderable> Help { get; }
+}

--- a/src/Spectre.Console.Cli/Internal/HelpWriter.cs
+++ b/src/Spectre.Console.Cli/Internal/HelpWriter.cs
@@ -1,7 +1,24 @@
 namespace Spectre.Console.Cli;
 
-internal static class HelpWriter
+internal class HelpWriter : IHelpProvider
 {
+    /// <inheritdoc/>
+    public IEnumerable<IRenderable> Help { get; }
+
+    public HelpWriter(CommandModel model, CommandTreeParserResult parsedResult, bool showOptionDefaultValues)
+    {
+        if (parsedResult.Tree == null)
+        {
+            Help = Write(model, showOptionDefaultValues);
+        }
+        else
+        {
+            var leaf = parsedResult.Tree.GetLeafCommand();
+
+            Help = WriteCommand(model, leaf.Command, showOptionDefaultValues);
+        }
+    }
+
     private sealed class HelpArgument
     {
         public string Name { get; }
@@ -67,12 +84,12 @@ internal static class HelpWriter
         }
     }
 
-    public static IEnumerable<IRenderable> Write(CommandModel model, bool writeOptionsDefaultValues)
+    private static IEnumerable<IRenderable> Write(CommandModel model, bool writeOptionsDefaultValues)
     {
         return WriteCommand(model, null, writeOptionsDefaultValues);
     }
 
-    public static IEnumerable<IRenderable> WriteCommand(CommandModel model, CommandInfo? command, bool writeOptionsDefaultValues)
+    private static IEnumerable<IRenderable> WriteCommand(CommandModel model, CommandInfo? command, bool writeOptionsDefaultValues)
     {
         var container = command as ICommandContainer ?? model;
         var isDefaultCommand = command?.IsDefaultCommand ?? false;

--- a/test/Spectre.Console.Cli.Tests/Data/Commands/DefaultCommand.cs
+++ b/test/Spectre.Console.Cli.Tests/Data/Commands/DefaultCommand.cs
@@ -1,0 +1,35 @@
+namespace Spectre.Console.Tests.Data;
+
+/// <summary>
+/// Represents a command that renders a custom bannder, and then help text and the application version.
+/// </summary>
+/// <remarks>
+/// A good example of the behaviour that some spectre.console users would like from their application default command.
+/// </remarks>
+public sealed class DefaultCommand : Command<EmptyCommandSettings>
+{
+    private readonly IAnsiConsole _console;
+
+    public DefaultCommand(IAnsiConsole console)
+    {
+        _console = console;
+    }
+
+    public override int Execute(CommandContext context, EmptyCommandSettings settings)
+    {
+        // Fancy application banner.
+        _console.WriteLine("----------------------------------");
+        _console.WriteLine("---      DEFAULT COMMAND       ---");
+        _console.WriteLine("----------------------------------");
+        _console.WriteLine();
+
+        // Command help.
+        _console.SafeRender(context.Help);
+        _console.WriteLine();
+
+        // Application version.
+        _console.MarkupLine("Version {0}", context.ApplicationVersion);
+
+        return 0;
+    }
+}

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/CommandContext/Help_DefaultCommand.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/CommandContext/Help_DefaultCommand.Output.verified.txt
@@ -1,0 +1,14 @@
+----------------------------------
+---      DEFAULT COMMAND       ---
+----------------------------------
+
+USAGE:
+    myapp [OPTIONS]
+
+OPTIONS:
+    -h, --help    Prints help information
+
+COMMANDS:
+    dog <AGE>    The dog command
+
+Version 1.1.0

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/CommandContext/Help_DefaultCommand_With_Branch.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/CommandContext/Help_DefaultCommand_With_Branch.Output.verified.txt
@@ -1,0 +1,14 @@
+----------------------------------
+---      DEFAULT COMMAND       ---
+----------------------------------
+
+USAGE:
+    myapp [OPTIONS]
+
+OPTIONS:
+    -h, --help    Prints help information
+
+COMMANDS:
+    animal <AGE>
+
+Version 1.1.0

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
@@ -8,6 +8,58 @@ public sealed partial class CommandAppTests
     [ExpectationPath("Help")]
     public class Help
     {
+        [UsesVerify]
+        [ExpectationPath("CommandContext")]
+        public class CommandContext
+        {
+            [Fact]
+            [Expectation("Help_DefaultCommand")]
+            public Task Should_Output_Help_Correctly_DefaultCommand()
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.SetDefaultCommand<DefaultCommand>();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationName("myapp");
+                    configurator.SetApplicationVersion("1.1.0");
+
+                    configurator.AddCommand<DogCommand>("dog");
+                });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                return Verifier.Verify(result.Output);
+            }
+
+            [Fact]
+            [Expectation("Help_DefaultCommand_With_Branch")]
+            public Task Should_Output_Help_Correctly_DefaultCommand_With_Branch()
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.SetDefaultCommand<DefaultCommand>();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationName("myapp");
+                    configurator.SetApplicationVersion("1.1.0");
+
+                    configurator.AddBranch<DogSettings>("animal", animal =>
+                    {
+                        animal.AddCommand<DogCommand>("dog");
+                    });
+                });
+
+                // When
+                var result = fixture.Run();
+
+                // Then
+                return Verifier.Verify(result.Output);
+            }
+        }
+
         [Fact]
         [Expectation("Root")]
         public Task Should_Output_Root_Correctly()


### PR DESCRIPTION
Fully implements https://github.com/spectreconsole/spectre.console/issues/702

---

Also, starts to introduce a clean entry point for allowing spectre.console users (in the future) to override the default HelpWriter with their own implementation, here is where the DI will need to happen, `Spectre.Console.Cli.CommandExecutor` line 54: 

```csharp
var helpProvider = new HelpWriter(model, parsedResult, configuration.Settings.ShowOptionDefaultValues) as IHelpProvider;
```