### PR TITLE
Check and ignoring nulls when using reflection.

### DIFF
--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
@@ -303,15 +303,16 @@ internal static class ExceptionFormatter
             .FirstOrDefault(a =>
             {
                 var attributeType = a.GetType();
-                return attributeType.Namespace == "System.Runtime.CompilerServices" &&
+                return attributeType != null &&
+                       attributeType.Namespace == "System.Runtime.CompilerServices" &&
                        attributeType.Name == "TupleElementNamesAttribute";
             });
 
         if (tupleNameAttribute != null)
         {
             var propertyInfo = tupleNameAttribute.GetType()
-                .GetProperty("TransformNames", BindingFlags.Instance | BindingFlags.Public)!;
-            var tupleNames = propertyInfo.GetValue(tupleNameAttribute) as IList<string>;
+                .GetProperty("TransformNames", BindingFlags.Instance | BindingFlags.Public);
+            var tupleNames = propertyInfo?.GetValue(tupleNameAttribute) as IList<string>;
             if (tupleNames?.Count > 0)
             {
                 var args = parameterType.GetGenericArguments();


### PR DESCRIPTION
Fixes #1401

- [ ] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

- Better null checking when `ExceptionFormatter` is looking for `TupleElementNamesAttribute` using reflection and the type or part of the type was removed by .NET Trimmer.

