### PR TITLE
Feature - Add failed task

### DIFF
--- a/src/Spectre.Console/Live/Progress/Columns/DownloadedColumn.cs
+++ b/src/Spectre.Console/Live/Progress/Columns/DownloadedColumn.cs
@@ -14,6 +14,16 @@ public sealed class DownloadedColumn : ProgressColumn
     public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
     {
         var total = new FileSize(task.MaxValue);
+        var downloaded = new FileSize(task.Value, total.Unit);
+
+        if (task.IsFailed)
+        {
+            return new Markup(string.Format(
+                "[red]{0}/{1}[/] [red]{2}[/]",
+                downloaded.Format(Culture),
+                total.Format(Culture),
+                total.Suffix));
+        }
 
         if (task.IsFinished)
         {
@@ -24,8 +34,6 @@ public sealed class DownloadedColumn : ProgressColumn
         }
         else
         {
-            var downloaded = new FileSize(task.Value, total.Unit);
-
             return new Markup(string.Format(
                 "{0}[grey]/[/]{1} [grey]{2}[/]",
                 downloaded.Format(Culture),

--- a/src/Spectre.Console/Live/Progress/Columns/PercentageColumn.cs
+++ b/src/Spectre.Console/Live/Progress/Columns/PercentageColumn.cs
@@ -15,11 +15,25 @@ public sealed class PercentageColumn : ProgressColumn
     /// </summary>
     public Style CompletedStyle { get; set; } = new Style(foreground: Color.Green);
 
+    /// <summary>
+    /// Gets or sets style for a failed task.
+    /// </summary>
+    public Style FailedStype { get; set; } = new Style(foreground: Color.Red);
+
     /// <inheritdoc/>
     public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
     {
         var percentage = (int)task.Percentage;
-        var style = percentage == 100 ? CompletedStyle : Style ?? Style.Plain;
+        var style = Style;
+        if (task.IsFailed)
+        {
+            style = FailedStype;
+        }
+        else if (percentage == 100)
+        {
+            style = CompletedStyle;
+        }
+
         return new Text($"{percentage}%", style).RightJustified();
     }
 

--- a/src/Spectre.Console/Live/Progress/Columns/ProgressBarColumn.cs
+++ b/src/Spectre.Console/Live/Progress/Columns/ProgressBarColumn.cs
@@ -30,6 +30,8 @@ public sealed class ProgressBarColumn : ProgressColumn
     /// </summary>
     public Style IndeterminateStyle { get; set; } = ProgressBar.DefaultPulseStyle;
 
+    public Style FailedStyle { get; set; } = new Style(foreground: Color.Red);
+
     /// <inheritdoc/>
     public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
     {
@@ -43,6 +45,8 @@ public sealed class ProgressBarColumn : ProgressColumn
             RemainingStyle = RemainingStyle,
             IndeterminateStyle = IndeterminateStyle,
             IsIndeterminate = task.IsIndeterminate,
+            FailedStyle = FailedStyle,
+            IsFailed = task.IsFailed,
         };
     }
 }

--- a/src/Spectre.Console/Live/Progress/Columns/SpinnerColumn.cs
+++ b/src/Spectre.Console/Live/Progress/Columns/SpinnerColumn.cs
@@ -13,6 +13,7 @@ public sealed class SpinnerColumn : ProgressColumn
     private int? _maxWidth;
     private string? _completed;
     private string? _pending;
+    private string? _failedText;
 
     /// <inheritdoc/>
     protected internal override bool NoWrap => true;
@@ -47,6 +48,12 @@ public sealed class SpinnerColumn : ProgressColumn
         }
     }
 
+    public string? FailedText
+    {
+        get => _failedText;
+        set => _failedText = value;
+    }
+
     /// <summary>
     /// Gets or sets the text that should be shown instead
     /// of the spinner before a task begins.
@@ -77,6 +84,11 @@ public sealed class SpinnerColumn : ProgressColumn
     public Style? Style { get; set; } = new Style(foreground: Color.Yellow);
 
     /// <summary>
+    /// Gets or sets the failed style.
+    /// </summary>
+    public Style? FailedStyle { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="SpinnerColumn"/> class.
     /// </summary>
     public SpinnerColumn()
@@ -103,6 +115,11 @@ public sealed class SpinnerColumn : ProgressColumn
         if (!task.IsStarted)
         {
             return new Markup(PendingText ?? " ", PendingStyle ?? Style.Plain);
+        }
+
+        if (task.IsFailed)
+        {
+            return new Markup(FailedText ?? " ", FailedStyle ?? Style.Plain);
         }
 
         if (task.IsFinished)

--- a/src/Spectre.Console/Live/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Live/Progress/ProgressTask.cs
@@ -96,6 +96,11 @@ public sealed class ProgressTask : IProgress<double>
     public bool IsIndeterminate { get; set; }
 
     /// <summary>
+    /// Gets a value indicating whether the task execution failed.
+    /// </summary>
+    public bool IsFailed { get; private set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ProgressTask"/> class.
     /// </summary>
     /// <param name="id">The task ID.</param>
@@ -149,6 +154,22 @@ public sealed class ProgressTask : IProgress<double>
             StartTime ??= now;
 
             StopTime = now;
+        }
+    }
+
+    /// <summary>
+    /// Stops and marks the task as failed.
+    /// </summary>
+    public void StopTaskWithFailure()
+    {
+        lock (_lock)
+        {
+            var now = DateTime.Now;
+            StartTime ??= now;
+
+            StopTime = now;
+
+            IsFailed = true;
         }
     }
 

--- a/src/Spectre.Console/Widgets/ProgressBar.cs
+++ b/src/Spectre.Console/Widgets/ProgressBar.cs
@@ -5,6 +5,8 @@ internal sealed class ProgressBar : Renderable, IHasCulture
     private const int PULSESIZE = 20;
     private const int PULSESPEED = 15;
 
+    public bool IsFailed { get; set; }
+
     public double Value { get; set; }
     public double MaxValue { get; set; } = 100;
 
@@ -20,6 +22,7 @@ internal sealed class ProgressBar : Renderable, IHasCulture
     public Style FinishedStyle { get; set; } = new Style(foreground: Color.Green);
     public Style RemainingStyle { get; set; } = new Style(foreground: Color.Grey);
     public Style IndeterminateStyle { get; set; } = DefaultPulseStyle;
+    public Style FailedStyle { get; set; } = new Style(foreground: Color.Red);
 
     internal static Style DefaultPulseStyle { get; } = new Style(foreground: Color.DodgerBlue1, background: Color.Grey23);
 
@@ -35,7 +38,7 @@ internal sealed class ProgressBar : Renderable, IHasCulture
         var completedBarCount = Math.Min(MaxValue, Math.Max(0, Value));
         var isCompleted = completedBarCount >= MaxValue;
 
-        if (IsIndeterminate && !isCompleted)
+        if (IsIndeterminate && !isCompleted && !IsFailed)
         {
             foreach (var segment in RenderIndeterminate(options, width))
             {
@@ -46,7 +49,16 @@ internal sealed class ProgressBar : Renderable, IHasCulture
         }
 
         var bar = !options.Unicode ? AsciiBar : UnicodeBar;
-        var style = isCompleted ? FinishedStyle : CompletedStyle;
+        var style = CompletedStyle;
+        if (isCompleted)
+        {
+            style = FinishedStyle;
+        }
+        else if (IsFailed)
+        {
+            style = FailedStyle;
+        }
+
         var barCount = Math.Max(0, (int)(width * (completedBarCount / MaxValue)));
 
         // Show value?


### PR DESCRIPTION
- Add fail state for ProgressTask
- Add failed rendering for: ProgressBar, PercentageColumn, SpinnerColumn, DownloadedColumn

Usage example:
```C#
using Spectre.Console;

await AnsiConsole.Progress()
    .Columns(
        new TaskDescriptionColumn(),
        new ProgressBarColumn
        {
            FailedStyle = new Style(Color.Red),
        },
        new PercentageColumn
        {
            FailedStype = new Style(Color.Red),
        },
        new SpinnerColumn
        {
            CompletedText = "Completed", 
            FailedText = "Failed",
            FailedStyle = new Style(Color.Red),
            CompletedStyle = new Style(Color.Green),
        },
        new DownloadedColumn()
    )
    .AutoClear(false)
    .StartAsync(async context =>
    {
        var goodTask = Task.Run(async () =>
        {
            var task = context.AddTask("Good task");
            var x = 0;
            while (x != 100)
            {
                task.Increment(1);
                x++;
                await Task.Delay(50);
            }
        });

        var badTask = Task.Run(async () =>
        {
            var task = context.AddTask("Bad task");
            try
            {
                var x = 0;
                while (x != 100)
                {
                    task.Increment(1);
                    x++;
                    await Task.Delay(100);
                    if (x == 30)
                    {
                        throw new Exception();
                    }
                }
            }
            catch (Exception ex)
            {
                task.StopTaskWithFailure();
            }
        });
        await Task.WhenAll(goodTask, badTask);
    });
```

<img width="538" alt="Screenshot 2023-03-11 at 10 57 33" src="https://user-images.githubusercontent.com/26182437/224465977-11b1a73a-e3f9-4dc9-bbac-e88b8f76fc87.png">
