### PR TITLE
Fix AnsiConsoleOutput safe height

### DIFF
--- a/src/Spectre.Console/AnsiConsoleOutput.cs
+++ b/src/Spectre.Console/AnsiConsoleOutput.cs
@@ -28,10 +28,10 @@ public sealed class AnsiConsoleOutput : IAnsiConsoleOutput
     }
 
     /// <inheritdoc/>
-    public int Width => ConsoleHelper.GetSafeWidth(Constants.DefaultTerminalWidth);
+    public int Width => ConsoleHelper.GetSafeWidth();
 
     /// <inheritdoc/>
-    public int Height => ConsoleHelper.GetSafeHeight(Constants.DefaultTerminalWidth);
+    public int Height => ConsoleHelper.GetSafeHeight();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AnsiConsoleOutput"/> class.


### PR DESCRIPTION
The safe height (introduced in 3e2eea730bf0f6fe4a5e336faa312b526d351079) would be 80 (the value of the safe width) instead of 24.

Removing the explicit `defaultValue` parameter ensures that the correct constants are used, i.e. Constants.DefaultTerminalWidth and Constants.DefaultTerminalHeight.