### PR TITLE
Allow specifying a property to ignore the use of build-time packages for versioning and analysis

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,8 +30,9 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
-  
-  <ItemGroup Label="Package References">
+
+  <!-- Allow folks to build with minimal dependencies (though they will need to provide their own Version data) -->
+  <ItemGroup Label="Build Tools Package References" Condition="'$(UseBuildTimeTools)' != 'false'">
     <PackageReference Include="MinVer" PrivateAssets="All" Version="4.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="1.1.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">


### PR DESCRIPTION
Fixes #1421 by adding a `UseBuildTimeTools` conditional. When set explicitly to `false` the PackageReferences are not included in the build.

Before:
```
> dotnet build -bl
MSBuild version 17.8.3+195e7f5a3 for .NET
  Determining projects to restore...
  All projects are up-to-date for restore.
  MinVer: Using { Commit: 7397169, Tag: '0.48.0', Version: 0.48.0, Height: 7 }.
  MinVer: Calculated version 0.48.1-preview.0.7.
  MinVer: Using { Commit: 7397169, Tag: '0.48.0', Version: 0.48.0, Height: 7 }.
  MinVer: Calculated version 0.48.1-preview.0.7.
  MinVer: Using { Commit: 7397169, Tag: '0.48.0', Version: 0.48.0, Height: 7 }.
  MinVer: Calculated version 0.48.1-preview.0.7.
  Spectre.Console -> E:\Code\spectre.console\src\Spectre.Console\bin\Debug\net6.0\Spectre.Console.dll
  Spectre.Console -> E:\Code\spectre.console\src\Spectre.Console\bin\Debug\net7.0\Spectre.Console.dll
  Spectre.Console -> E:\Code\spectre.console\src\Spectre.Console\bin\Debug\net8.0\Spectre.Console.dll
  MinVer: Using { Commit: 7397169, Tag: '0.48.0', Version: 0.48.0, Height: 7 }.
  MinVer: Calculated version 0.48.1-preview.0.7.
  Spectre.Console -> E:\Code\spectre.console\src\Spectre.Console\bin\Debug\netstandard2.0\Spectre.Console.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:04.16
```

After:
```
> dotnet build -bl -p UseBuildTimeTools=false
MSBuild version 17.8.3+195e7f5a3 for .NET
  Determining projects to restore...
  Restored E:\Code\spectre.console\src\Spectre.Console\Spectre.Console.csproj (in 181 ms).
  Spectre.Console -> E:\Code\spectre.console\src\Spectre.Console\bin\Debug\netstandard2.0\Spectre.Console.dll
  Spectre.Console -> E:\Code\spectre.console\src\Spectre.Console\bin\Debug\net6.0\Spectre.Console.dll
  Spectre.Console -> E:\Code\spectre.console\src\Spectre.Console\bin\Debug\net7.0\Spectre.Console.dll
  Spectre.Console -> E:\Code\spectre.console\src\Spectre.Console\bin\Debug\net8.0\Spectre.Console.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:02.11
```

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [ ] All newly added code is adequately covered by tests
- [ ] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

I introduced an MSBuild property that can be set to skip the use of build-time analyzers and build-time version inference.
