### PR TITLE
(#1363) fix rendering of ListPrompt for odd pageSizes

### DIFF
--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -89,10 +89,10 @@ internal sealed class ListPrompt<T>
             skip = Math.Max(0, state.Index - middleOfList);
             take = Math.Min(pageSize, state.ItemCount - skip);
 
-            if (state.ItemCount - state.Index < middleOfList)
+            if (take < pageSize)
             {
-                // Pointer should be below the end of the list
-                var diff = middleOfList - (state.ItemCount - state.Index);
+                // Pointer should be below the middle of the (visual) list
+                var diff = pageSize - take;
                 skip -= diff;
                 take += diff;
                 cursorIndex = middleOfList + diff;


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #1363 

<!-- formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [X] A maintainer has signed off on the changes and the issue was assigned to me
- [ ] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

<!-- describe the changes you made. -->
Instead of the two calculations used for detection of "lower than the middle of the visual page" and "diff to move the cursor instead of the page", both are now based on the difference of `pageSize` to `take`.

Sadly I was unable to construct a nice unit test for this. Any ideas are welcome 😃  