### PR TITLE
Demonstration of "-v" Option Conflict Bug in Spectre.Console Command Settings

### DIFF
--- a/test/Spectre.Console.Cli.Tests/Data/Commands/VersionableMammal.cs
+++ b/test/Spectre.Console.Cli.Tests/Data/Commands/VersionableMammal.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Spectre.Console.Tests.Data;
+
+[Description("The versionable mammal")]
+public class VersionableMammalCommand : AnimalCommand<VersionableMammalSettings>
+{
+    private readonly IAnsiConsole _console;
+
+    public VersionableMammalCommand(IAnsiConsole console)
+    {
+        _console = console;
+    }
+
+    public override int Execute(CommandContext context, VersionableMammalSettings settings)
+    {
+        _console.WriteLine("Versionable ran!");
+        return 0;
+    }
+}

--- a/test/Spectre.Console.Cli.Tests/Data/Settings/VersionableMammalSettings.cs
+++ b/test/Spectre.Console.Cli.Tests/Data/Settings/VersionableMammalSettings.cs
@@ -1,0 +1,12 @@
+namespace Spectre.Console.Tests.Data;
+
+public sealed class VersionableMammalSettings : MammalSettings
+{
+    [CommandOption("-v|--version")]
+    public string Version { get; set; }
+
+    public override ValidationResult Validate()
+    {
+        return ValidationResult.Success();
+    }
+}

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Parsing.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Parsing.cs
@@ -585,6 +585,24 @@ public sealed partial class CommandAppTests
                 // Then
                 result.Output.ShouldBe("Error: Command 'dog' is missing required argument 'AGE'.");
             }
+
+            // versionableMammal -v should run VersionableMammalCommand and not display the version
+            [Fact]
+            public void Should_Allow_VersionableMammalCommand()
+            {
+                // Given
+                var app = new CommandAppTester();
+                app.Configure(configurator =>
+                {
+                    configurator.AddCommand<VersionableMammalCommand>("versionableMammal");
+                });
+
+                // When
+                var result = app.Run("versionableMammal", "-v", "1.2.5");
+
+                // Then
+                result.Output.ShouldBe("Versionable ran!");
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request introduces a test case that demonstrates an existing bug in Spectre.Console where the command option "-v" is incorrectly prioritized as a version flag rather than as an argument to a command when both are present.


## Test Case
A new test case, `Should_Allow_VersionableMammalCommand`, has been added to clearly illustrate the problem. This test is designed to run the `VersionableMammalCommand` with the "-v" option followed by a version number. The expected output is "Versionable ran!", which confirms the command's execution. The current failing state of this test highlights the bug in question.

## Changes
This pull request includes the following additions:
- `VersionableMammalCommand` class to simulate a command with a version option.
- `VersionableMammalSettings` class to encapsulate the command settings, including the "-v" option.
- A failing unit test in `CommandAppTests.Parsing.cs` that exposes the incorrect behavior.


## Objective
The sole purpose of this pull request is to provide a clear and concise demonstration of the bug through a failing test case. It serves as a basis for discussion and further development towards a fix.

## Next Steps
The next step would be to address the bug identified by this test case in a separate pull request. This would involve modifying the command parsing logic to correctly handle the "-v" option within command settings.
