### PR TITLE
Fix figlet centering possibly throwing due to negative size

### DIFF
--- a/src/Spectre.Console/Widgets/Figlet/FigletText.cs
+++ b/src/Spectre.Console/Widgets/Figlet/FigletText.cs
@@ -67,8 +67,8 @@ public sealed class FigletText : Renderable, IHasJustification
                 }
                 else if (alignment == Console.Justify.Center)
                 {
-                    var left = (maxWidth - lineWidth) / 2;
-                    var right = left + ((maxWidth - lineWidth) % 2);
+                    var left = Math.Max(0, maxWidth - lineWidth) / 2;
+                    var right = left + (Math.Max(0, maxWidth - lineWidth) % 2);
 
                     yield return Segment.Padding(left);
                     yield return line;


### PR DESCRIPTION
Fixing this issue https://github.com/spectreconsole/spectre.console/issues/1189

Zeroing values which can end up negative causing Segment.Padding ctor to throw