### PR TITLE
Add an example showing the decorations off

### DIFF
--- a/examples/Console/Decorations/Decorations.csproj
+++ b/examples/Console/Decorations/Decorations.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+    <ExampleTitle>Decorations</ExampleTitle>
+    <ExampleDescription>Demonstrates how to [italic]use[/] [bold]decorations[/] [dim]in[/] the console.</ExampleDescription>
+    <ExampleGroup>Misc</ExampleGroup>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Shared\Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/examples/Console/Decorations/Program.cs
+++ b/examples/Console/Decorations/Program.cs
@@ -1,0 +1,29 @@
+using Spectre.Console;
+
+namespace Colors;
+
+public static class Program
+{
+    public static void Main()
+    {
+        AnsiConsole.ResetDecoration();
+        AnsiConsole.WriteLine();
+
+        if (AnsiConsole.Profile.Capabilities.Ansi)
+        {
+            AnsiConsole.Write(new Rule("[bold green]ANSI Decorations[/]"));
+        }
+        else
+        {
+            AnsiConsole.Write(new Rule("[bold red]Legacy Decorations (unsupported)[/]"));
+        }
+
+        var decorations = System.Enum.GetValues(typeof(Decoration));
+        foreach (var decoration in decorations)
+        {
+            var name = System.Enum.GetName(typeof(Decoration),decoration);
+            AnsiConsole.Write(name + ": ");
+            AnsiConsole.Write(new Markup(name+"\n", new Style(decoration: (Decoration)decoration)));
+        }
+    }
+}

--- a/examples/Examples.sln
+++ b/examples/Examples.sln
@@ -85,6 +85,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Spectre.Console.Json", "..\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Help", "Cli\Help\Help.csproj", "{BAB490D6-FF8D-462B-B2B0-933384D629DB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Decorations", "Console\Decorations\Decorations.csproj", "{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -563,6 +565,18 @@ Global
 		{BAB490D6-FF8D-462B-B2B0-933384D629DB}.Release|x64.Build.0 = Release|Any CPU
 		{BAB490D6-FF8D-462B-B2B0-933384D629DB}.Release|x86.ActiveCfg = Release|Any CPU
 		{BAB490D6-FF8D-462B-B2B0-933384D629DB}.Release|x86.Build.0 = Release|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Debug|x64.Build.0 = Debug|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Debug|x86.Build.0 = Debug|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Release|x64.ActiveCfg = Release|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Release|x64.Build.0 = Release|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Release|x86.ActiveCfg = Release|Any CPU
+		{FC5852F1-E01F-4DF7-9B49-CA19A9EE670F}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
There wasn't any existing example that made it easy to look at all the decoration styles. This adds a simple one to just print each decoration style with its name.

![image](https://user-images.githubusercontent.com/1398274/223201415-a748da16-6b1b-423f-bfd5-ecc0f872b8f0.png)
