### PR TITLE
Allow Confirmation Prompt Styling

### DIFF
--- a/src/Spectre.Console/Extensions/ConfirmationPromptExtensions.cs
+++ b/src/Spectre.Console/Extensions/ConfirmationPromptExtensions.cs
@@ -43,6 +43,28 @@ public static class ConfirmationPromptExtensions
     }
 
     /// <summary>
+    /// Sets the style in which the list of choices is displayed.
+    /// </summary>
+    /// <param name="obj">The confirmation prompt.</param>
+    /// <param name="style">The style to use for displaying the choices.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static ConfirmationPrompt ChoicesStyle(this ConfirmationPrompt obj, Style style)
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        if (style is null)
+        {
+            throw new ArgumentNullException(nameof(style));
+        }
+
+        obj.ChoicesStyle = style;
+        return obj;
+    }
+
+    /// <summary>
     /// Show or hide the default value.
     /// </summary>
     /// <param name="obj">The prompt.</param>
@@ -77,6 +99,28 @@ public static class ConfirmationPromptExtensions
     public static ConfirmationPrompt HideDefaultValue(this ConfirmationPrompt obj)
     {
         return ShowDefaultValue(obj, false);
+    }
+
+    /// <summary>
+    /// Sets the style in which the default value is displayed.
+    /// </summary>
+    /// <param name="obj">The confirmation prompt.</param>
+    /// <param name="style">The default value style.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static ConfirmationPrompt DefaultValueStyle(this ConfirmationPrompt obj, Style style)
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        if (style is null)
+        {
+            throw new ArgumentNullException(nameof(style));
+        }
+
+        obj.DefaultValueStyle = style;
+        return obj;
     }
 
     /// <summary>

--- a/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
+++ b/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
@@ -40,6 +40,16 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
     public bool ShowDefaultValue { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets the style in which the default value is displayed.
+    /// </summary>
+    public Style? DefaultValueStyle { get; set; }
+
+    /// <summary>
+    /// Gets or sets the style in which the list of choices is displayed.
+    /// </summary>
+    public Style? ChoicesStyle { get; set; }
+
+    /// <summary>
     /// Gets or sets the string comparer to use when comparing user input
     /// against Yes/No choices.
     /// </summary>
@@ -72,8 +82,10 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
             .InvalidChoiceMessage(InvalidChoiceMessage)
             .ValidationErrorMessage(InvalidChoiceMessage)
             .ShowChoices(ShowChoices)
+            .ChoicesStyle(ChoicesStyle ?? "blue")
             .ShowDefaultValue(ShowDefaultValue)
             .DefaultValue(DefaultValue ? Yes : No)
+            .DefaultValueStyle(DefaultValueStyle ?? "green")
             .AddChoice(Yes)
             .AddChoice(No);
 


### PR DESCRIPTION
Allows styling of `ConfirmationPrompt` in the same way that `TextPrompt` can be styled for choices and default values. 

If no style is provided, fallback to the same `"blue"` and `"green"` that `TextPrompt` uses is done.

Addresses https://github.com/spectreconsole/spectre.console/issues/1209.