### PR TITLE
Selection Prompt Search

### DIFF
--- a/examples/Console/Prompt/Program.cs
+++ b/examples/Console/Prompt/Program.cs
@@ -110,6 +110,7 @@ namespace Prompt
             {
                 fruit = AnsiConsole.Prompt(
                     new SelectionPrompt<string>()
+                        .EnableSearch()
                         .Title("Ok, but if you could only choose [green]one[/]?")
                         .MoreChoicesText("[grey](Move up and down to reveal more fruits)[/]")
                         .AddChoices(favorites));

--- a/src/Spectre.Console/Extensions/StringExtensions.cs
+++ b/src/Spectre.Console/Extensions/StringExtensions.cs
@@ -187,6 +187,13 @@ public static class StringExtensions
 #endif
     }
 
+#if NETSTANDARD2_0
+    internal static bool Contains(this string target, string value, System.StringComparison comparisonType)
+    {
+        return target.IndexOf(value, comparisonType) != -1;
+    }
+#endif
+
     /// <summary>
     /// "Masks" every character in a string.
     /// </summary>

--- a/src/Spectre.Console/Extensions/StringExtensions.cs
+++ b/src/Spectre.Console/Extensions/StringExtensions.cs
@@ -202,18 +202,11 @@ public static class StringExtensions
     /// <returns>Masked string.</returns>
     public static string Mask(this string value, char? mask)
     {
-        var output = string.Empty;
-
         if (mask is null)
         {
-            return output;
+            return string.Empty;
         }
 
-        foreach (var c in value)
-        {
-            output += mask;
-        }
-
-        return output;
+        return new string(mask.Value, value.Length);
     }
 }

--- a/src/Spectre.Console/Internal/Extensions/EnumerableExtensions.cs
+++ b/src/Spectre.Console/Internal/Extensions/EnumerableExtensions.cs
@@ -31,12 +31,11 @@ internal static class EnumerableExtensions
     }
 
     public static int IndexOf<T>(this IEnumerable<T> source, T item)
-        where T : class
     {
         var index = 0;
         foreach (var candidate in source)
         {
-            if (candidate == item)
+            if (Equals(candidate, item))
             {
                 return index;
             }

--- a/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
+++ b/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
@@ -25,12 +25,6 @@ internal interface IListPromptStrategy<T>
     public int CalculatePageSize(IAnsiConsole console, int totalItemCount, int requestedPageSize);
 
     /// <summary>
-    /// Gets the selection mode.
-    /// </summary>
-    /// <returns>The selection mode.</returns>
-    public SelectionMode GetSelectionMode();
-
-    /// <summary>
     /// Builds a <see cref="IRenderable"/> from the current state.
     /// </summary>
     /// <param name="console">The console.</param>

--- a/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
+++ b/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
@@ -8,6 +8,11 @@ internal interface IListPromptStrategy<T>
     where T : notnull
 {
     /// <summary>
+    /// Gets a value indicating whether or not the prompt should skip unselectable items.
+    /// </summary>
+    public bool ShouldSkipUnselectableItems { get; }
+
+    /// <summary>
     /// Handles any input received from the user.
     /// </summary>
     /// <param name="key">The key that was pressed.</param>

--- a/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
+++ b/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
@@ -25,12 +25,20 @@ internal interface IListPromptStrategy<T>
     public int CalculatePageSize(IAnsiConsole console, int totalItemCount, int requestedPageSize);
 
     /// <summary>
+    /// Gets the selection mode.
+    /// </summary>
+    /// <returns>The selection mode.</returns>
+    public SelectionMode GetSelectionMode();
+
+    /// <summary>
     /// Builds a <see cref="IRenderable"/> from the current state.
     /// </summary>
     /// <param name="console">The console.</param>
     /// <param name="scrollable">Whether or not the list is scrollable.</param>
     /// <param name="cursorIndex">The cursor index.</param>
     /// <param name="items">The visible items.</param>
+    /// <param name="searchFilter">The search filter.</param>
     /// <returns>A <see cref="IRenderable"/> representing the items.</returns>
-    public IRenderable Render(IAnsiConsole console, bool scrollable, int cursorIndex, IEnumerable<(int Index, ListPromptItem<T> Node)> items);
+    public IRenderable Render(IAnsiConsole console, bool scrollable, int cursorIndex,
+        IEnumerable<(int Index, ListPromptItem<T> Node)> items, string searchFilter);
 }

--- a/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
+++ b/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
@@ -8,11 +8,6 @@ internal interface IListPromptStrategy<T>
     where T : notnull
 {
     /// <summary>
-    /// Gets a value indicating whether or not the prompt should skip unselectable items.
-    /// </summary>
-    public bool ShouldSkipUnselectableItems { get; }
-
-    /// <summary>
     /// Handles any input received from the user.
     /// </summary>
     /// <param name="key">The key that was pressed.</param>
@@ -36,8 +31,9 @@ internal interface IListPromptStrategy<T>
     /// <param name="scrollable">Whether or not the list is scrollable.</param>
     /// <param name="cursorIndex">The cursor index.</param>
     /// <param name="items">The visible items.</param>
+    /// <param name="skipUnselectableItems">A value indicating whether or not the prompt should skip unselectable items.</param>
     /// <param name="searchText">The search text.</param>
     /// <returns>A <see cref="IRenderable"/> representing the items.</returns>
     public IRenderable Render(IAnsiConsole console, bool scrollable, int cursorIndex,
-        IEnumerable<(int Index, ListPromptItem<T> Node)> items, string searchText);
+        IEnumerable<(int Index, ListPromptItem<T> Node)> items, bool skipUnselectableItems, string searchText);
 }

--- a/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
+++ b/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
@@ -36,8 +36,8 @@ internal interface IListPromptStrategy<T>
     /// <param name="scrollable">Whether or not the list is scrollable.</param>
     /// <param name="cursorIndex">The cursor index.</param>
     /// <param name="items">The visible items.</param>
-    /// <param name="searchFilter">The search filter.</param>
+    /// <param name="searchText">The search text.</param>
     /// <returns>A <see cref="IRenderable"/> representing the items.</returns>
     public IRenderable Render(IAnsiConsole console, bool scrollable, int cursorIndex,
-        IEnumerable<(int Index, ListPromptItem<T> Node)> items, string searchFilter);
+        IEnumerable<(int Index, ListPromptItem<T> Node)> items, string searchText);
 }

--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -15,6 +15,7 @@ internal sealed class ListPrompt<T>
     public async Task<ListPromptState<T>> Show(
         ListPromptTree<T> tree,
         SelectionMode selectionMode,
+        bool skipUnselectableItems,
         bool searchEnabled,
         int requestedPageSize,
         bool wrapAround,
@@ -40,7 +41,7 @@ internal sealed class ListPrompt<T>
         }
 
         var nodes = tree.Traverse().ToList();
-        var state = new ListPromptState<T>(nodes, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, selectionMode, _strategy.ShouldSkipUnselectableItems, searchEnabled);
+        var state = new ListPromptState<T>(nodes, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, selectionMode, skipUnselectableItems, searchEnabled);
         var hook = new ListPromptRenderHook<T>(_console, () => BuildRenderable(state));
 
         using (new RenderHookScope(_console, hook))
@@ -113,6 +114,7 @@ internal sealed class ListPrompt<T>
             scrollable, cursorIndex,
             state.Items.Skip(skip).Take(take)
                 .Select((node, index) => (index, node)),
+            state.SkipUnselectableItems,
             state.SearchText);
     }
 }

--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -38,7 +38,7 @@ internal sealed class ListPrompt<T>
         }
 
         var nodes = tree.Traverse().ToList();
-        var state = new ListPromptState<T>(nodes, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround);
+        var state = new ListPromptState<T>(nodes, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, _strategy.GetSelectionMode());
         var hook = new ListPromptRenderHook<T>(_console, () => BuildRenderable(state));
 
         using (new RenderHookScope(_console, hook))
@@ -62,7 +62,7 @@ internal sealed class ListPrompt<T>
                     break;
                 }
 
-                if (state.Update(key.Key) || result == ListPromptInputResult.Refresh)
+                if (state.Update(key) || result == ListPromptInputResult.Refresh)
                 {
                     hook.Refresh();
                 }
@@ -110,6 +110,7 @@ internal sealed class ListPrompt<T>
             _console,
             scrollable, cursorIndex,
             state.Items.Skip(skip).Take(take)
-                .Select((node, index) => (index, node)));
+                .Select((node, index) => (index, node)),
+            state.SearchFilter);
     }
 }

--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -40,7 +40,7 @@ internal sealed class ListPrompt<T>
         }
 
         var nodes = tree.Traverse().ToList();
-        var state = new ListPromptState<T>(nodes, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, selectionMode, searchFilterEnabled);
+        var state = new ListPromptState<T>(nodes, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, selectionMode, _strategy.ShouldSkipUnselectableItems, searchFilterEnabled);
         var hook = new ListPromptRenderHook<T>(_console, () => BuildRenderable(state));
 
         using (new RenderHookScope(_console, hook))

--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -14,9 +14,11 @@ internal sealed class ListPrompt<T>
 
     public async Task<ListPromptState<T>> Show(
         ListPromptTree<T> tree,
-        CancellationToken cancellationToken,
-        int requestedPageSize = 15,
-        bool wrapAround = false)
+        SelectionMode selectionMode,
+        bool searchFilterEnabled,
+        int requestedPageSize,
+        bool wrapAround,
+        CancellationToken cancellationToken = default)
     {
         if (tree is null)
         {
@@ -38,7 +40,7 @@ internal sealed class ListPrompt<T>
         }
 
         var nodes = tree.Traverse().ToList();
-        var state = new ListPromptState<T>(nodes, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, _strategy.GetSelectionMode());
+        var state = new ListPromptState<T>(nodes, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, selectionMode, searchFilterEnabled);
         var hook = new ListPromptRenderHook<T>(_console, () => BuildRenderable(state));
 
         using (new RenderHookScope(_console, hook))

--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -15,7 +15,7 @@ internal sealed class ListPrompt<T>
     public async Task<ListPromptState<T>> Show(
         ListPromptTree<T> tree,
         SelectionMode selectionMode,
-        bool searchFilterEnabled,
+        bool searchEnabled,
         int requestedPageSize,
         bool wrapAround,
         CancellationToken cancellationToken = default)
@@ -40,7 +40,7 @@ internal sealed class ListPrompt<T>
         }
 
         var nodes = tree.Traverse().ToList();
-        var state = new ListPromptState<T>(nodes, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, selectionMode, _strategy.ShouldSkipUnselectableItems, searchFilterEnabled);
+        var state = new ListPromptState<T>(nodes, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, selectionMode, _strategy.ShouldSkipUnselectableItems, searchEnabled);
         var hook = new ListPromptRenderHook<T>(_console, () => BuildRenderable(state));
 
         using (new RenderHookScope(_console, hook))
@@ -113,6 +113,6 @@ internal sealed class ListPrompt<T>
             scrollable, cursorIndex,
             state.Items.Skip(skip).Take(take)
                 .Select((node, index) => (index, node)),
-            state.SearchFilter);
+            state.SearchText);
     }
 }

--- a/src/Spectre.Console/Prompts/List/ListPromptConstants.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptConstants.cs
@@ -8,4 +8,5 @@ internal sealed class ListPromptConstants
     public const string GroupSelectedCheckbox = "[[[grey]X[/]]]";
     public const string InstructionsMarkup = "[grey](Press <space> to select, <enter> to accept)[/]";
     public const string MoreChoicesMarkup = "[grey](Move up and down to reveal more choices)[/]";
+    public const string SearchPlaceholderMarkup = "[grey](Type to search)[/]";
 }

--- a/src/Spectre.Console/Prompts/List/ListPromptState.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptState.cs
@@ -22,17 +22,22 @@ internal sealed class ListPromptState<T>
         Mode = mode;
         SearchFilter = string.Empty;
 
-        _leafIndexes =
-            mode == SelectionMode.Leaf
-                ? Items
+        if (mode == SelectionMode.Leaf)
+        {
+            _leafIndexes =
+                Items
                     .Select((item, index) => new { item, index })
                     .Where(x => !x.item.IsGroup)
                     .Select(x => x.index)
                     .ToList()
-                    .AsReadOnly()
-                : new List<int>().AsReadOnly();
+                    .AsReadOnly();
 
-        Index = _leafIndexes.FirstOrDefault();
+            Index = _leafIndexes.FirstOrDefault();
+        }
+        else
+        {
+            Index = 0;
+        }
     }
 
     public bool Update(ConsoleKeyInfo keyInfo)

--- a/src/Spectre.Console/Prompts/List/ListPromptState.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptState.cs
@@ -22,12 +22,15 @@ internal sealed class ListPromptState<T>
         Mode = mode;
         SearchFilter = string.Empty;
 
-        _leafIndexes = Items
-            .Select((item, index) => new { item, index })
-            .Where(x => !x.item.IsGroup)
-            .Select(x => x.index)
-            .ToList()
-            .AsReadOnly();
+        _leafIndexes =
+            mode == SelectionMode.Leaf
+                ? Items
+                    .Select((item, index) => new { item, index })
+                    .Where(x => !x.item.IsGroup)
+                    .Select(x => x.index)
+                    .ToList()
+                    .AsReadOnly()
+                : new List<int>().AsReadOnly();
 
         Index = _leafIndexes.FirstOrDefault();
     }

--- a/src/Spectre.Console/Prompts/List/ListPromptState.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptState.cs
@@ -9,22 +9,22 @@ internal sealed class ListPromptState<T>
     public bool WrapAround { get; }
     public SelectionMode Mode { get; }
     public bool SkipUnselectableItems { get; private set; }
-    public bool SearchFilterEnabled { get; }
+    public bool SearchEnabled { get; }
     public IReadOnlyList<ListPromptItem<T>> Items { get; }
     private readonly IReadOnlyList<int>? _leafIndexes;
 
     public ListPromptItem<T> Current => Items[Index];
-    public string SearchFilter { get; private set; }
+    public string SearchText { get; private set; }
 
-    public ListPromptState(IReadOnlyList<ListPromptItem<T>> items, int pageSize, bool wrapAround, SelectionMode mode, bool skipUnselectableItems, bool searchFilterEnabled)
+    public ListPromptState(IReadOnlyList<ListPromptItem<T>> items, int pageSize, bool wrapAround, SelectionMode mode, bool skipUnselectableItems, bool searchEnabled)
     {
         Items = items;
         PageSize = pageSize;
         WrapAround = wrapAround;
         Mode = mode;
         SkipUnselectableItems = skipUnselectableItems;
-        SearchFilterEnabled = searchFilterEnabled;
-        SearchFilter = string.Empty;
+        SearchEnabled = searchEnabled;
+        SearchText = string.Empty;
 
         if (SkipUnselectableItems && mode == SelectionMode.Leaf)
         {
@@ -118,14 +118,14 @@ internal sealed class ListPromptState<T>
             };
         }
 
-        var search = SearchFilter;
+        var search = SearchText;
 
-        if (SearchFilterEnabled)
+        if (SearchEnabled)
         {
             // If is text input, append to search filter
             if (!char.IsControl(keyInfo.KeyChar))
             {
-                search = SearchFilter + keyInfo.KeyChar;
+                search = SearchText + keyInfo.KeyChar;
                 var item = Items.FirstOrDefault(x => x.Data.ToString()?.Contains(search, StringComparison.OrdinalIgnoreCase) == true && (!x.IsGroup || Mode != SelectionMode.Leaf));
                 if (item != null)
                 {
@@ -152,10 +152,10 @@ internal sealed class ListPromptState<T>
             ? (ItemCount + (index % ItemCount)) % ItemCount
             : index.Clamp(0, ItemCount - 1);
 
-        if (index != Index || SearchFilter != search)
+        if (index != Index || SearchText != search)
         {
             Index = index;
-            SearchFilter = search;
+            SearchText = search;
             return true;
         }
 

--- a/src/Spectre.Console/Prompts/List/ListPromptState.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptState.cs
@@ -7,37 +7,139 @@ internal sealed class ListPromptState<T>
     public int ItemCount => Items.Count;
     public int PageSize { get; }
     public bool WrapAround { get; }
+    public SelectionMode Mode { get; }
     public IReadOnlyList<ListPromptItem<T>> Items { get; }
+    private readonly IReadOnlyList<int> _leafIndexes;
 
     public ListPromptItem<T> Current => Items[Index];
+    public string SearchFilter { get; set; }
 
-    public ListPromptState(IReadOnlyList<ListPromptItem<T>> items, int pageSize, bool wrapAround)
+    public ListPromptState(IReadOnlyList<ListPromptItem<T>> items, int pageSize, bool wrapAround, SelectionMode mode)
     {
-        Index = 0;
         Items = items;
         PageSize = pageSize;
         WrapAround = wrapAround;
+        Mode = mode;
+        SearchFilter = string.Empty;
+
+        _leafIndexes = Items
+            .Select((item, index) => new { item, index })
+            .Where(x => !x.item.IsGroup)
+            .Select(x => x.index)
+            .ToList()
+            .AsReadOnly();
+
+        Index = _leafIndexes.FirstOrDefault();
     }
 
-    public bool Update(ConsoleKey key)
+    public bool Update(ConsoleKeyInfo keyInfo)
     {
-        var index = key switch
+        var index = Index;
+        if (Mode == SelectionMode.Leaf)
         {
-            ConsoleKey.UpArrow => Index - 1,
-            ConsoleKey.DownArrow => Index + 1,
-            ConsoleKey.Home => 0,
-            ConsoleKey.End => ItemCount - 1,
-            ConsoleKey.PageUp => Index - PageSize,
-            ConsoleKey.PageDown => Index + PageSize,
-            _ => Index,
-        };
+            var currentLeafIndex = _leafIndexes.IndexOf(index);
+            switch (keyInfo.Key)
+            {
+                case ConsoleKey.UpArrow:
+                    if (currentLeafIndex > 0)
+                    {
+                        index = _leafIndexes[currentLeafIndex - 1];
+                    }
+                    else if (WrapAround)
+                    {
+                        index = _leafIndexes.LastOrDefault();
+                    }
+
+                    break;
+
+                case ConsoleKey.DownArrow:
+                    if (currentLeafIndex < _leafIndexes.Count - 1)
+                    {
+                        index = _leafIndexes[currentLeafIndex + 1];
+                    }
+                    else if (WrapAround)
+                    {
+                        index = _leafIndexes.FirstOrDefault();
+                    }
+
+                    break;
+
+                case ConsoleKey.Home:
+                    index = _leafIndexes.FirstOrDefault();
+                    break;
+
+                case ConsoleKey.End:
+                    index = _leafIndexes.LastOrDefault();
+                    break;
+
+                case ConsoleKey.PageUp:
+                    index = Math.Max(currentLeafIndex - PageSize, 0);
+                    if (index < _leafIndexes.Count)
+                    {
+                        index = _leafIndexes[index];
+                    }
+
+                    break;
+
+                case ConsoleKey.PageDown:
+                    index = Math.Min(currentLeafIndex + PageSize, _leafIndexes.Count - 1);
+                    if (index < _leafIndexes.Count)
+                    {
+                        index = _leafIndexes[index];
+                    }
+
+                    break;
+            }
+        }
+        else
+        {
+            index = keyInfo.Key switch
+            {
+                ConsoleKey.UpArrow => Index - 1,
+                ConsoleKey.DownArrow => Index + 1,
+                ConsoleKey.Home => 0,
+                ConsoleKey.End => ItemCount - 1,
+                ConsoleKey.PageUp => Index - PageSize,
+                ConsoleKey.PageDown => Index + PageSize,
+                _ => Index,
+            };
+        }
+
+        var search = SearchFilter;
+
+        // If is text input, append to search filter
+        if (!char.IsControl(keyInfo.KeyChar))
+        {
+            search = SearchFilter + keyInfo.KeyChar;
+            var item = Items.FirstOrDefault(x => x.Data.ToString()?.Contains(search, StringComparison.OrdinalIgnoreCase) == true && (!x.IsGroup || Mode != SelectionMode.Leaf));
+            if (item != null)
+            {
+                index = Items.IndexOf(item);
+            }
+        }
+
+        if (keyInfo.Key == ConsoleKey.Backspace)
+        {
+            if (search.Length > 0)
+            {
+                search = search.Substring(0, search.Length - 1);
+            }
+
+            var item = Items.FirstOrDefault(x => x.Data.ToString()?.Contains(search, StringComparison.OrdinalIgnoreCase) == true && (!x.IsGroup || Mode != SelectionMode.Leaf));
+            if (item != null)
+            {
+                index = Items.IndexOf(item);
+            }
+        }
 
         index = WrapAround
             ? (ItemCount + (index % ItemCount)) % ItemCount
             : index.Clamp(0, ItemCount - 1);
-        if (index != Index)
+
+        if (index != Index || SearchFilter != search)
         {
             Index = index;
+            SearchFilter = search;
             return true;
         }
 

--- a/src/Spectre.Console/Prompts/List/ListPromptState.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptState.cs
@@ -8,23 +8,25 @@ internal sealed class ListPromptState<T>
     public int PageSize { get; }
     public bool WrapAround { get; }
     public SelectionMode Mode { get; }
+    public bool SkipUnselectableItems { get; private set; }
     public bool SearchFilterEnabled { get; }
     public IReadOnlyList<ListPromptItem<T>> Items { get; }
     private readonly IReadOnlyList<int>? _leafIndexes;
 
     public ListPromptItem<T> Current => Items[Index];
-    public string SearchFilter { get; set; }
+    public string SearchFilter { get; private set; }
 
-    public ListPromptState(IReadOnlyList<ListPromptItem<T>> items, int pageSize, bool wrapAround, SelectionMode mode, bool searchFilterEnabled)
+    public ListPromptState(IReadOnlyList<ListPromptItem<T>> items, int pageSize, bool wrapAround, SelectionMode mode, bool skipUnselectableItems, bool searchFilterEnabled)
     {
         Items = items;
         PageSize = pageSize;
         WrapAround = wrapAround;
         Mode = mode;
+        SkipUnselectableItems = skipUnselectableItems;
         SearchFilterEnabled = searchFilterEnabled;
         SearchFilter = string.Empty;
 
-        if (mode == SelectionMode.Leaf)
+        if (SkipUnselectableItems && mode == SelectionMode.Leaf)
         {
             _leafIndexes =
                 Items
@@ -45,7 +47,7 @@ internal sealed class ListPromptState<T>
     public bool Update(ConsoleKeyInfo keyInfo)
     {
         var index = Index;
-        if (Mode == SelectionMode.Leaf)
+        if (SkipUnselectableItems && Mode == SelectionMode.Leaf)
         {
             Debug.Assert(_leafIndexes != null, nameof(_leafIndexes) + " != null");
             var currentLeafIndex = _leafIndexes.IndexOf(index);

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -226,7 +226,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
 
     /// <inheritdoc/>
     IRenderable IListPromptStrategy<T>.Render(IAnsiConsole console, bool scrollable, int cursorIndex,
-        IEnumerable<(int Index, ListPromptItem<T> Node)> items, string stateSearchFilter)
+        IEnumerable<(int Index, ListPromptItem<T> Node)> items, string searchText)
     {
         var list = new List<IRenderable>();
         var highlightStyle = HighlightStyle ?? Color.Blue;

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -94,7 +94,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
     {
         // Create the list prompt
         var prompt = new ListPrompt<T>(console, this);
-        var result = await prompt.Show(Tree, Mode, false, PageSize, WrapAround, cancellationToken).ConfigureAwait(false);
+        var result = await prompt.Show(Tree, Mode, false, false, PageSize, WrapAround, cancellationToken).ConfigureAwait(false);
 
         if (Mode == SelectionMode.Leaf)
         {
@@ -144,9 +144,6 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
     {
         return GetParents(item).LastOrDefault();
     }
-
-    /// <inheritdoc />
-    bool IListPromptStrategy<T>.ShouldSkipUnselectableItems => false;
 
     /// <inheritdoc/>
     ListPromptInputResult IListPromptStrategy<T>.HandleInput(ConsoleKeyInfo key, ListPromptState<T> state)
@@ -226,7 +223,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
 
     /// <inheritdoc/>
     IRenderable IListPromptStrategy<T>.Render(IAnsiConsole console, bool scrollable, int cursorIndex,
-        IEnumerable<(int Index, ListPromptItem<T> Node)> items, string searchText)
+        IEnumerable<(int Index, ListPromptItem<T> Node)> items, bool skipUnselectableItems, string searchText)
     {
         var list = new List<IRenderable>();
         var highlightStyle = HighlightStyle ?? Color.Blue;

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -145,6 +145,9 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
         return GetParents(item).LastOrDefault();
     }
 
+    /// <inheritdoc />
+    bool IListPromptStrategy<T>.ShouldSkipUnselectableItems => false;
+
     /// <inheritdoc/>
     ListPromptInputResult IListPromptStrategy<T>.HandleInput(ConsoleKeyInfo key, ListPromptState<T> state)
     {

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -222,7 +222,14 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
     }
 
     /// <inheritdoc/>
-    IRenderable IListPromptStrategy<T>.Render(IAnsiConsole console, bool scrollable, int cursorIndex, IEnumerable<(int Index, ListPromptItem<T> Node)> items)
+    public SelectionMode GetSelectionMode()
+    {
+        return this.Mode;
+    }
+
+    /// <inheritdoc/>
+    IRenderable IListPromptStrategy<T>.Render(IAnsiConsole console, bool scrollable, int cursorIndex,
+        IEnumerable<(int Index, ListPromptItem<T> Node)> items, string stateSearchFilter)
     {
         var list = new List<IRenderable>();
         var highlightStyle = HighlightStyle ?? Color.Blue;

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -94,7 +94,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
     {
         // Create the list prompt
         var prompt = new ListPrompt<T>(console, this);
-        var result = await prompt.Show(Tree, cancellationToken, PageSize, WrapAround).ConfigureAwait(false);
+        var result = await prompt.Show(Tree, Mode, false, PageSize, WrapAround, cancellationToken).ConfigureAwait(false);
 
         if (Mode == SelectionMode.Leaf)
         {
@@ -219,12 +219,6 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
         }
 
         return pageSize;
-    }
-
-    /// <inheritdoc/>
-    public SelectionMode GetSelectionMode()
-    {
-        return this.Mode;
     }
 
     /// <inheritdoc/>

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -37,6 +37,11 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     public Style? DisabledStyle { get; set; }
 
     /// <summary>
+    /// Gets or sets the style of highlighted search matches.
+    /// </summary>
+    public Style? SearchHighlightStyle { get; set; }
+
+    /// <summary>
     /// Gets or sets the converter to get the display string for a choice. By default
     /// the corresponding <see cref="TypeConverter"/> is used.
     /// </summary>
@@ -52,6 +57,11 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     /// Defaults to <see cref="SelectionMode.Leaf"/>.
     /// </summary>
     public SelectionMode Mode { get; set; } = SelectionMode.Leaf;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not the search filter is enabled.
+    /// </summary>
+    public bool SearchFilterEnabled { get; set; } = false;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SelectionPrompt{T}"/> class.
@@ -134,11 +144,19 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     }
 
     /// <inheritdoc/>
-    IRenderable IListPromptStrategy<T>.Render(IAnsiConsole console, bool scrollable, int cursorIndex, IEnumerable<(int Index, ListPromptItem<T> Node)> items)
+    public SelectionMode GetSelectionMode()
+    {
+        return this.Mode;
+    }
+
+    /// <inheritdoc/>
+    IRenderable IListPromptStrategy<T>.Render(IAnsiConsole console, bool scrollable, int cursorIndex,
+        IEnumerable<(int Index, ListPromptItem<T> Node)> items, string stateSearchFilter)
     {
         var list = new List<IRenderable>();
         var disabledStyle = DisabledStyle ?? Color.Grey;
         var highlightStyle = HighlightStyle ?? Color.Blue;
+        var searchHighlightStyle = SearchHighlightStyle ?? new Style(foreground: Color.Default, background: Color.Yellow, Decoration.Bold);
 
         if (Title != null)
         {
@@ -169,6 +187,23 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
                 text = text.RemoveMarkup().EscapeMarkup();
             }
 
+            if (stateSearchFilter.Length > 0 && !(item.Node.IsGroup && Mode == SelectionMode.Leaf))
+            {
+                var index = text.IndexOf(stateSearchFilter, StringComparison.OrdinalIgnoreCase);
+                if (index >= 0)
+                {
+                    var before = text.Substring(0, index);
+                    var match = text.Substring(index, stateSearchFilter.Length);
+                    var after = text.Substring(index + stateSearchFilter.Length);
+
+                    text = new StringBuilder()
+                        .Append(before)
+                        .AppendWithStyle(searchHighlightStyle, match)
+                        .Append(after)
+                        .ToString();
+                }
+            }
+
             grid.AddRow(new Markup(indent + prompt + " " + text, style));
         }
 
@@ -179,6 +214,13 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
             // (Move up and down to reveal more choices)
             list.Add(Text.Empty);
             list.Add(new Markup(MoreChoicesText ?? ListPromptConstants.MoreChoicesMarkup));
+        }
+
+        if (SearchFilterEnabled)
+        {
+            list.Add(Text.Empty);
+            list.Add(new Markup(
+                $"search: {(stateSearchFilter.Length > 0 ? stateSearchFilter.EscapeMarkup() : ListPromptConstants.SearchPlaceholderMarkup)}"));
         }
 
         return new Rows(list);

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -94,7 +94,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     {
         // Create the list prompt
         var prompt = new ListPrompt<T>(console, this);
-        var result = await prompt.Show(_tree, cancellationToken, PageSize, WrapAround).ConfigureAwait(false);
+        var result = await prompt.Show(_tree, Mode, SearchFilterEnabled, PageSize, WrapAround, cancellationToken).ConfigureAwait(false);
 
         // Return the selected item
         return result.Items[result.Index].Data;
@@ -135,18 +135,18 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
             extra += 2;
         }
 
+        if (SearchFilterEnabled)
+        {
+            // The search instructions takes up two rows
+            extra += 2;
+        }
+
         if (requestedPageSize > console.Profile.Height - extra)
         {
             return console.Profile.Height - extra;
         }
 
         return requestedPageSize;
-    }
-
-    /// <inheritdoc/>
-    public SelectionMode GetSelectionMode()
-    {
-        return this.Mode;
     }
 
     /// <inheritdoc/>

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -103,7 +103,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     /// <inheritdoc/>
     ListPromptInputResult IListPromptStrategy<T>.HandleInput(ConsoleKeyInfo key, ListPromptState<T> state)
     {
-        if (key.Key == ConsoleKey.Enter || key.Key == ConsoleKey.Spacebar || key.Key == ConsoleKey.Packet)
+        if (key.Key == ConsoleKey.Enter || key.Key == ConsoleKey.Packet)
         {
             // Selecting a non leaf in "leaf mode" is not allowed
             if (state.Current.IsGroup && Mode == SelectionMode.Leaf)

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -61,7 +61,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     /// <summary>
     /// Gets or sets a value indicating whether or not the search filter is enabled.
     /// </summary>
-    public bool SearchFilterEnabled { get; set; } = false;
+    public bool SearchFilterEnabled { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SelectionPrompt{T}"/> class.

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -197,19 +197,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
 
             if (searchText.Length > 0 && !(item.Node.IsGroup && Mode == SelectionMode.Leaf))
             {
-                var index = text.IndexOf(searchText, StringComparison.OrdinalIgnoreCase);
-                if (index >= 0)
-                {
-                    var before = text.Substring(0, index);
-                    var match = text.Substring(index, searchText.Length);
-                    var after = text.Substring(index + searchText.Length);
-
-                    text = new StringBuilder()
-                        .Append(before)
-                        .AppendWithStyle(searchHighlightStyle, match)
-                        .Append(after)
-                        .ToString();
-                }
+                text = text.Highlight(searchText, searchHighlightStyle);
             }
 
             grid.AddRow(new Markup(indent + prompt + " " + text, style));

--- a/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
@@ -183,13 +183,12 @@ public static class SelectionPromptExtensions
     }
 
     /// <summary>
-    /// Sets whether the search filter should be enabled.
+    /// Enables search for the prompt.
     /// </summary>
     /// <typeparam name="T">The prompt result type.</typeparam>
     /// <param name="obj">The prompt.</param>
-    /// <param name="enabled">Whether the search filter should be enabled.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static SelectionPrompt<T> Search<T>(this SelectionPrompt<T> obj, bool enabled = true)
+    public static SelectionPrompt<T> EnableSearch<T>(this SelectionPrompt<T> obj)
         where T : notnull
     {
         if (obj is null)
@@ -197,7 +196,44 @@ public static class SelectionPromptExtensions
             throw new ArgumentNullException(nameof(obj));
         }
 
-        obj.SearchEnabled = enabled;
+        obj.SearchEnabled = true;
+        return obj;
+    }
+
+    /// <summary>
+    /// Disables search for the prompt.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static SelectionPrompt<T> DisableSearch<T>(this SelectionPrompt<T> obj)
+        where T : notnull
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        obj.SearchEnabled = false;
+        return obj;
+    }
+
+    /// <summary>
+    /// Sets the text that will be displayed when no search text has been entered.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="text">The text to display.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static SelectionPrompt<T> SearchPlaceholderText<T>(this SelectionPrompt<T> obj, string? text)
+        where T : notnull
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        obj.SearchPlaceholderText = text;
         return obj;
     }
 

--- a/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
@@ -183,6 +183,25 @@ public static class SelectionPromptExtensions
     }
 
     /// <summary>
+    /// Sets whether the search filter should be enabled.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="enabled">Whether the search filter should be enabled.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static SelectionPrompt<T> SearchFilter<T>(this SelectionPrompt<T> obj, bool enabled = true)
+        where T : notnull
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        obj.SearchFilterEnabled = enabled;
+        return obj;
+    }
+
+    /// <summary>
     /// Sets the highlight style of the selected choice.
     /// </summary>
     /// <typeparam name="T">The prompt result type.</typeparam>

--- a/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
@@ -189,7 +189,7 @@ public static class SelectionPromptExtensions
     /// <param name="obj">The prompt.</param>
     /// <param name="enabled">Whether the search filter should be enabled.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static SelectionPrompt<T> SearchFilter<T>(this SelectionPrompt<T> obj, bool enabled = true)
+    public static SelectionPrompt<T> Search<T>(this SelectionPrompt<T> obj, bool enabled = true)
         where T : notnull
     {
         if (obj is null)
@@ -197,7 +197,7 @@ public static class SelectionPromptExtensions
             throw new ArgumentNullException(nameof(obj));
         }
 
-        obj.SearchFilterEnabled = enabled;
+        obj.SearchEnabled = enabled;
         return obj;
     }
 

--- a/test/Spectre.Console.Tests/Extensions/ConsoleKeyExtensions.cs
+++ b/test/Spectre.Console.Tests/Extensions/ConsoleKeyExtensions.cs
@@ -1,0 +1,15 @@
+namespace Spectre.Console.Tests;
+
+public static class ConsoleKeyExtensions
+{
+    public static ConsoleKeyInfo ToConsoleKeyInfo(this ConsoleKey key)
+    {
+        var ch = (char)key;
+        if (char.IsControl(ch))
+        {
+            ch = '\0';
+        }
+
+        return new ConsoleKeyInfo(ch, key, false, false, false);
+    }
+}

--- a/test/Spectre.Console.Tests/Unit/HighlightTests.cs
+++ b/test/Spectre.Console.Tests/Unit/HighlightTests.cs
@@ -4,6 +4,8 @@ namespace Namespace;
 
 public class HighlightTests
 {
+    private readonly Style _highlightStyle = new Style(foreground: Color.Default, background: Color.Yellow, Decoration.Bold);
+
     [Fact]
     public void Should_Return_Same_Value_When_SearchText_Is_Empty()
     {
@@ -25,7 +27,7 @@ public class HighlightTests
         // Given
         var value = "Sample text with test word";
         var searchText = "test";
-        var highlightStyle = new Style(foreground: Color.Default, background: Color.Yellow, Decoration.Bold);
+        var highlightStyle = _highlightStyle;
 
         // When
         var result = value.Highlight(searchText, highlightStyle);
@@ -40,7 +42,22 @@ public class HighlightTests
         // Given
         var value = "[red]Sample text[/] with test word";
         var searchText = "text with";
-        var highlightStyle = new Style(foreground: Color.Default, background: Color.Yellow, Decoration.Bold);
+        var highlightStyle = _highlightStyle;
+
+        // When
+        var result = value.Highlight(searchText, highlightStyle);
+
+        // Then
+        result.ShouldBe(value);
+    }
+
+    [Fact]
+    public void Should_Not_Match_Text_Outside_Of_Text_Tokens()
+    {
+        // Given
+        var value = "[red]Sample text with test word[/]";
+        var searchText = "red";
+        var highlightStyle = _highlightStyle;
 
         // When
         var result = value.Highlight(searchText, highlightStyle);

--- a/test/Spectre.Console.Tests/Unit/HighlightTests.cs
+++ b/test/Spectre.Console.Tests/Unit/HighlightTests.cs
@@ -52,6 +52,21 @@ public class HighlightTests
     }
 
     [Fact]
+    public void Should_Highlight_Only_First_Matched_Text()
+    {
+        // Given
+        var value = "Sample text with test word";
+        var searchText = "te";
+        var highlightStyle = _highlightStyle;
+
+        // When
+        var result = value.Highlight(searchText, highlightStyle);
+
+        // Then
+        result.ShouldBe("Sample [bold on yellow]te[/]xt with test word");
+    }
+
+    [Fact]
     public void Should_Not_Match_Text_Outside_Of_Text_Tokens()
     {
         // Given

--- a/test/Spectre.Console.Tests/Unit/HighlightTests.cs
+++ b/test/Spectre.Console.Tests/Unit/HighlightTests.cs
@@ -1,0 +1,51 @@
+using Spectre.Console;
+
+namespace Namespace;
+
+public class HighlightTests
+{
+    [Fact]
+    public void Should_Return_Same_Value_When_SearchText_Is_Empty()
+    {
+        // Given
+        var value = "Sample text";
+        var searchText = string.Empty;
+        var highlightStyle = new Style();
+
+        // When
+        var result = value.Highlight(searchText, highlightStyle);
+
+        // Then
+        result.ShouldBe(value);
+    }
+
+    [Fact]
+    public void Should_Highlight_Matched_Text()
+    {
+        // Given
+        var value = "Sample text with test word";
+        var searchText = "test";
+        var highlightStyle = new Style(foreground: Color.Default, background: Color.Yellow, Decoration.Bold);
+
+        // When
+        var result = value.Highlight(searchText, highlightStyle);
+
+        // Then
+        result.ShouldBe("Sample text with [bold on yellow]test[/] word");
+    }
+
+    [Fact]
+    public void Should_Not_Match_Text_Across_Tokens()
+    {
+        // Given
+        var value = "[red]Sample text[/] with test word";
+        var searchText = "text with";
+        var highlightStyle = new Style(foreground: Color.Default, background: Color.Yellow, Decoration.Bold);
+
+        // When
+        var result = value.Highlight(searchText, highlightStyle);
+
+        // Then
+        result.ShouldBe(value);
+    }
+}

--- a/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
@@ -3,7 +3,7 @@ namespace Spectre.Console.Tests.Unit;
 public sealed class ListPromptStateTests
 {
     private ListPromptState<string> CreateListPromptState(int count, int pageSize, bool shouldWrap)
-        => new(Enumerable.Repeat(new ListPromptItem<string>(string.Empty), count).ToList(), pageSize, shouldWrap, SelectionMode.Independent);
+        => new(Enumerable.Repeat(new ListPromptItem<string>(string.Empty), count).ToList(), pageSize, shouldWrap, SelectionMode.Independent, false);
 
     [Fact]
     public void Should_Have_Start_Index_Zero()

--- a/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
@@ -2,14 +2,14 @@ namespace Spectre.Console.Tests.Unit;
 
 public sealed class ListPromptStateTests
 {
-    private ListPromptState<string> CreateListPromptState(int count, int pageSize, bool shouldWrap)
-        => new(Enumerable.Repeat(new ListPromptItem<string>(string.Empty), count).ToList(), pageSize, shouldWrap, SelectionMode.Independent, true, false);
+    private ListPromptState<string> CreateListPromptState(int count, int pageSize, bool shouldWrap, bool searchEnabled)
+        => new(Enumerable.Range(0, count).Select(i => new ListPromptItem<string>(i.ToString())).ToList(), pageSize, shouldWrap, SelectionMode.Independent, true, searchEnabled);
 
     [Fact]
     public void Should_Have_Start_Index_Zero()
     {
         // Given
-        var state = CreateListPromptState(100, 10, false);
+        var state = CreateListPromptState(100, 10, false, false);
 
         // When
         /* noop */
@@ -24,7 +24,7 @@ public sealed class ListPromptStateTests
     public void Should_Increase_Index(bool wrap)
     {
         // Given
-        var state = CreateListPromptState(100, 10, wrap);
+        var state = CreateListPromptState(100, 10, wrap, false);
         var index = state.Index;
 
         // When
@@ -40,7 +40,7 @@ public sealed class ListPromptStateTests
     public void Should_Go_To_End(bool wrap)
     {
         // Given
-        var state = CreateListPromptState(100, 10, wrap);
+        var state = CreateListPromptState(100, 10, wrap, false);
 
         // When
         state.Update(ConsoleKey.End.ToConsoleKeyInfo());
@@ -53,7 +53,7 @@ public sealed class ListPromptStateTests
     public void Should_Clamp_Index_If_No_Wrap()
     {
         // Given
-        var state = CreateListPromptState(100, 10, false);
+        var state = CreateListPromptState(100, 10, false, false);
         state.Update(ConsoleKey.End.ToConsoleKeyInfo());
 
         // When
@@ -67,7 +67,7 @@ public sealed class ListPromptStateTests
     public void Should_Wrap_Index_If_Wrap()
     {
         // Given
-        var state = CreateListPromptState(100, 10, true);
+        var state = CreateListPromptState(100, 10, true, false);
         state.Update(ConsoleKey.End.ToConsoleKeyInfo());
 
         // When
@@ -81,7 +81,7 @@ public sealed class ListPromptStateTests
     public void Should_Wrap_Index_If_Wrap_And_Down()
     {
         // Given
-        var state = CreateListPromptState(100, 10, true);
+        var state = CreateListPromptState(100, 10, true, false);
 
         // When
         state.Update(ConsoleKey.UpArrow.ToConsoleKeyInfo());
@@ -94,7 +94,7 @@ public sealed class ListPromptStateTests
     public void Should_Wrap_Index_If_Wrap_And_Page_Up()
     {
         // Given
-        var state = CreateListPromptState(10, 100, true);
+        var state = CreateListPromptState(10, 100, true, false);
 
         // When
         state.Update(ConsoleKey.PageUp.ToConsoleKeyInfo());
@@ -107,7 +107,7 @@ public sealed class ListPromptStateTests
     public void Should_Wrap_Index_If_Wrap_And_Offset_And_Page_Down()
     {
         // Given
-        var state = CreateListPromptState(10, 100, true);
+        var state = CreateListPromptState(10, 100, true, false);
         state.Update(ConsoleKey.End.ToConsoleKeyInfo());
         state.Update(ConsoleKey.UpArrow.ToConsoleKeyInfo());
 
@@ -116,5 +116,32 @@ public sealed class ListPromptStateTests
 
         // Then
         state.Index.ShouldBe(8);
+    }
+
+    [Fact]
+    public void Should_Jump_To_First_Matching_Item_When_Searching()
+    {
+        // Given
+        var state = CreateListPromptState(10, 100, true, true);
+
+        // When
+        state.Update(ConsoleKey.D3.ToConsoleKeyInfo());
+
+        // Then
+        state.Index.ShouldBe(3);
+    }
+
+    [Fact]
+    public void Should_Jump_Back_To_First_Item_When_Clearing_Search_Term()
+    {
+        // Given
+        var state = CreateListPromptState(10, 100, true, true);
+
+        // When
+        state.Update(ConsoleKey.D3.ToConsoleKeyInfo());
+        state.Update(ConsoleKey.Backspace.ToConsoleKeyInfo());
+
+        // Then
+        state.Index.ShouldBe(0);
     }
 }

--- a/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
@@ -3,7 +3,7 @@ namespace Spectre.Console.Tests.Unit;
 public sealed class ListPromptStateTests
 {
     private ListPromptState<string> CreateListPromptState(int count, int pageSize, bool shouldWrap)
-        => new(Enumerable.Repeat(new ListPromptItem<string>(string.Empty), count).ToList(), pageSize, shouldWrap);
+        => new(Enumerable.Repeat(new ListPromptItem<string>(string.Empty), count).ToList(), pageSize, shouldWrap, SelectionMode.Independent);
 
     [Fact]
     public void Should_Have_Start_Index_Zero()
@@ -28,7 +28,7 @@ public sealed class ListPromptStateTests
         var index = state.Index;
 
         // When
-        state.Update(ConsoleKey.DownArrow);
+        state.Update(ConsoleKey.DownArrow.ToConsoleKeyInfo());
 
         // Then
         state.Index.ShouldBe(index + 1);
@@ -43,7 +43,7 @@ public sealed class ListPromptStateTests
         var state = CreateListPromptState(100, 10, wrap);
 
         // When
-        state.Update(ConsoleKey.End);
+        state.Update(ConsoleKey.End.ToConsoleKeyInfo());
 
         // Then
         state.Index.ShouldBe(99);
@@ -54,10 +54,10 @@ public sealed class ListPromptStateTests
     {
         // Given
         var state = CreateListPromptState(100, 10, false);
-        state.Update(ConsoleKey.End);
+        state.Update(ConsoleKey.End.ToConsoleKeyInfo());
 
         // When
-        state.Update(ConsoleKey.DownArrow);
+        state.Update(ConsoleKey.DownArrow.ToConsoleKeyInfo());
 
         // Then
         state.Index.ShouldBe(99);
@@ -68,10 +68,10 @@ public sealed class ListPromptStateTests
     {
         // Given
         var state = CreateListPromptState(100, 10, true);
-        state.Update(ConsoleKey.End);
+        state.Update(ConsoleKey.End.ToConsoleKeyInfo());
 
         // When
-        state.Update(ConsoleKey.DownArrow);
+        state.Update(ConsoleKey.DownArrow.ToConsoleKeyInfo());
 
         // Then
         state.Index.ShouldBe(0);
@@ -84,7 +84,7 @@ public sealed class ListPromptStateTests
         var state = CreateListPromptState(100, 10, true);
 
         // When
-        state.Update(ConsoleKey.UpArrow);
+        state.Update(ConsoleKey.UpArrow.ToConsoleKeyInfo());
 
         // Then
         state.Index.ShouldBe(99);
@@ -97,7 +97,7 @@ public sealed class ListPromptStateTests
         var state = CreateListPromptState(10, 100, true);
 
         // When
-        state.Update(ConsoleKey.PageUp);
+        state.Update(ConsoleKey.PageUp.ToConsoleKeyInfo());
 
         // Then
         state.Index.ShouldBe(0);
@@ -108,11 +108,11 @@ public sealed class ListPromptStateTests
     {
         // Given
         var state = CreateListPromptState(10, 100, true);
-        state.Update(ConsoleKey.End);
-        state.Update(ConsoleKey.UpArrow);
+        state.Update(ConsoleKey.End.ToConsoleKeyInfo());
+        state.Update(ConsoleKey.UpArrow.ToConsoleKeyInfo());
 
         // When
-        state.Update(ConsoleKey.PageDown);
+        state.Update(ConsoleKey.PageDown.ToConsoleKeyInfo());
 
         // Then
         state.Index.ShouldBe(8);

--- a/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
@@ -3,7 +3,7 @@ namespace Spectre.Console.Tests.Unit;
 public sealed class ListPromptStateTests
 {
     private ListPromptState<string> CreateListPromptState(int count, int pageSize, bool shouldWrap)
-        => new(Enumerable.Repeat(new ListPromptItem<string>(string.Empty), count).ToList(), pageSize, shouldWrap, SelectionMode.Independent, false);
+        => new(Enumerable.Repeat(new ListPromptItem<string>(string.Empty), count).ToList(), pageSize, shouldWrap, SelectionMode.Independent, true, false);
 
     [Fact]
     public void Should_Have_Start_Index_Zero()

--- a/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -2,6 +2,8 @@ namespace Spectre.Console.Tests.Unit;
 
 public sealed class SelectionPromptTests
 {
+    private const string ESC = "\u001b";
+
     [Fact]
     public void Should_Not_Throw_When_Selecting_An_Item_With_Escaped_Markup()
     {
@@ -61,5 +63,27 @@ public sealed class SelectionPromptTests
 
         // Then
         selection.ShouldBe("D");
+    }
+
+    [Fact]
+    public void Should_Highlight_Search_Term()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.EmitAnsiSequences();
+        console.Input.PushText("1");
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+            .Title("Select one")
+            .EnableSearch()
+            .AddChoices("Item 1");
+        prompt.Show(console);
+
+        // Then
+        var consoleOutput = console.Output;
+        consoleOutput.ShouldContain($"{ESC}[38;5;12m> Item {ESC}[0m{ESC}[1;38;5;12;48;5;11m1{ESC}[0m");
     }
 }

--- a/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -20,4 +20,48 @@ public sealed class SelectionPromptTests
         // Then
         console.Output.ShouldContain(@"[red]This text will never be red[/]");
     }
+
+    [Fact]
+    public void Should_Select_The_First_Leaf_Item()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .Mode(SelectionMode.Leaf)
+                .AddChoiceGroup("Group one", "A", "B")
+                .AddChoiceGroup("Group two", "C", "D");
+        var selection = prompt.Show(console);
+
+        // Then
+        selection.ShouldBe("A");
+    }
+
+    [Fact]
+    public void Should_Select_The_Last_Leaf_Item_When_Wrapping_Around()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.UpArrow);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+            .Title("Select one")
+            .Mode(SelectionMode.Leaf)
+            .WrapAround()
+            .AddChoiceGroup("Group one", "A", "B")
+            .AddChoiceGroup("Group two", "C", "D");
+        var selection = prompt.Show(console);
+
+        // Then
+        selection.ShouldBe("D");
+    }
+
+
 }

--- a/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -83,7 +83,6 @@ public sealed class SelectionPromptTests
         prompt.Show(console);
 
         // Then
-        var consoleOutput = console.Output;
-        consoleOutput.ShouldContain($"{ESC}[38;5;12m> Item {ESC}[0m{ESC}[1;38;5;12;48;5;11m1{ESC}[0m");
+        console.Output.ShouldContain($"{ESC}[38;5;12m> Item {ESC}[0m{ESC}[1;38;5;12;48;5;11m1{ESC}[0m");
     }
 }

--- a/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -62,6 +62,4 @@ public sealed class SelectionPromptTests
         // Then
         selection.ShouldBe("D");
     }
-
-
 }


### PR DESCRIPTION
![Multi Selection Search](https://github.com/spectreconsole/spectre.console/assets/1341446/76476b6c-3d9f-4e28-a383-0b8fa047d998)

This PR adds a couple of features to Selection Prompt:
* Search as you type
* Skipping selection of group nodes for `Leaf` selection mode

I've yet to add the tests which is a bit naughty, but wanted to share what I have so far to start some discussion. Is this feature welcome, or is there a better direction?