### PR TITLE
Add ability to pass example args using `params` syntax

### DIFF
--- a/docs/input/cli/commands.md
+++ b/docs/input/cli/commands.md
@@ -37,8 +37,8 @@ app.Configure(config =>
     config.AddCommand<HelloCommand>("hello")
         .WithAlias("hola")
         .WithDescription("Say hello")
-        .WithExample(new []{"hello", "Phil"})
-        .WithExample(new []{"hello", "Phil", "--count", "4"});
+        .WithExample("hello", "Phil")
+        .WithExample("hello", "Phil", "--count", "4");
 });
 ```
 

--- a/src/Spectre.Console.Cli/ICommandConfigurator.cs
+++ b/src/Spectre.Console.Cli/ICommandConfigurator.cs
@@ -10,7 +10,7 @@ public interface ICommandConfigurator
     /// </summary>
     /// <param name="args">The example arguments.</param>
     /// <returns>The same <see cref="ICommandConfigurator"/> instance so that multiple calls can be chained.</returns>
-    ICommandConfigurator WithExample(string[] args);
+    ICommandConfigurator WithExample(params string[] args);
 
     /// <summary>
     /// Adds an alias (an alternative name) to the command being configured.

--- a/src/Spectre.Console.Cli/IConfigurator.cs
+++ b/src/Spectre.Console.Cli/IConfigurator.cs
@@ -14,7 +14,7 @@ public interface IConfigurator
     /// Adds an example of how to use the application.
     /// </summary>
     /// <param name="args">The example arguments.</param>
-    void AddExample(string[] args);
+    void AddExample(params string[] args);
 
     /// <summary>
     /// Adds a command.

--- a/src/Spectre.Console.Cli/Internal/Configuration/CommandConfigurator.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/CommandConfigurator.cs
@@ -9,7 +9,7 @@ internal sealed class CommandConfigurator : ICommandConfigurator
         Command = command;
     }
 
-    public ICommandConfigurator WithExample(string[] args)
+    public ICommandConfigurator WithExample(params string[] args)
     {
         Command.Examples.Add(args);
         return this;

--- a/src/Spectre.Console.Cli/Internal/Configuration/Configurator.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/Configurator.cs
@@ -20,7 +20,7 @@ internal sealed class Configurator : IUnsafeConfigurator, IConfigurator, IConfig
         Examples = new List<string[]>();
     }
 
-    public void AddExample(string[] args)
+    public void AddExample(params string[] args)
     {
         Examples.Add(args);
     }

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
@@ -1,5 +1,3 @@
-using Spectre.Console.Cli;
-
 namespace Spectre.Console.Tests.Unit.Cli;
 
 public sealed partial class CommandAppTests
@@ -41,7 +39,7 @@ public sealed partial class CommandAppTests
                 configurator.AddCommand<DogCommand>("dog");
                 configurator.AddCommand<HorseCommand>("horse");
                 configurator.AddCommand<GiraffeCommand>("giraffe")
-                    .WithExample(new[] { "giraffe", "123" })
+                    .WithExample("giraffe", "123")
                     .IsHidden();
             });
 
@@ -64,7 +62,7 @@ public sealed partial class CommandAppTests
                 configurator.AddCommand<DogCommand>("dog");
                 configurator.AddCommand<HorseCommand>("horse");
                 configurator.AddCommand<GiraffeCommand>("giraffe")
-                    .WithExample(new[] { "giraffe", "123" })
+                    .WithExample("giraffe", "123")
                     .IsHidden();
                 configurator.TrimTrailingPeriods(false);
             });
@@ -232,8 +230,8 @@ public sealed partial class CommandAppTests
             fixture.Configure(configurator =>
             {
                 configurator.SetApplicationName("myapp");
-                configurator.AddExample(new[] { "dog", "--name", "Rufus", "--age", "12", "--good-boy" });
-                configurator.AddExample(new[] { "horse", "--name", "Brutus" });
+                configurator.AddExample("dog", "--name", "Rufus", "--age", "12", "--good-boy");
+                configurator.AddExample("horse", "--name", "Brutus");
                 configurator.AddCommand<DogCommand>("dog");
                 configurator.AddCommand<HorseCommand>("horse");
             });
@@ -255,9 +253,9 @@ public sealed partial class CommandAppTests
             {
                 configurator.SetApplicationName("myapp");
                 configurator.AddCommand<DogCommand>("dog")
-                    .WithExample(new[] { "dog", "--name", "Rufus", "--age", "12", "--good-boy" });
+                    .WithExample("dog", "--name", "Rufus", "--age", "12", "--good-boy");
                 configurator.AddCommand<HorseCommand>("horse")
-                    .WithExample(new[] { "horse", "--name", "Brutus" });
+                    .WithExample("horse", "--name", "Brutus");
             });
 
             // When
@@ -280,9 +278,9 @@ public sealed partial class CommandAppTests
                 {
                     animal.SetDescription("The animal command.");
                     animal.AddCommand<DogCommand>("dog")
-                        .WithExample(new[] { "animal", "dog", "--name", "Rufus", "--age", "12", "--good-boy" });
+                        .WithExample("animal", "dog", "--name", "Rufus", "--age", "12", "--good-boy");
                     animal.AddCommand<HorseCommand>("horse")
-                        .WithExample(new[] { "animal", "horse", "--name", "Brutus" });
+                        .WithExample("animal", "horse", "--name", "Brutus");
                 });
             });
 
@@ -308,9 +306,9 @@ public sealed partial class CommandAppTests
                     animal.AddExample(new[] { "animal", "--help" });
 
                     animal.AddCommand<DogCommand>("dog")
-                        .WithExample(new[] { "animal", "dog", "--name", "Rufus", "--age", "12", "--good-boy" });
+                        .WithExample("animal", "dog", "--name", "Rufus", "--age", "12", "--good-boy");
                     animal.AddCommand<HorseCommand>("horse")
-                        .WithExample(new[] { "animal", "horse", "--name", "Brutus" });
+                        .WithExample("animal", "horse", "--name", "Brutus");
                 });
             });
 
@@ -331,7 +329,7 @@ public sealed partial class CommandAppTests
             fixture.Configure(configurator =>
             {
                 configurator.SetApplicationName("myapp");
-                configurator.AddExample(new[] { "12", "-c", "3" });
+                configurator.AddExample("12", "-c", "3");
             });
 
             // When


### PR DESCRIPTION
The most used way of specifying the examples is by hardcoding values. So it will be much easier without additional `new [] { ... }` syntax noise, but with the same outcome.

With `params` you are still able to specify items as an array, so the compatibility is kept.