### PR TITLE
Allow configuration of confirmation prompt comparison via `StringComparer`

### DIFF
--- a/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
+++ b/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
@@ -40,10 +40,13 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
     public bool ShowDefaultValue { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether the confirmation
-    /// should use case insensitive matching.
+    /// Gets or sets the string comparer to use when comparing user input
+    /// against Yes/No choices.
     /// </summary>
-    public bool CaseInsensitive { get; set; } = true;
+    /// <remarks>
+    /// Defaults to <see cref="StringComparer.CurrentCultureIgnoreCase"/>.
+    /// </remarks>
+    public StringComparer ChoiceComparer { get; set; } = StringComparer.CurrentCultureIgnoreCase;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConfirmationPrompt"/> class.
@@ -63,8 +66,7 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
     /// <inheritdoc/>
     public async Task<bool> ShowAsync(IAnsiConsole console, CancellationToken cancellationToken)
     {
-        var comparer = CaseInsensitive ? StringComparer.CurrentCultureIgnoreCase : StringComparer.CurrentCulture;
-        var prompt = new TextPrompt<char>(_prompt, comparer)
+        var prompt = new TextPrompt<char>(_prompt, ChoiceComparer)
             .InvalidChoiceMessage(InvalidChoiceMessage)
             .ValidationErrorMessage(InvalidChoiceMessage)
             .ShowChoices(ShowChoices)
@@ -75,6 +77,6 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
 
         var result = await prompt.ShowAsync(console, cancellationToken).ConfigureAwait(false);
 
-        return Yes.ToString().Equals(result.ToString(), CaseInsensitive ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture);
+        return ChoiceComparer.Compare(Yes.ToString(), result.ToString()) == 0;
     }
 }

--- a/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
+++ b/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
@@ -46,7 +46,7 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
     /// <remarks>
     /// Defaults to <see cref="StringComparer.CurrentCultureIgnoreCase"/>.
     /// </remarks>
-    public StringComparer ChoiceComparer { get; set; } = StringComparer.CurrentCultureIgnoreCase;
+    public StringComparer Comparer { get; set; } = StringComparer.CurrentCultureIgnoreCase;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ConfirmationPrompt"/> class.
@@ -66,7 +66,9 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
     /// <inheritdoc/>
     public async Task<bool> ShowAsync(IAnsiConsole console, CancellationToken cancellationToken)
     {
-        var prompt = new TextPrompt<char>(_prompt, ChoiceComparer)
+        var comparer = Comparer ?? StringComparer.CurrentCultureIgnoreCase;
+
+        var prompt = new TextPrompt<char>(_prompt, comparer)
             .InvalidChoiceMessage(InvalidChoiceMessage)
             .ValidationErrorMessage(InvalidChoiceMessage)
             .ShowChoices(ShowChoices)
@@ -77,6 +79,6 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
 
         var result = await prompt.ShowAsync(console, cancellationToken).ConfigureAwait(false);
 
-        return ChoiceComparer.Compare(Yes.ToString(), result.ToString()) == 0;
+        return comparer.Compare(Yes.ToString(), result.ToString()) == 0;
     }
 }


### PR DESCRIPTION
Based on suggestion from @0xced https://github.com/spectreconsole/spectre.console/pull/1151#issuecomment-1426768481 👍