### PR TITLE
Relax the SDK requirements by rolling forward to the latest feature

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
+  "$schema": "http://json.schemastore.org/global",
   "sdk": {
-    "version": "7.0.100"
+    "version": "7.0.100",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
This was initially introduced in 3c5b98123b4c9cd50a37da25ca9a3fd34ac7f479 by Daniel Cazzulino, then reverted in 82de4a55c48e269225ff2b137850a303b3776879 by Patrick Svensson because of a bug in the .NET 6.0.401 SDK.