### PR TITLE
Added option to set the calendar highlight style on a daily basis.

### DIFF
--- a/src/Spectre.Console/Extensions/CalendarExtensions.cs
+++ b/src/Spectre.Console/Extensions/CalendarExtensions.cs
@@ -62,20 +62,37 @@ public static class CalendarExtensions
     }
 
     /// <summary>
-    /// Sets the calendar's highlight <see cref="Style"/>.
+    /// Adds a calendar event.
     /// </summary>
     /// <param name="calendar">The calendar.</param>
-    /// <param name="style">The highlight style.</param>
+    /// <param name="description">The calendar event description.</param>
+    /// <param name="year">The year of the calendar event.</param>
+    /// <param name="month">The month of the calendar event.</param>
+    /// <param name="day">The day of the calendar event.</param>
+    /// <param name="style">The style of the calendar event.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static Calendar HighlightStyle(this Calendar calendar, Style? style)
+    public static Calendar AddCalendarEvent(this Calendar calendar, string description, int year, int month, int day, Style style)
     {
         if (calendar is null)
         {
             throw new ArgumentNullException(nameof(calendar));
         }
 
-        calendar.HighlightStyle = style ?? Style.Plain;
+        calendar.CalendarEvents.Add(new CalendarEvent(description, year, month, day, style));
         return calendar;
+    }
+
+    /// <summary>
+    /// Adds a calendar event.
+    /// </summary>
+    /// <param name="calendar">The calendar to add the calendar event to.</param>
+    /// <param name="description">The calendar event description.</param>
+    /// <param name="date">The calendar event date.</param>
+    /// <param name="style">The style of the calendar event.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Calendar AddCalendarEvent(this Calendar calendar, string description, DateTime date, Style style)
+    {
+        return AddCalendarEvent(calendar, description, date.Year, date.Month, date.Day, style);
     }
 
     /// <summary>

--- a/src/Spectre.Console/Widgets/Calendar.cs
+++ b/src/Spectre.Console/Widgets/Calendar.cs
@@ -17,7 +17,6 @@ public sealed class Calendar : JustInTimeRenderable, IHasCulture, IHasTableBorde
     private bool _useSafeBorder;
     private Style? _borderStyle;
     private CultureInfo? _culture;
-    private Style _highlightStyle;
     private bool _showHeader;
     private Style? _headerStyle;
     private Justify? _alignment;
@@ -77,15 +76,6 @@ public sealed class Calendar : JustInTimeRenderable, IHasCulture, IHasTableBorde
     {
         get => _culture;
         set => MarkAsDirty(() => _culture = value);
-    }
-
-    /// <summary>
-    /// Gets or sets the calendar's highlight <see cref="Style"/>.
-    /// </summary>
-    public Style HighlightStyle
-    {
-        get => _highlightStyle;
-        set => MarkAsDirty(() => _highlightStyle = value);
     }
 
     /// <summary>
@@ -153,7 +143,6 @@ public sealed class Calendar : JustInTimeRenderable, IHasCulture, IHasTableBorde
         _useSafeBorder = true;
         _borderStyle = null;
         _culture = CultureInfo.InvariantCulture;
-        _highlightStyle = Color.Blue;
         _showHeader = true;
         _calendarEvents = new ListWithCallback<CalendarEvent>(MarkAsDirty);
     }
@@ -196,9 +185,11 @@ public sealed class Calendar : JustInTimeRenderable, IHasCulture, IHasTableBorde
         {
             if (weekdays[currentDay - 1] == weekday)
             {
-                if (_calendarEvents.Any(e => e.Month == Month && e.Day == currentDay))
+                var currentDayEvents = _calendarEvents.Where(e => e.Month == Month && e.Day == currentDay);
+
+                if (currentDayEvents is not null && currentDayEvents.Any())
                 {
-                    row.Add(new Markup(currentDay.ToString(CultureInfo.InvariantCulture) + "*", _highlightStyle));
+                    row.Add(new Markup(currentDay.ToString(CultureInfo.InvariantCulture) + "*", currentDayEvents.First().Style));
                 }
                 else
                 {

--- a/src/Spectre.Console/Widgets/CalendarEvent.cs
+++ b/src/Spectre.Console/Widgets/CalendarEvent.cs
@@ -26,13 +26,18 @@ public sealed class CalendarEvent
     public int Day { get; }
 
     /// <summary>
+    /// Gets the <see cref="Style"/> of the calendar event.
+    /// </summary>
+    public Style Style { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CalendarEvent"/> class.
     /// </summary>
     /// <param name="year">The year of the calendar event.</param>
     /// <param name="month">The month of the calendar event.</param>
     /// <param name="day">The day of the calendar event.</param>
     public CalendarEvent(int year, int month, int day)
-        : this(string.Empty, year, month, day)
+        : this(string.Empty, year, month, day, null)
     {
     }
 
@@ -43,11 +48,13 @@ public sealed class CalendarEvent
     /// <param name="year">The year of the calendar event.</param>
     /// <param name="month">The month of the calendar event.</param>
     /// <param name="day">The day of the calendar event.</param>
-    public CalendarEvent(string description, int year, int month, int day)
+    /// <param name="style">The style of the calendar event.</param>
+    public CalendarEvent(string description, int year, int month, int day, Style? style = null)
     {
         Description = description ?? string.Empty;
         Year = year;
         Month = month;
         Day = day;
+        Style = style ?? Style.Plain;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/spectreconsole/spectre.console/issues/1234.

However, this would be a breaking change as the `calendar.HighlightStyle()` method is completely removed (https://spectreconsole.net/widgets/calendar). --> Maybe the docs need to be adjusted afterwards as well.