### PR TITLE
Alignment => Justification Docs Fixes

### DIFF
--- a/docs/input/widgets/figlet.md
+++ b/docs/input/widgets/figlet.md
@@ -12,7 +12,7 @@ Spectre.Console can render [FIGlet](http://www.figlet.org/) text by using the `F
 ```csharp
 AnsiConsole.Write(
     new FigletText("Hello")
-        .LeftAligned()
+        .LeftJustified()
         .Color(Color.Red));
 ```
 
@@ -26,6 +26,6 @@ var font = FigletFont.Load("starwars.flf");
 
 AnsiConsole.Write(
     new FigletText(font, "Hello")
-        .LeftAligned()
+        .LeftJustified()
         .Color(Color.Red));
 ```

--- a/docs/input/widgets/grid.md
+++ b/docs/input/widgets/grid.md
@@ -45,16 +45,16 @@ grid.AddColumn();
 
 // Add header row 
 grid.AddRow(new Text[]{
-    new Text("Header 1", new Style(Color.Red, Color.Black)).LeftAligned(),
+    new Text("Header 1", new Style(Color.Red, Color.Black)).LeftJustified(),
     new Text("Header 2", new Style(Color.Green, Color.Black)).Centered(),
-    new Text("Header 3", new Style(Color.Blue, Color.Black)).RightAligned()
+    new Text("Header 3", new Style(Color.Blue, Color.Black)).RightJustified()
 });
 
 // Add content row 
 grid.AddRow(new Text[]{
-    new Text("Row 1").LeftAligned(),
+    new Text("Row 1").LeftJustified(),
     new Text("Row 2").Centered(),
-    new Text("Row 3").RightAligned()
+    new Text("Row 3").RightJustified()
 });
 
 // Write centered cell grid contents to Console
@@ -73,9 +73,9 @@ grid.AddColumn();
 
 // Add header row 
 grid.AddRow(new Text[]{
-    new Text("Header 1", new Style(Color.Red, Color.Black)).LeftAligned(),
+    new Text("Header 1", new Style(Color.Red, Color.Black)).LeftJustified(),
     new Text("Header 2", new Style(Color.Green, Color.Black)).Centered(),
-    new Text("Header 3", new Style(Color.Blue, Color.Black)).RightAligned()
+    new Text("Header 3", new Style(Color.Blue, Color.Black)).RightJustified()
 });
 
 var embedded = new Grid();
@@ -88,7 +88,7 @@ embedded.AddRow(new Text("Embedded III"), new Text("Embedded IV"));
 
 // Add content row 
 grid.AddRow(
-    new Text("Row 1").LeftAligned(),
+    new Text("Row 1").LeftJustified(),
     new Text("Row 2").Centered(),
     embedded
 );

--- a/docs/input/widgets/rule.md
+++ b/docs/input/widgets/rule.md
@@ -53,7 +53,7 @@ You can also specify it via an extension method:
 
 ```csharp
 var rule = new Rule("[red]Hello[/]");
-rule.LeftAligned();
+rule.LeftJustified();
 AnsiConsole.Write(rule);
 ```
 

--- a/docs/input/widgets/text-path.md
+++ b/docs/input/widgets/text-path.md
@@ -34,7 +34,7 @@ You can also specify styles via extension methods:
 
 ```csharp
 var path = new TextPath("C:/This/Path/Is/Too/Long/To/Fit/In/The/Area.txt")
-    .RightAligned();
+    .RightJustified();
 ```
 
 ## Styling


### PR DESCRIPTION
The documentation for the `Figlet`, `Text`, `TextPath`, and `Rule` classes include examples that use `LeftAligned()` and `RightAligned()`, instead of the currently available `LeftJustified()` and `RightJustified()` methods on the latest version (`v0.46.0`) of this library. 

The changes here just update the docs to match what's currently available on these classes. 😄