### PR TITLE
Do not register analyzer if SpectreConsole is not available in the current compilation

### DIFF
--- a/src/Spectre.Console.Analyzer/Analyzers/FavorInstanceAnsiConsoleOverStaticAnalyzer.cs
+++ b/src/Spectre.Console.Analyzer/Analyzers/FavorInstanceAnsiConsoleOverStaticAnalyzer.cs
@@ -16,11 +16,15 @@ public class FavorInstanceAnsiConsoleOverStaticAnalyzer : SpectreAnalyzer
     /// <inheritdoc />
     protected override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext)
     {
+        var ansiConsoleType = compilationStartContext.Compilation.GetTypeByMetadataName("Spectre.Console.AnsiConsole");
+        if (ansiConsoleType == null)
+        {
+            return;
+        }
+
         compilationStartContext.RegisterOperationAction(
             context =>
             {
-                var ansiConsoleType = context.Compilation.GetTypeByMetadataName("Spectre.Console.AnsiConsole");
-
                 // if this operation isn't an invocation against one of the System.Console methods
                 // defined in _methods then we can safely stop analyzing and return;
                 var invocationOperation = (IInvocationOperation)context.Operation;

--- a/src/Spectre.Console.Analyzer/Analyzers/NoConcurrentLiveRenderablesAnalyzer.cs
+++ b/src/Spectre.Console.Analyzer/Analyzers/NoConcurrentLiveRenderablesAnalyzer.cs
@@ -17,6 +17,16 @@ public class NoConcurrentLiveRenderablesAnalyzer : SpectreAnalyzer
     /// <inheritdoc />
     protected override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext)
     {
+        var liveTypes = Constants.LiveRenderables
+            .Select(i => compilationStartContext.Compilation.GetTypeByMetadataName(i))
+            .Where(i => i != null)
+            .ToImmutableArray();
+
+        if (liveTypes.Length == 0)
+        {
+            return;
+        }
+
         compilationStartContext.RegisterOperationAction(
             context =>
             {
@@ -28,10 +38,6 @@ public class NoConcurrentLiveRenderablesAnalyzer : SpectreAnalyzer
                 {
                     return;
                 }
-
-                var liveTypes = Constants.LiveRenderables
-                    .Select(i => context.Compilation.GetTypeByMetadataName(i))
-                    .ToImmutableArray();
 
                 if (liveTypes.All(i => !SymbolEqualityComparer.Default.Equals(i, methodSymbol.ContainingType)))
                 {

--- a/src/Spectre.Console.Analyzer/Analyzers/NoPromptsDuringLiveRenderablesAnalyzer.cs
+++ b/src/Spectre.Console.Analyzer/Analyzers/NoPromptsDuringLiveRenderablesAnalyzer.cs
@@ -17,6 +17,14 @@ public class NoPromptsDuringLiveRenderablesAnalyzer : SpectreAnalyzer
     /// <inheritdoc />
     protected override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext)
     {
+        var ansiConsoleType = compilationStartContext.Compilation.GetTypeByMetadataName("Spectre.Console.AnsiConsole");
+        var ansiConsoleExtensionsType = compilationStartContext.Compilation.GetTypeByMetadataName("Spectre.Console.AnsiConsoleExtensions");
+
+        if (ansiConsoleType is null && ansiConsoleExtensionsType is null)
+        {
+            return;
+        }
+
         compilationStartContext.RegisterOperationAction(
             context =>
             {
@@ -30,9 +38,6 @@ public class NoPromptsDuringLiveRenderablesAnalyzer : SpectreAnalyzer
                 {
                     return;
                 }
-
-                var ansiConsoleType = context.Compilation.GetTypeByMetadataName("Spectre.Console.AnsiConsole");
-                var ansiConsoleExtensionsType = context.Compilation.GetTypeByMetadataName("Spectre.Console.AnsiConsoleExtensions");
 
                 if (!SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, ansiConsoleType) &&
                     !SymbolEqualityComparer.Default.Equals(methodSymbol.ContainingType, ansiConsoleExtensionsType))

--- a/src/Spectre.Console.Analyzer/Analyzers/UseSpectreInsteadOfSystemConsoleAnalyzer.cs
+++ b/src/Spectre.Console.Analyzer/Analyzers/UseSpectreInsteadOfSystemConsoleAnalyzer.cs
@@ -18,6 +18,13 @@ public class UseSpectreInsteadOfSystemConsoleAnalyzer : SpectreAnalyzer
     /// <inheritdoc />
     protected override void AnalyzeCompilation(CompilationStartAnalysisContext compilationStartContext)
     {
+        var systemConsoleType = compilationStartContext.Compilation.GetTypeByMetadataName("System.Console");
+        var spectreConsoleType = compilationStartContext.Compilation.GetTypeByMetadataName("Spectre.Console.AnsiConsole");
+        if (systemConsoleType == null || spectreConsoleType == null)
+        {
+            return;
+        }
+
         compilationStartContext.RegisterOperationAction(
             context =>
             {
@@ -30,8 +37,6 @@ public class UseSpectreInsteadOfSystemConsoleAnalyzer : SpectreAnalyzer
                 {
                     return;
                 }
-
-                var systemConsoleType = context.Compilation.GetTypeByMetadataName("System.Console");
 
                 if (!SymbolEqualityComparer.Default.Equals(invocationOperation.TargetMethod.ContainingType, systemConsoleType))
                 {


### PR DESCRIPTION
It's common to register analyzers in Directory.Build.props or Central packages. This means the analyzers are registered for all projects even if they don't contain a reference to Spectre.Console. This PR checks in CompilationStart if the types are actually available before registering analyzers.
