### PR TITLE
Remove unnecessary [NotNull] attributes

### DIFF
--- a/src/Spectre.Console.Cli/CommandOfT.cs
+++ b/src/Spectre.Console.Cli/CommandOfT.cs
@@ -14,7 +14,7 @@ public abstract class Command<TSettings> : ICommand<TSettings>
     /// <param name="context">The command context.</param>
     /// <param name="settings">The settings.</param>
     /// <returns>The validation result.</returns>
-    public virtual ValidationResult Validate([NotNull] CommandContext context, [NotNull] TSettings settings)
+    public virtual ValidationResult Validate(CommandContext context, TSettings settings)
     {
         return ValidationResult.Success();
     }
@@ -25,7 +25,7 @@ public abstract class Command<TSettings> : ICommand<TSettings>
     /// <param name="context">The command context.</param>
     /// <param name="settings">The settings.</param>
     /// <returns>An integer indicating whether or not the command executed successfully.</returns>
-    public abstract int Execute([NotNull] CommandContext context, [NotNull] TSettings settings);
+    public abstract int Execute(CommandContext context, TSettings settings);
 
     /// <inheritdoc/>
     ValidationResult ICommand.Validate(CommandContext context, CommandSettings settings)

--- a/src/Spectre.Console.Cli/Internal/Commands/ExplainCommand.cs
+++ b/src/Spectre.Console.Cli/Internal/Commands/ExplainCommand.cs
@@ -34,7 +34,7 @@ internal sealed class ExplainCommand : Command<ExplainCommand.Settings>
         public bool IncludeHidden { get; }
     }
 
-    public override int Execute([NotNull] CommandContext context, [NotNull] Settings settings)
+    public override int Execute(CommandContext context, Settings settings)
     {
         var tree = new Tree("CLI Configuration");
         tree.AddNode(ValueMarkup("Application Name", _commandModel.ApplicationName, "no application name"));

--- a/src/Spectre.Console.Cli/Internal/Commands/VersionCommand.cs
+++ b/src/Spectre.Console.Cli/Internal/Commands/VersionCommand.cs
@@ -15,7 +15,7 @@ internal sealed class VersionCommand : Command<VersionCommand.Settings>
     {
     }
 
-    public override int Execute([NotNull] CommandContext context, [NotNull] Settings settings)
+    public override int Execute(CommandContext context, Settings settings)
     {
         _writer.MarkupLine(
             "[yellow]Spectre.Cli[/] version [aqua]{0}[/]",

--- a/src/Spectre.Console.Cli/Internal/Commands/XmlDocCommand.cs
+++ b/src/Spectre.Console.Cli/Internal/Commands/XmlDocCommand.cs
@@ -17,7 +17,7 @@ internal sealed class XmlDocCommand : Command<XmlDocCommand.Settings>
     {
     }
 
-    public override int Execute([NotNull] CommandContext context, [NotNull] Settings settings)
+    public override int Execute(CommandContext context, Settings settings)
     {
         _writer.Write(Serialize(_model), Style.Plain);
         return 0;

--- a/test/Spectre.Console.Cli.Tests/Data/Commands/GreeterCommand.cs
+++ b/test/Spectre.Console.Cli.Tests/Data/Commands/GreeterCommand.cs
@@ -9,7 +9,7 @@ public class GreeterCommand : Command<OptionalArgumentWithDefaultValueSettings>
         _console = console;
     }
 
-    public override int Execute([NotNull] CommandContext context, [NotNull] OptionalArgumentWithDefaultValueSettings settings)
+    public override int Execute(CommandContext context, OptionalArgumentWithDefaultValueSettings settings)
     {
         _console.WriteLine(settings.Greeting);
         return 0;


### PR DESCRIPTION
When subclassing `Command<TSettings>` which has the [NotNull] attributes, Rider/ReSharper gives this warning:
> Nullability of type of parameter 'context' in method does not match overridden member `int Spectre.Console.Cli.Command<TSettings>.Execute(CommandContext, TSettings)` (possibly because of nullability attributes)

![image](https://github.com/spectreconsole/spectre.console/assets/51363/47fe84e5-8442-45d9-a7ee-8a49c167ffff)

When subclassing `Command<TSettings>` which does not have the [NotNull] attributes, Rider/ReSharper gives this warning:
> The nullability attribute has no effect and can be safely removed

![image](https://github.com/spectreconsole/spectre.console/assets/51363/58d79af1-0fb2-46d9-9625-5a8f1b952bbd)

The solution is simply to remove the [NotNull] attributes.

Since `<Nullable>enable</Nullable>` is set in the project, they are actually not necessary. By the way, the non-generic `Command` class does not have the [NotNull] attributes.