### PR TITLE
Set end_of_line to LF instead of CRLF

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -2,7 +2,7 @@ root = true
 
 [*]
 charset = utf-8
-end_of_line = CRLF
+end_of_line = LF
 indent_style = space
 indent_size = 4
 insert_final_newline = false
@@ -25,9 +25,6 @@ indent_size = 2
 
 [*.md]
 trim_trailing_whitespace = false
-
-[*.sh]
-end_of_line = lf
 
 [*.cs]
 # Prefer file scoped namespace declarations


### PR DESCRIPTION
This matches the actual content of the repository (except for a few files which have CRLF instead of LF)

The motivation behind this change is that Rider observes the .editorconfig rules and changes the line ending to CRLF on save. When submitting pull requests the diff is full of changes because all the end of lines were changed from LF to CRLF. By setting `end_of_line` to `LF` the end of lines are not changed on save and the diffs are clean when submitting pull requests.