### PR TITLE
Add custom style for each calendar event

### DIFF
--- a/src/Spectre.Console/Extensions/CalendarExtensions.cs
+++ b/src/Spectre.Console/Extensions/CalendarExtensions.cs
@@ -10,10 +10,11 @@ public static class CalendarExtensions
     /// </summary>
     /// <param name="calendar">The calendar to add the calendar event to.</param>
     /// <param name="date">The calendar event date.</param>
+    /// <param name="customEventHighlightStyle">The calendar event custom highlight style.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static Calendar AddCalendarEvent(this Calendar calendar, DateTime date)
+    public static Calendar AddCalendarEvent(this Calendar calendar, DateTime date, Style? customEventHighlightStyle = null)
     {
-        return AddCalendarEvent(calendar, string.Empty, date.Year, date.Month, date.Day);
+        return AddCalendarEvent(calendar, string.Empty, date.Year, date.Month, date.Day, customEventHighlightStyle);
     }
 
     /// <summary>
@@ -22,10 +23,11 @@ public static class CalendarExtensions
     /// <param name="calendar">The calendar to add the calendar event to.</param>
     /// <param name="description">The calendar event description.</param>
     /// <param name="date">The calendar event date.</param>
+    /// <param name="customEventHighlightStyle">The calendar event custom highlight style.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static Calendar AddCalendarEvent(this Calendar calendar, string description, DateTime date)
+    public static Calendar AddCalendarEvent(this Calendar calendar, string description, DateTime date, Style? customEventHighlightStyle = null)
     {
-        return AddCalendarEvent(calendar, description, date.Year, date.Month, date.Day);
+        return AddCalendarEvent(calendar, description, date.Year, date.Month, date.Day, customEventHighlightStyle);
     }
 
     /// <summary>
@@ -35,10 +37,11 @@ public static class CalendarExtensions
     /// <param name="year">The year of the calendar event.</param>
     /// <param name="month">The month of the calendar event.</param>
     /// <param name="day">The day of the calendar event.</param>
+    /// <param name="customEventHighlightStyle">The calendar event custom highlight style.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static Calendar AddCalendarEvent(this Calendar calendar, int year, int month, int day)
+    public static Calendar AddCalendarEvent(this Calendar calendar, int year, int month, int day, Style? customEventHighlightStyle = null)
     {
-        return AddCalendarEvent(calendar, string.Empty, year, month, day);
+        return AddCalendarEvent(calendar, string.Empty, year, month, day, customEventHighlightStyle);
     }
 
     /// <summary>
@@ -49,15 +52,16 @@ public static class CalendarExtensions
     /// <param name="year">The year of the calendar event.</param>
     /// <param name="month">The month of the calendar event.</param>
     /// <param name="day">The day of the calendar event.</param>
+    /// <param name="customEventHighlightStyle">The calendar event custom highlight style.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static Calendar AddCalendarEvent(this Calendar calendar, string description, int year, int month, int day)
+    public static Calendar AddCalendarEvent(this Calendar calendar, string description, int year, int month, int day, Style? customEventHighlightStyle = null)
     {
         if (calendar is null)
         {
             throw new ArgumentNullException(nameof(calendar));
         }
 
-        calendar.CalendarEvents.Add(new CalendarEvent(description, year, month, day));
+        calendar.CalendarEvents.Add(new CalendarEvent(description, year, month, day, customEventHighlightStyle));
         return calendar;
     }
 
@@ -65,7 +69,7 @@ public static class CalendarExtensions
     /// Sets the calendar's highlight <see cref="Style"/>.
     /// </summary>
     /// <param name="calendar">The calendar.</param>
-    /// <param name="style">The highlight style.</param>
+    /// <param name="style">The default highlight style.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public static Calendar HighlightStyle(this Calendar calendar, Style? style)
     {

--- a/src/Spectre.Console/Widgets/Calendar.cs
+++ b/src/Spectre.Console/Widgets/Calendar.cs
@@ -196,9 +196,10 @@ public sealed class Calendar : JustInTimeRenderable, IHasCulture, IHasTableBorde
         {
             if (weekdays[currentDay - 1] == weekday)
             {
-                if (_calendarEvents.Any(e => e.Month == Month && e.Day == currentDay))
+                var todayEvent = _calendarEvents.LastOrDefault(e => e.Month == Month && e.Day == currentDay);
+                if (todayEvent != null)
                 {
-                    row.Add(new Markup(currentDay.ToString(CultureInfo.InvariantCulture) + "*", _highlightStyle));
+                    row.Add(new Markup(currentDay.ToString(CultureInfo.InvariantCulture) + "*", todayEvent.CustomHighlightStyle ?? _highlightStyle));
                 }
                 else
                 {

--- a/src/Spectre.Console/Widgets/CalendarEvent.cs
+++ b/src/Spectre.Console/Widgets/CalendarEvent.cs
@@ -26,13 +26,19 @@ public sealed class CalendarEvent
     public int Day { get; }
 
     /// <summary>
+    /// Gets the custom highlight style of the calendar event.
+    /// </summary>
+    public Style? CustomHighlightStyle { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CalendarEvent"/> class.
     /// </summary>
     /// <param name="year">The year of the calendar event.</param>
     /// <param name="month">The month of the calendar event.</param>
     /// <param name="day">The day of the calendar event.</param>
-    public CalendarEvent(int year, int month, int day)
-        : this(string.Empty, year, month, day)
+    /// <param name="customHighlightStyle">The custom highlight style of the calendar event.</param>
+    public CalendarEvent(int year, int month, int day, Style? customHighlightStyle = null)
+        : this(string.Empty, year, month, day, customHighlightStyle)
     {
     }
 
@@ -43,11 +49,14 @@ public sealed class CalendarEvent
     /// <param name="year">The year of the calendar event.</param>
     /// <param name="month">The month of the calendar event.</param>
     /// <param name="day">The day of the calendar event.</param>
-    public CalendarEvent(string description, int year, int month, int day)
+    /// <param name="customHighlightStyle">The custom highlight style of the calendar event.</param>
+    public CalendarEvent(string description, int year, int month, int day, Style? customHighlightStyle = null)
     {
         Description = description ?? string.Empty;
         Year = year;
         Month = month;
         Day = day;
+        CustomHighlightStyle = customHighlightStyle;
+
     }
 }

--- a/src/Spectre.Console/Widgets/CalendarEvent.cs
+++ b/src/Spectre.Console/Widgets/CalendarEvent.cs
@@ -57,6 +57,5 @@ public sealed class CalendarEvent
         Month = month;
         Day = day;
         CustomHighlightStyle = customHighlightStyle;
-
     }
 }


### PR DESCRIPTION
# Description

Implemented the custom highlight style for single calendar event.
Also requested with issue #1234.

# Example

As shown below the calendar now support the default highlight style `2023-06-22` but also support different style for different events like `2023-06-24` and `2023-06-25` in yellow foreground and `2023-06-27` with red foreground

![image](https://github.com/spectreconsole/spectre.console/assets/133281491/e3ac5acd-7660-468a-9824-def0f4d05b60)

# To Test

To test this implementation is sufficient to put it into the `Main` method of the `Program.cs` in the `Spectre.Console.Analyzer.Sandbox` .

```csharp
        var today = DateTime.Today;

        var calendar = new Calendar(today.Year, today.Month);

        //Just keep an eye on the current day
        calendar.AddCalendarEvent(today);

        //Interesting events
        calendar.AddCalendarEvent(today.AddDays(2), Color.Yellow);
        calendar.AddCalendarEvent(today.AddDays(3), Color.Yellow);

        //Inderogable important event
        calendar.AddCalendarEvent(today.AddDays(5), Color.Red);

        AnsiConsole.Write(calendar);
```

---
Please upvote :+1: this pull request if you are interested in it.