### PR TITLE
Add TypeResolver to ExceptionHandler

### DIFF
--- a/src/Spectre.Console.Cli/ConfiguratorExtensions.cs
+++ b/src/Spectre.Console.Cli/ConfiguratorExtensions.cs
@@ -359,7 +359,7 @@ public static class ConfiguratorExtensions
     /// <param name="configurator">The configurator.</param>
     /// <param name="exceptionHandler">The Action that handles the exception.</param>
     /// <returns>A configurator that can be used to configure the application further.</returns>
-    public static IConfigurator SetExceptionHandler(this IConfigurator configurator, Func<Exception, int>? exceptionHandler)
+    public static IConfigurator SetExceptionHandler(this IConfigurator configurator, Func<Exception, ITypeResolver, int>? exceptionHandler)
     {
         if (configurator == null)
         {
@@ -368,5 +368,16 @@ public static class ConfiguratorExtensions
 
         configurator.Settings.ExceptionHandler = exceptionHandler;
         return configurator;
+    }
+
+    /// <summary>
+    /// Sets the ExceptionsHandler.
+    /// </summary>
+    /// <param name="configurator">The configurator.</param>
+    /// <param name="exceptionHandler">The Action that handles the exception.</param>
+    /// <returns>A configurator that can be used to configure the application further.</returns>
+    public static IConfigurator SetExceptionHandler(this IConfigurator configurator, Func<Exception, int>? exceptionHandler)
+    {
+        return configurator.SetExceptionHandler(exceptionHandler == null ? null : (ex, _) => exceptionHandler(ex));
     }
 }

--- a/src/Spectre.Console.Cli/ICommandAppSettings.cs
+++ b/src/Spectre.Console.Cli/ICommandAppSettings.cs
@@ -80,5 +80,5 @@ public interface ICommandAppSettings
     /// Gets or sets a handler for Exceptions.
     /// <para>This handler will not be called, if <see cref="PropagateExceptions"/> is set to <c>true</c>.</para>
     /// </summary>
-    public Func<Exception, int>? ExceptionHandler { get; set; }
+    public Func<Exception, ITypeResolver, int>? ExceptionHandler { get; set; }
 }

--- a/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
@@ -4,118 +4,92 @@ internal sealed class CommandExecutor
 {
     private readonly ITypeRegistrar _registrar;
 
-    public CommandExecutor(ITypeRegistrar registrar)
+    public IConfiguration Configuration { get; }
+    public IEnumerable<string> Args { get; }
+    public bool RequiresVersion { get; internal set; }
+    public HelpProvider DefaultHelpProvider { get; internal set; }
+    public CommandTreeParserResult ParsedResult { get; internal set; }
+    public CommandModel Model { get; internal set; }
+
+    public CommandExecutor(
+        ITypeRegistrar registrar,
+        IConfiguration configuration,
+        IEnumerable<string> args,
+        bool requiresVersion,
+        HelpProvider? defaultHelpProvider,
+        CommandTreeParserResult? parsedResult,
+        CommandModel? model)
     {
         _registrar = registrar ?? throw new ArgumentNullException(nameof(registrar));
+        Configuration = configuration;
+        Args = args;
         _registrar.Register(typeof(DefaultPairDeconstructor), typeof(DefaultPairDeconstructor));
-    }
+        RequiresVersion = requiresVersion;
 
-    public async Task<int> Execute(IConfiguration configuration, IEnumerable<string> args)
-    {
-        if (configuration == null)
+        if (requiresVersion)
         {
-            throw new ArgumentNullException(nameof(configuration));
+            return;
         }
 
-        args ??= new List<string>();
+        DefaultHelpProvider = defaultHelpProvider ?? throw new ArgumentNullException(nameof(defaultHelpProvider));
+        ParsedResult = parsedResult ?? throw new ArgumentNullException(nameof(parsedResult));
+        Model = model ?? throw new ArgumentNullException(nameof(model));
+    }
 
-        _registrar.RegisterInstance(typeof(IConfiguration), configuration);
-        _registrar.RegisterLazy(typeof(IAnsiConsole), () => configuration.Settings.Console.GetConsole());
-
-        // Register the help provider
-        var defaultHelpProvider = new HelpProvider(configuration.Settings);
-        _registrar.RegisterInstance(typeof(IHelpProvider), defaultHelpProvider);
-
-        // Create the command model.
-        var model = CommandModelBuilder.Build(configuration);
-        _registrar.RegisterInstance(typeof(CommandModel), model);
-        _registrar.RegisterDependencies(model);
-
+    public async Task<int> Execute()
+    {
         // Asking for version? Kind of a hack, but it's alright.
         // We should probably make this a bit better in the future.
-        if (args.Contains("-v") || args.Contains("--version"))
+        if (RequiresVersion)
         {
-            var console = configuration.Settings.Console.GetConsole();
-            console.WriteLine(ResolveApplicationVersion(configuration));
+            var console = Configuration.Settings.Console.GetConsole();
+            console.WriteLine(ResolveApplicationVersion(Configuration));
             return 0;
         }
 
-        // Parse and map the model against the arguments.
-        var parsedResult = ParseCommandLineArguments(model, configuration.Settings, args);
-
-        // Register the arguments with the container.
-        _registrar.RegisterInstance(typeof(CommandTreeParserResult), parsedResult);
-        _registrar.RegisterInstance(typeof(IRemainingArguments), parsedResult.Remaining);
-
         // Create the resolver.
-        using (var resolver = new TypeResolverAdapter(_registrar.Build()))
+        using var resolver = new TypeResolverAdapter(_registrar.Build());
+
+        // Get the registered help provider, falling back to the default provider
+        // registered above if no custom implementations have been registered.
+        var helpProvider = resolver.Resolve(typeof(IHelpProvider)) as IHelpProvider ?? DefaultHelpProvider;
+
+        // Currently the root?
+        if (ParsedResult?.Tree == null)
         {
-            // Get the registered help provider, falling back to the default provider
-            // registered above if no custom implementations have been registered.
-            var helpProvider = resolver.Resolve(typeof(IHelpProvider)) as IHelpProvider ?? defaultHelpProvider;
-
-            // Currently the root?
-            if (parsedResult?.Tree == null)
-            {
-                // Display help.
-                configuration.Settings.Console.SafeRender(helpProvider.Write(model, null));
-                return 0;
-            }
-
-            // Get the command to execute.
-            var leaf = parsedResult.Tree.GetLeafCommand();
-            if (leaf.Command.IsBranch || leaf.ShowHelp)
-            {
-                // Branches can't be executed. Show help.
-                configuration.Settings.Console.SafeRender(helpProvider.Write(model, leaf.Command));
-                return leaf.ShowHelp ? 0 : 1;
-            }
-
-            // Is this the default and is it called without arguments when there are required arguments?
-            if (leaf.Command.IsDefaultCommand && args.Count() == 0 && leaf.Command.Parameters.Any(p => p.Required))
-            {
-                // Display help for default command.
-                configuration.Settings.Console.SafeRender(helpProvider.Write(model, leaf.Command));
-                return 1;
-            }
-
-            // Create the content.
-            var context = new CommandContext(parsedResult.Remaining, leaf.Command.Name, leaf.Command.Data);
-
-            // Execute the command tree.
-            return await Execute(leaf, parsedResult.Tree, context, resolver, configuration).ConfigureAwait(false);
+            // Display help.
+            Configuration.Settings.Console.SafeRender(helpProvider.Write(Model, null));
+            return 0;
         }
+
+        // Get the command to execute.
+        var leaf = ParsedResult.Tree.GetLeafCommand();
+        if (leaf.Command.IsBranch || leaf.ShowHelp)
+        {
+            // Branches can't be executed. Show help.
+            Configuration.Settings.Console.SafeRender(helpProvider.Write(Model, leaf.Command));
+            return leaf.ShowHelp ? 0 : 1;
+        }
+
+        // Is this the default and is it called without arguments when there are required arguments?
+        if (leaf.Command.IsDefaultCommand && Args.Count() == 0 && leaf.Command.Parameters.Any(p => p.Required))
+        {
+            // Display help for default command.
+            Configuration.Settings.Console.SafeRender(helpProvider.Write(Model, leaf.Command));
+            return 1;
+        }
+
+        // Create the content.
+        var context = new CommandContext(ParsedResult.Remaining, leaf.Command.Name, leaf.Command.Data);
+
+        // Execute the command tree.
+        return await Execute(leaf, ParsedResult.Tree, context, resolver, Configuration).ConfigureAwait(false);
     }
 
-#pragma warning disable CS8603 // Possible null reference return.
-    private CommandTreeParserResult ParseCommandLineArguments(CommandModel model, CommandAppSettings settings, IEnumerable<string> args)
+    public TypeResolverAdapter BuildTypeResolver()
     {
-        var parser = new CommandTreeParser(model, settings.CaseSensitivity, settings.ParsingMode, settings.ConvertFlagsToRemainingArguments);
-
-        var parserContext = new CommandTreeParserContext(args, settings.ParsingMode);
-        var tokenizerResult = CommandTreeTokenizer.Tokenize(args);
-        var parsedResult = parser.Parse(parserContext, tokenizerResult);
-
-        var lastParsedLeaf = parsedResult?.Tree?.GetLeafCommand();
-        var lastParsedCommand = lastParsedLeaf?.Command;
-        if (lastParsedLeaf != null && lastParsedCommand != null &&
-            lastParsedCommand.IsBranch && !lastParsedLeaf.ShowHelp &&
-            lastParsedCommand.DefaultCommand != null)
-        {
-            // Insert this branch's default command into the command line
-            // arguments and try again to see if it will parse.
-            var argsWithDefaultCommand = new List<string>(args);
-
-            argsWithDefaultCommand.Insert(tokenizerResult.Tokens.Position, lastParsedCommand.DefaultCommand.Name);
-
-            parserContext = new CommandTreeParserContext(argsWithDefaultCommand, settings.ParsingMode);
-            tokenizerResult = CommandTreeTokenizer.Tokenize(argsWithDefaultCommand);
-            parsedResult = parser.Parse(parserContext, tokenizerResult);
-        }
-
-        return parsedResult;
+        return new TypeResolverAdapter(_registrar.Build());
     }
-#pragma warning restore CS8603 // Possible null reference return.
 
     private static string ResolveApplicationVersion(IConfiguration configuration)
     {

--- a/src/Spectre.Console.Cli/Internal/CommandExecutorFactory.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExecutorFactory.cs
@@ -1,0 +1,97 @@
+namespace Spectre.Console.Cli.Internal;
+
+internal class CommandExecutorFactory
+{
+    private ITypeRegistrar _registrar;
+
+    public CommandExecutorFactory(ITypeRegistrar registrar)
+    {
+        _registrar = registrar ?? throw new ArgumentNullException(nameof(registrar));
+    }
+
+    public CommandExecutor CreateCommandExecutor(IConfiguration configuration, IEnumerable<string> args)
+    {
+        if (configuration == null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        args ??= new List<string>();
+
+        // Asking for version? Kind of a hack, but it's alright.
+        // We should probably make this a bit better in the future.
+        if (args.Contains("-v") || args.Contains("--version"))
+        {
+            return new CommandExecutor(
+                registrar: _registrar,
+                configuration: configuration,
+                args: args,
+                requiresVersion: true,
+                defaultHelpProvider: null,
+                parsedResult: null,
+                model: null);
+        }
+
+        _registrar.Register(typeof(DefaultPairDeconstructor), typeof(DefaultPairDeconstructor));
+        _registrar.RegisterInstance(typeof(IConfiguration), configuration);
+        _registrar.RegisterLazy(typeof(IAnsiConsole), () => configuration.Settings.Console.GetConsole());
+
+        // Register the help provider
+        var defaultHelpProvider = new HelpProvider(configuration.Settings);
+        _registrar.RegisterInstance(typeof(IHelpProvider), defaultHelpProvider);
+
+        // Create the command model.
+        var model = CommandModelBuilder.Build(configuration);
+        _registrar.RegisterInstance(typeof(CommandModel), model);
+        _registrar.RegisterDependencies(model);
+
+        // Parse and map the model against the arguments.
+        var parsedResult = ParseCommandLineArguments(model, configuration.Settings, args);
+
+        // Register the arguments with the container.
+        _registrar.RegisterInstance(typeof(CommandTreeParserResult), parsedResult);
+        _registrar.RegisterInstance(typeof(IRemainingArguments), parsedResult.Remaining);
+
+        return new CommandExecutor(
+            registrar: _registrar,
+            configuration: configuration,
+            args: args,
+            requiresVersion: false,
+            defaultHelpProvider: defaultHelpProvider,
+            parsedResult: parsedResult,
+            model: model
+        );
+    }
+
+#pragma warning disable CS8603 // Possible null reference return.
+
+    private CommandTreeParserResult ParseCommandLineArguments(CommandModel model, CommandAppSettings settings, IEnumerable<string> args)
+    {
+        var parser = new CommandTreeParser(model, settings.CaseSensitivity, settings.ParsingMode, settings.ConvertFlagsToRemainingArguments);
+
+        var parserContext = new CommandTreeParserContext(args, settings.ParsingMode);
+        var tokenizerResult = CommandTreeTokenizer.Tokenize(args);
+        var parsedResult = parser.Parse(parserContext, tokenizerResult);
+
+        var lastParsedLeaf = parsedResult?.Tree?.GetLeafCommand();
+        var lastParsedCommand = lastParsedLeaf?.Command;
+        if (lastParsedLeaf != null && lastParsedCommand != null &&
+            lastParsedCommand.IsBranch && !lastParsedLeaf.ShowHelp &&
+            lastParsedCommand.DefaultCommand != null)
+        {
+            // Insert this branch's default command into the command line
+            // arguments and try again to see if it will parse.
+            var argsWithDefaultCommand = new List<string>(args);
+
+            argsWithDefaultCommand.Insert(tokenizerResult.Tokens.Position, lastParsedCommand.DefaultCommand.Name);
+
+            parserContext = new CommandTreeParserContext(argsWithDefaultCommand, settings.ParsingMode);
+            tokenizerResult = CommandTreeTokenizer.Tokenize(argsWithDefaultCommand);
+            parsedResult = parser.Parse(parserContext, tokenizerResult);
+        }
+
+        return parsedResult;
+    }
+
+#pragma warning restore CS8603 // Possible null reference return.
+}

--- a/src/Spectre.Console.Cli/Internal/Configuration/CommandAppSettings.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/CommandAppSettings.cs
@@ -19,7 +19,7 @@ internal sealed class CommandAppSettings : ICommandAppSettings
     public ParsingMode ParsingMode =>
         StrictParsing ? ParsingMode.Strict : ParsingMode.Relaxed;
 
-    public Func<Exception, int>? ExceptionHandler { get; set; }
+    public Func<Exception, ITypeResolver, int>? ExceptionHandler { get; set; }
 
     public CommandAppSettings(ITypeRegistrar registrar)
     {


### PR DESCRIPTION
[Original PR](https://github.com/spectreconsole/spectre.console/pull/1264)
[PR #1](https://github.com/spectreconsole/spectre.console/pull/1325)
[PR #2](https://github.com/spectreconsole/spectre.console/pull/1326)

This one is the 2nd of 3 PR's. Different flavors for the same problem.  
I believe this one is somewhat the cleanest approach, even if there is quite a bit of change.

Why do i need this? TL;DR when using Logging, for e.g microsoft.extensions.logging, i cannot access the logger without a  TypeResolver in order to log the exception details.

- [ ] I have read the [Contribution Guidelines](../CONTRIBUTING.md) (Not available)
- [x] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes
Add TypeResolver to ExceptionHandler while trying to not break the api. 
If the user chose to set the handler directly through the settings, their code might be broken.
But if the user uses ``SetExceptionHandler``, everything is fine, i have made an overload for that.
