### PR TITLE
Added TextPath.NoLineBreak flag

### DIFF
--- a/src/Spectre.Console/Extensions/TextPathExtensions.cs
+++ b/src/Spectre.Console/Extensions/TextPathExtensions.cs
@@ -116,4 +116,20 @@ public static class TextPathExtensions
     {
         return LeafStyle(obj, new Style(foreground: color));
     }
+
+    /// <summary>
+    /// Sets the <see cref="TextPath.NoLineBreak"/> flag to true.
+    /// </summary>
+    /// <param name="obj">The path.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static TextPath NoLineBreak(this TextPath obj)
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        obj.NoLineBreak = true;
+        return obj;
+    }
 }

--- a/src/Spectre.Console/Widgets/TextPath.cs
+++ b/src/Spectre.Console/Widgets/TextPath.cs
@@ -38,6 +38,11 @@ public sealed class TextPath : IRenderable, IHasJustification
     public Justify? Justification { get; set; }
 
     /// <summary>
+    /// Gets or sets if no line break should be rendered after the path.
+    /// </summary>
+    public bool? NoLineBreak { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="TextPath"/> class.
     /// </summary>
     /// <param name="path">The path to render.</param>
@@ -84,6 +89,7 @@ public sealed class TextPath : IRenderable, IHasJustification
         var separatorStyle = SeparatorStyle ?? Style.Plain;
         var stemStyle = StemStyle ?? Style.Plain;
         var leafStyle = LeafStyle ?? Style.Plain;
+        var lineBreak = NoLineBreak != true;
 
         var fitted = Fit(options, maxWidth);
         var parts = new List<Segment>();
@@ -119,8 +125,11 @@ public sealed class TextPath : IRenderable, IHasJustification
         // Align the result
         Aligner.Align(parts, Justification, maxWidth);
 
-        // Insert a line break
-        parts.Add(Segment.LineBreak);
+        // Insert a line break (if not omitted)
+        if (lineBreak)
+        {
+            parts.Add(Segment.LineBreak);
+        }
 
         return parts;
     }

--- a/test/Spectre.Console.Tests/Unit/Widgets/TextPathTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Widgets/TextPathTests.cs
@@ -70,6 +70,24 @@ public sealed class TextPathTests
         console.Output.ShouldEndWith("\n");
     }
 
+    [Theory]
+    [InlineData("C:/My documents/Bar/Baz.txt")]
+    [InlineData("/My documents/Bar/Baz.txt")]
+    [InlineData("My documents/Bar/Baz.txt")]
+    [InlineData("Bar/Baz.txt")]
+    [InlineData("Baz.txt")]
+    public void Should_Not_Insert_Line_Break_At_End_Of_Path_If_No_Line_Break_Is_Set(string input)
+    {
+        // Given
+        var console = new TestConsole().Width(80);
+
+        // When
+        console.Write(new TextPath(input).NoLineBreak());
+
+        // Then
+        console.Output.ShouldNotEndWith("\n");
+    }
+
     [Fact]
     public void Should_Right_Align_Correctly()
     {


### PR DESCRIPTION
Added the NoLineBreak flag to TextPath to make it possible to conditionally prevent a new line break from being rendered after the path.

Created Unit tests and added extension method to set the NoLineBreak flag.

Resolves #1177