### PR TITLE
Add TypeResolver to ExceptionHandler (OPTION #2)

### DIFF
--- a/src/Spectre.Console.Cli/CommandApp.cs
+++ b/src/Spectre.Console.Cli/CommandApp.cs
@@ -9,6 +9,7 @@ public sealed class CommandApp : ICommandApp
 {
     private readonly Configurator _configurator;
     private readonly CommandExecutor _executor;
+    private ITypeRegistrar _registrar;
     private bool _executed;
 
     /// <summary>
@@ -21,6 +22,7 @@ public sealed class CommandApp : ICommandApp
 
         _configurator = new Configurator(registrar);
         _executor = new CommandExecutor(registrar);
+        _registrar = registrar;
     }
 
     /// <summary>
@@ -102,7 +104,8 @@ public sealed class CommandApp : ICommandApp
 
             if (_configurator.Settings.ExceptionHandler != null)
             {
-                return _configurator.Settings.ExceptionHandler(ex);
+                using var resolver = new TypeResolverAdapter(_registrar.Build());
+                return _configurator.Settings.ExceptionHandler(ex, resolver);
             }
 
             // Render the exception.

--- a/src/Spectre.Console.Cli/ConfiguratorExtensions.cs
+++ b/src/Spectre.Console.Cli/ConfiguratorExtensions.cs
@@ -359,7 +359,7 @@ public static class ConfiguratorExtensions
     /// <param name="configurator">The configurator.</param>
     /// <param name="exceptionHandler">The Action that handles the exception.</param>
     /// <returns>A configurator that can be used to configure the application further.</returns>
-    public static IConfigurator SetExceptionHandler(this IConfigurator configurator, Func<Exception, int>? exceptionHandler)
+    public static IConfigurator SetExceptionHandler(this IConfigurator configurator, Func<Exception, ITypeResolver, int>? exceptionHandler)
     {
         if (configurator == null)
         {
@@ -368,5 +368,16 @@ public static class ConfiguratorExtensions
 
         configurator.Settings.ExceptionHandler = exceptionHandler;
         return configurator;
+    }
+
+    /// <summary>
+    /// Sets the ExceptionsHandler.
+    /// </summary>
+    /// <param name="configurator">The configurator.</param>
+    /// <param name="exceptionHandler">The Action that handles the exception.</param>
+    /// <returns>A configurator that can be used to configure the application further.</returns>
+    public static IConfigurator SetExceptionHandler(this IConfigurator configurator, Func<Exception, int>? exceptionHandler)
+    {
+        return configurator.SetExceptionHandler(exceptionHandler == null ? null : (ex, _) => exceptionHandler(ex));
     }
 }

--- a/src/Spectre.Console.Cli/ICommandAppSettings.cs
+++ b/src/Spectre.Console.Cli/ICommandAppSettings.cs
@@ -80,5 +80,5 @@ public interface ICommandAppSettings
     /// Gets or sets a handler for Exceptions.
     /// <para>This handler will not be called, if <see cref="PropagateExceptions"/> is set to <c>true</c>.</para>
     /// </summary>
-    public Func<Exception, int>? ExceptionHandler { get; set; }
+    public Func<Exception, ITypeResolver, int>? ExceptionHandler { get; set; }
 }

--- a/src/Spectre.Console.Cli/Internal/Configuration/CommandAppSettings.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/CommandAppSettings.cs
@@ -19,7 +19,7 @@ internal sealed class CommandAppSettings : ICommandAppSettings
     public ParsingMode ParsingMode =>
         StrictParsing ? ParsingMode.Strict : ParsingMode.Relaxed;
 
-    public Func<Exception, int>? ExceptionHandler { get; set; }
+    public Func<Exception, ITypeResolver, int>? ExceptionHandler { get; set; }
 
     public CommandAppSettings(ITypeRegistrar registrar)
     {

--- a/test/Spectre.Console.Cli.Tests/Data/Commands/ThrowingCommand.cs
+++ b/test/Spectre.Console.Cli.Tests/Data/Commands/ThrowingCommand.cs
@@ -2,8 +2,10 @@ namespace Spectre.Console.Tests.Data;
 
 public sealed class ThrowingCommand : Command<ThrowingCommandSettings>
 {
+    public const string Message = "W00t?";
+
     public override int Execute(CommandContext context, ThrowingCommandSettings settings)
     {
-        throw new InvalidOperationException("W00t?");
+        throw new InvalidOperationException(Message);
     }
 }

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Exceptions.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Exceptions.cs
@@ -117,7 +117,7 @@ public sealed partial class CommandAppTests
             result.ExitCode.ShouldBe(-99);
             loggerGlobal.ShouldBe(new[]
             {
-                ThrowingCommand.Message
+                ThrowingCommand.Message,
             });
         }
     }


### PR DESCRIPTION
[Original PR](https://github.com/spectreconsole/spectre.console/pull/1264)
[PR #1](https://github.com/spectreconsole/spectre.console/pull/1325)
[PR #2](https://github.com/spectreconsole/spectre.console/pull/1326)

This one is the 3rd of 3 PR's. Different flavors for the same problem.  
This one is the one, that does not change all too much, but could come with side effects.

Why do i need this? TL;DR when using Logging, for e.g microsoft.extensions.logging, i cannot access the logger without a  TypeResolver in order to log the exception details.

- [ ] I have read the [Contribution Guidelines](../CONTRIBUTING.md) (Not available)
- [x] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes
Add TypeResolver to ExceptionHandler while trying to not break the api. 
If the user chose to set the handler directly through the settings, their code might be broken.
But if the user uses ``SetExceptionHandler``, everything is fine, i have made an overload for that.
