### PR TITLE
Add support for converting command parameters into FileInfo and DirectoryInfo

### DIFF
--- a/test/Spectre.Console.Cli.Tests/Data/Settings/HorseSettings.cs
+++ b/test/Spectre.Console.Cli.Tests/Data/Settings/HorseSettings.cs
@@ -1,7 +1,15 @@
+using System.IO;
+
 namespace Spectre.Console.Tests.Data;
 
 public class HorseSettings : MammalSettings
 {
     [CommandOption("-d|--day")]
     public DayOfWeek Day { get; set; }
+
+    [CommandOption("--file")]
+    public FileInfo File { get; set; }
+
+    [CommandOption("--directory")]
+    public DirectoryInfo Directory { get; set; }
 }

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_1.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_1.Output.verified.txt
@@ -30,6 +30,8 @@
       <Command Name="horse" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
         <Parameters>
           <Option Short="d" Long="day" Value="NULL" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
+          <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />
+          <Option Short="" Long="file" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.FileInfo" />
         </Parameters>
       </Command>
     </Command>

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_3.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_3.Output.verified.txt
@@ -26,6 +26,8 @@
     <Command Name="horse" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
       <Parameters>
         <Option Short="d" Long="day" Value="NULL" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
+        <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />
+        <Option Short="" Long="file" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.FileInfo" />
         <Option Short="n,p" Long="name,pet-name" Value="VALUE" Required="false" Kind="scalar" ClrType="System.String" />
       </Parameters>
     </Command>

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_6.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_6.Output.verified.txt
@@ -32,6 +32,8 @@
         <Description>Indicates whether or not the animal is alive.</Description>
       </Option>
       <Option Short="d" Long="day" Value="NULL" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
+      <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />
+      <Option Short="" Long="file" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.FileInfo" />
       <Option Short="n,p" Long="name,pet-name" Value="VALUE" Required="false" Kind="scalar" ClrType="System.String" />
     </Parameters>
   </Command>

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.TypeConverters.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.TypeConverters.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 namespace Spectre.Console.Tests.Unit.Cli;
 
 public sealed partial class CommandAppTests
@@ -75,6 +77,28 @@ public sealed partial class CommandAppTests
             result.Output.ShouldContain(nameof(DayOfWeek.Thursday));
             result.Output.ShouldContain(nameof(DayOfWeek.Friday));
             result.Output.ShouldContain(nameof(DayOfWeek.Saturday));
+        }
+
+        [Fact]
+        public void Should_Convert_FileInfo_And_DirectoryInfo()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.AddCommand<HorseCommand>("horse");
+            });
+
+            // When
+            var result = app.Run(new[] { "horse", "--file", "ntp.conf", "--directory", "etc" });
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<HorseSettings>().And(horse =>
+            {
+                horse.File.Name.ShouldBe("ntp.conf");
+                horse.Directory.Name.ShouldBe("etc");
+            });
         }
     }
 }


### PR DESCRIPTION
And actually any type that doesn't have a builtin TypeConverter but has a constructor that takes a string. For CLI apps, FileInfo and DirectoryInfo will likely be the most useful ones.