### PR TITLE
Make node label attr public

### DIFF
--- a/src/Spectre.Console/Widgets/TreeNode.cs
+++ b/src/Spectre.Console/Widgets/TreeNode.cs
@@ -5,7 +5,7 @@ namespace Spectre.Console;
 /// </summary>
 public sealed class TreeNode : IHasTreeNodes
 {
-    internal IRenderable Renderable { get; }
+    public IRenderable Renderable { get; }
 
     /// <summary>
     /// Gets the tree node's child nodes.


### PR DESCRIPTION
Making the Renderable attribute (the label for the TreeNode) allows for changing the name after the initial creation of the node.

This helps especially for people who are attempting to make a more interactive tree that allows the user to select nodes and open/close them.

Changing the name would allow for renaming files or adding an underline, asterisk, etc. to signify what node is currently selected on the tree.

If for some reason you can't make this specific attribute public, I can add a method to the class for renaming the variable.