### PR TITLE
Ensure correct comparer is used for `TextPrompt`

### DIFF
--- a/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
+++ b/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
@@ -63,7 +63,8 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
     /// <inheritdoc/>
     public async Task<bool> ShowAsync(IAnsiConsole console, CancellationToken cancellationToken)
     {
-        var prompt = new TextPrompt<char>(_prompt)
+        var comparer = CaseInsensitive ? StringComparer.CurrentCultureIgnoreCase : StringComparer.CurrentCulture;
+        var prompt = new TextPrompt<char>(_prompt, comparer)
             .InvalidChoiceMessage(InvalidChoiceMessage)
             .ValidationErrorMessage(InvalidChoiceMessage)
             .ShowChoices(ShowChoices)


### PR DESCRIPTION
Follow up to #1151, to correctly capture the response, the correct comparer needs to be used for `TextPrompt` choices. Verified this now works as expected.