### PR TITLE
Removed the default registration of the IHelpProvider

### DIFF
--- a/src/Spectre.Console.Cli/Internal/Composition/ComponentRegistry.cs
+++ b/src/Spectre.Console.Cli/Internal/Composition/ComponentRegistry.cs
@@ -38,8 +38,9 @@ internal sealed class ComponentRegistry : IDisposable
             {
                 // Only add each registration type once.
                 _registrations.Add(type, new HashSet<ComponentRegistration>());
-                _registrations[type].Add(registration);
             }
+
+            _registrations[type].Add(registration);
         }
     }
 

--- a/src/Spectre.Console.Testing/Cli/TypeRegistrarBaseTests.cs
+++ b/src/Spectre.Console.Testing/Cli/TypeRegistrarBaseTests.cs
@@ -246,7 +246,9 @@ public sealed class TypeRegistrarBaseTests
 
     private class AnotherMockService : IMockService
     {
-        public AnotherMockService(string _){}
+        public AnotherMockService(string ignore)
+        {
+        }
     }
 
     /// <summary>

--- a/src/Spectre.Console.Testing/Cli/TypeRegistrarBaseTests.cs
+++ b/src/Spectre.Console.Testing/Cli/TypeRegistrarBaseTests.cs
@@ -23,18 +23,95 @@ public sealed class TypeRegistrarBaseTests
     /// <exception cref="TestFailedException">This exception is raised, if a test fails.</exception>
     public void RunAllTests()
     {
-        var testCases = new Action<ITypeRegistrar>[]
+        var testCases = new[]
         {
                 RegistrationsCanBeResolved,
                 InstanceRegistrationsCanBeResolved,
                 LazyRegistrationsCanBeResolved,
                 ResolvingNotRegisteredServiceReturnsNull,
                 ResolvingNullTypeReturnsNull,
+                ResolvingSingleInstanceOfMultipleRegistrationsResolvesTheFirstOne,
+                ResolvingAnEnumerableOfInstancesDoesNotReturnNull,
+                ResolvingAnEnumerableOfInstancesOfMultipleRegistrationsResolvesAllRegistrations,
         };
 
         foreach (var test in testCases)
         {
             test(_registrarFactory());
+        }
+    }
+
+    private void ResolvingAnEnumerableOfInstancesDoesNotReturnNull(ITypeRegistrar registrar)
+    {
+        // Given
+        var resolver = registrar.Build();
+
+        // When
+        var actual = resolver.Resolve(typeof(IEnumerable<IMockService>)) as IEnumerable<IMockService>;
+
+        // Then
+        if (actual == null)
+        {
+            throw new TestFailedException(
+                "Expected an IEnumerable never to resolve to null.");
+        }
+    }
+
+    private void ResolvingAnEnumerableOfInstancesOfMultipleRegistrationsResolvesAllRegistrations(ITypeRegistrar registrar)
+    {
+        // Given
+        var theLastRegistration = new AnotherMockService("last");
+        registrar.RegisterLazy(typeof(IMockService), () => new AnotherMockService("first"));
+        registrar.Register(typeof(IMockService), typeof(MockService));
+        registrar.RegisterInstance(typeof(IMockService), theLastRegistration);
+        var resolver = registrar.Build();
+
+        // When
+        var actual = (resolver.Resolve(typeof(IEnumerable<IMockService>)) as IEnumerable<IMockService>)!.ToList();
+
+        // Then
+        if (actual.Count != 3)
+        {
+            throw new TestFailedException(
+                "Expected the resolver to resolve a list with exactly 3 elements.");
+        }
+
+        if (actual.Count(x => x.GetType() == typeof(AnotherMockService)) != 2)
+        {
+            throw new TestFailedException(
+                $"Expected the resolver to resolve a list with exactly 2 elements of type {nameof(AnotherMockService)}.");
+        }
+
+        if (actual.Count(x => x.GetType() == typeof(MockService)) != 1)
+        {
+            throw new TestFailedException(
+                $"Expected the resolver to resolve a list with exactly one element of type {nameof(MockService)}.");
+        }
+
+        if (!actual.Contains(theLastRegistration))
+        {
+            throw new TestFailedException(
+                "Expected the resolver to resolve the known instance that was registered.");
+        }
+    }
+
+    private void ResolvingSingleInstanceOfMultipleRegistrationsResolvesTheFirstOne(ITypeRegistrar registrar)
+    {
+        // Given
+        var theLastRegistration = new AnotherMockService("last");
+        registrar.RegisterLazy(typeof(IMockService), () => new AnotherMockService("first"));
+        registrar.Register(typeof(IMockService), typeof(MockService));
+        registrar.RegisterInstance(typeof(IMockService), theLastRegistration);
+        var resolver = registrar.Build();
+
+        // When
+        var actual = resolver.Resolve(typeof(IMockService));
+
+        // Then
+        if (!ReferenceEquals(actual, theLastRegistration))
+        {
+            throw new TestFailedException(
+                "Expected the resolver to resolve the first registered instance of multiple registrations.");
         }
     }
 
@@ -165,6 +242,11 @@ public sealed class TypeRegistrarBaseTests
 
     private class MockService : IMockService
     {
+    }
+
+    private class AnotherMockService : IMockService
+    {
+        public AnotherMockService(string _){}
     }
 
     /// <summary>

--- a/src/Spectre.Console.Testing/FakeTypeRegistrar.cs
+++ b/src/Spectre.Console.Testing/FakeTypeRegistrar.cs
@@ -44,6 +44,10 @@ public sealed class FakeTypeRegistrar : ITypeRegistrar
         {
             Instances.Add(service, new List<object> { implementation });
         }
+        else
+        {
+            Instances[service].Add(implementation);
+        }
     }
 
     /// <inheritdoc/>
@@ -57,6 +61,10 @@ public sealed class FakeTypeRegistrar : ITypeRegistrar
         if (!Instances.ContainsKey(service))
         {
             Instances.Add(service, new List<object> { factory() });
+        }
+        else
+        {
+            Instances[service].Add(factory());
         }
     }
 

--- a/src/Spectre.Console.Testing/FakeTypeResolver.cs
+++ b/src/Spectre.Console.Testing/FakeTypeResolver.cs
@@ -40,7 +40,7 @@ public sealed class FakeTypeResolver : ITypeResolver
 
             if (_instances.TryGetValue(type, out var listInstances))
             {
-                listInstances.ForEach(i => castList.Add(i));
+                listInstances.ForEach(i => castList!.Add(i));
             }
 
             if (_registrations.TryGetValue(type, out var listRegistrations))
@@ -48,7 +48,7 @@ public sealed class FakeTypeResolver : ITypeResolver
                 listRegistrations
                     .Select<Type, object>(x => Activator.CreateInstance(x)!)
                     .ToList()
-                    .ForEach(i => castList.Add(i));
+                    .ForEach(i => castList!.Add(i));
             }
 
             return allRegistrations;

--- a/test/Spectre.Console.Cli.Tests/Unit/Testing/FakeTypeRegistrarTests.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/Testing/FakeTypeRegistrarTests.cs
@@ -1,0 +1,12 @@
+﻿namespace Spectre.Console.Tests.Unit.Cli.Testing;
+
+public class FakeTypeRegistrarTests
+{
+    [Fact]
+    public void TheFakeTypeRegistrarPassesAllTheTestsForARegistrar()
+    {
+        ITypeRegistrar Factory() => new FakeTypeRegistrar();
+        var tester = new TypeRegistrarBaseTests(Factory);
+        tester.RunAllTests();
+    }
+}


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #1313

<!-- formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [X] I have commented on the issue above and discussed the intended changes
- [X] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

<!-- describe the changes you made. -->
This was a bit more complicated than I expected:
After implementing the changes discussed in https://github.com/spectreconsole/spectre.console/issues/1313#issuecomment-1736083139 some of our own tests failed because the `FakeTypeRegistrar`/`FakeTypeResolver` did not adhere to our assumptions.

Thus, I created a unit test that covers the `FakeTypeRegistrar` using the `TypeRegistrarBaseTests` and resolved all issues accordingly.
Also, there was a minor issue in the `ComponentRegistry` that arose when mixing `Register`, `RegisterInstance` and `RegisterLazy` - not sure if mixing `Register` with `RegisterInstance` while using the same interface is an issue that will occur in the "real world", but it's fixed now 😄 
Also there was something going on with line endings in `CommandExecutor`, not sure why that was so.