### PR TITLE
Make the code fix more robust and detect more symbols of type IAnsiConsole

### DIFF
--- a/src/Spectre.Console.Analyzer/Fixes/FixProviders/StaticAnsiConsoleToInstanceFix.cs
+++ b/src/Spectre.Console.Analyzer/Fixes/FixProviders/StaticAnsiConsoleToInstanceFix.cs
@@ -20,7 +20,7 @@ public class StaticAnsiConsoleToInstanceFix : CodeFixProvider
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
         if (root != null)
         {
-            var methodDeclaration = root.FindNode(context.Span).FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            var methodDeclaration = root.FindNode(context.Span, getInnermostNodeForTie: true).FirstAncestorOrSelf<InvocationExpressionSyntax>();
             if (methodDeclaration != null)
             {
                 context.RegisterCodeFix(

--- a/test/Spectre.Console.Analyzer.Tests/SpectreAnalyzerVerifier.cs
+++ b/test/Spectre.Console.Analyzer.Tests/SpectreAnalyzerVerifier.cs
@@ -4,13 +4,20 @@ public static class SpectreAnalyzerVerifier<TAnalyzer>
     where TAnalyzer : DiagnosticAnalyzer, new()
 {
     public static Task VerifyCodeFixAsync(string source, DiagnosticResult expected, string fixedSource)
-        => VerifyCodeFixAsync(source, new[] { expected }, fixedSource);
+        => VerifyCodeFixAsync(source, OutputKind.DynamicallyLinkedLibrary, new[] { expected }, fixedSource);
 
-    private static Task VerifyCodeFixAsync(string source, IEnumerable<DiagnosticResult> expected, string fixedSource)
+    public static Task VerifyCodeFixAsync(string source, OutputKind outputKind, DiagnosticResult expected, string fixedSource)
+        => VerifyCodeFixAsync(source, outputKind, new[] { expected }, fixedSource);
+
+    private static Task VerifyCodeFixAsync(string source, OutputKind outputKind, IEnumerable<DiagnosticResult> expected, string fixedSource)
     {
         var test = new Test
         {
             TestCode = source,
+            TestState =
+            {
+                OutputKind = outputKind,
+            },
             FixedCode = fixedSource,
         };
 

--- a/test/Spectre.Console.Analyzer.Tests/Unit/Fixes/UseSpectreInsteadOfSystemConsoleFixTests.cs
+++ b/test/Spectre.Console.Analyzer.Tests/Unit/Fixes/UseSpectreInsteadOfSystemConsoleFixTests.cs
@@ -139,4 +139,25 @@ class TestClass
             .VerifyCodeFixAsync(Source, _expectedDiagnostic.WithLocation(11, 9), FixedSource)
             .ConfigureAwait(false);
     }
+
+    [Fact]
+    public async Task SystemConsole_replaced_with_AnsiConsole_in_top_level_statements()
+    {
+        const string Source = @"
+using System;
+
+Console.WriteLine(""Hello, World"");
+";
+
+        const string FixedSource = @"
+using System;
+using Spectre.Console;
+
+AnsiConsole.WriteLine(""Hello, World"");
+";
+
+        await SpectreAnalyzerVerifier<UseSpectreInsteadOfSystemConsoleAnalyzer>
+            .VerifyCodeFixAsync(Source, OutputKind.ConsoleApplication, _expectedDiagnostic.WithLocation(4, 1), FixedSource)
+            .ConfigureAwait(false);
+    }
 }


### PR DESCRIPTION
- Use `DocumentEditor` and `Generator`, so it can avoid using the `SyntaxFactory`
- Use the `SemanticModel` to find available symbols
  - Find local variables, parameters, fields, properties (with getter)
  - Improve `IAnsiConsole` comparisons as it uses the `SemanticModel` instead of checking the name
 
Note: This PR is based on https://github.com/spectreconsole/spectre.console/pull/1168. So, you can merge this one if you prefer, it includes the fix from the other MR. If you merge the other one first, I'll rebase this PR.