### PR TITLE
Add CommandExceptionHandler

### DIFF
--- a/src/Spectre.Console.Cli/CommandExceptionArgs.cs
+++ b/src/Spectre.Console.Cli/CommandExceptionArgs.cs
@@ -1,0 +1,30 @@
+namespace Spectre.Console.Cli;
+#pragma warning restore S2326
+
+/// <summary>
+/// Represents the args for a command exception.
+/// </summary>
+public readonly struct CommandExceptionArgs
+{
+    /// <summary>
+    /// Gets the command context.
+    /// </summary>
+    public CommandContext Context { get; }
+
+    /// <summary>
+    /// Gets the exception that was thrown.
+    /// </summary>
+    public Exception Exception { get; }
+
+    /// <summary>
+    /// Gets the command type.
+    /// </summary>
+    public Type? CommandType { get; }
+
+    internal CommandExceptionArgs(CommandContext context, Exception exception, Type? commandType)
+    {
+        Context = context;
+        Exception = exception;
+        CommandType = commandType;
+    }
+}

--- a/src/Spectre.Console.Cli/ICommandExceptionHandler.cs
+++ b/src/Spectre.Console.Cli/ICommandExceptionHandler.cs
@@ -1,0 +1,26 @@
+namespace Spectre.Console.Cli;
+
+/// <summary>
+/// Represents an args handler.
+/// Exception handlers are used to handle exceptions that occur during command execution.
+/// </summary>
+public interface ICommandExceptionHandler
+{
+    /// <summary>
+    /// Handles the specified args.
+    /// </summary>
+    /// <param name="args">The args to handle.</param>
+    /// <returns><c>true</c> if the args was handled, otherwise <c>false</c>.</returns>
+    bool Handle(CommandExceptionArgs args);
+}
+
+/// <summary>
+/// Represents an args handler for a specific command.
+/// </summary>
+/// <typeparam name="TCommand">Type of the command.</typeparam>
+// ReSharper disable once UnusedTypeParameter
+#pragma warning disable S2326
+public interface ICommandExceptionHandler<TCommand> : ICommandExceptionHandler
+    where TCommand : ICommand
+{
+}

--- a/src/Spectre.Console.Cli/Internal/CommandExceptionHandler.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExceptionHandler.cs
@@ -1,0 +1,75 @@
+using Spectre.Console.Cli.Internal.Extensions;
+
+namespace Spectre.Console.Cli.Internal;
+
+internal static class CommandExceptionHandler
+{
+    public static bool HandleException(
+        CommandTree leaf,
+        CommandContext context,
+        ITypeResolver resolver,
+        Exception ex)
+    {
+        var args = new CommandExceptionArgs(context, ex, leaf?.Command?.CommandType);
+
+        if (leaf?.Command?.CommandType == null)
+        {
+            return TryInvokeHandler(
+                resolver,
+                args,
+                typeof(IEnumerable<ICommandExceptionHandler>),
+                typeof(ICommandExceptionHandler));
+        }
+
+        var handlerType = typeof(ICommandExceptionHandler<>)
+            .MakeGenericType(leaf.Command.CommandType);
+
+        var enumerableHandlerType = typeof(IEnumerable<>)
+            .MakeGenericType(handlerType);
+
+        var handled = TryInvokeHandler(resolver, args, enumerableHandlerType, handlerType);
+        if (handled)
+        {
+            return true;
+        }
+
+        return TryInvokeHandler(resolver, args, typeof(IEnumerable<ICommandExceptionHandler>),
+            typeof(ICommandExceptionHandler));
+    }
+
+    private static bool TryInvokeHandler(
+        ITypeResolver resolver,
+        CommandExceptionArgs args,
+        Type enumerableHandlerType,
+        Type handlerType)
+    {
+        var handlers = resolver.TryResolve(enumerableHandlerType);
+        if (handlers is IEnumerable<ICommandExceptionHandler> exHandlerEnumerable)
+        {
+            foreach (var exHandlerItem in exHandlerEnumerable)
+            {
+                var isHandled = exHandlerItem.Handle(args);
+                if (isHandled)
+                {
+                    return true;
+                }
+            }
+        }
+        else
+        {
+            var handler = resolver.TryResolve(handlerType);
+            if (handler is not ICommandExceptionHandler exHandler)
+            {
+                return false;
+            }
+
+            var isHandled = exHandler.Handle(args);
+            if (isHandled)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Spectre.Console.Cli/Internal/Extensions/TypeResolverExtensions.cs
+++ b/src/Spectre.Console.Cli/Internal/Extensions/TypeResolverExtensions.cs
@@ -1,0 +1,31 @@
+namespace Spectre.Console.Cli.Internal.Extensions;
+
+internal static class TypeResolverExtensions
+{
+    public static object? TryResolve(this ITypeResolver resolver, Type type)
+    {
+        if (resolver == null)
+        {
+            throw new ArgumentNullException(nameof(resolver));
+        }
+
+        if (type == null)
+        {
+            throw new ArgumentNullException(nameof(type));
+        }
+
+        if (resolver is TypeResolverAdapter adapter)
+        {
+            return adapter.TryResolve(type);
+        }
+
+        try
+        {
+            return resolver.Resolve(type);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Spectre.Console.Cli/Internal/TypeResolverAdapter.cs
+++ b/src/Spectre.Console.Cli/Internal/TypeResolverAdapter.cs
@@ -37,6 +37,23 @@ internal sealed class TypeResolverAdapter : ITypeResolver, IDisposable
         }
     }
 
+    public object? TryResolve(Type? type)
+    {
+        if (type == null)
+        {
+            throw new CommandRuntimeException("Cannot resolve null type.");
+        }
+
+        try
+        {
+            return _resolver?.Resolve(type);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
     public void Dispose()
     {
         if (_resolver is IDisposable disposable)


### PR DESCRIPTION
Reason:
I need a way of handling exceptions while having the typeresolver around. (To log to an implementation of ILogger for e.g)
Unfortunately, the existing exceptionhandler does not provide a way of accessing the ITypeResolver

Usage:

```csharp
public class GenericExceptionHandler : ICommandExceptionHandler
{
    // You can inject services here
    public GenericExceptionHandler()
    {
        
    }

        public bool Handle(CommandExceptionArgs args)
        {
            AnsiConsole.MarkupLine($"[red]{args.Exception.Message}[/]");
            return true;
        }
}

public class CommandGenericExceptionHandler : ICommandExceptionHandler<MyCommand>
{
    // You can inject services here
    public CommandGenericExceptionHandler()
    {
        
    }

        public bool Handle(CommandExceptionArgs args)
        {
            AnsiConsole.MarkupLine($"[red]{args.Exception.Message}[/]");
            return true;
        }
}
```

Then register them during startup: 
```
//...
services.AddTransient<ICommandExceptionHandler, GenericExceptionHandler>();
services.AddTransient< ICommandExceptionHandler<MyCommand>, CommandGenericExceptionHandler>();

//...
var app = new CommandApp(new TypeRegistrar(services));
```