### PR TITLE
1400 command with  v displays app version instead of executing the command

### DIFF
--- a/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
@@ -46,16 +46,6 @@ internal sealed class CommandExecutor
             }
         }
 
-        //// Asking for version? Kind of a hack, but it's alright.
-        //// We should probably make this a bit better in the future.
-        //if (args.Count() > 0 &&
-        //    (args.First().Equals("-v", StringComparison.OrdinalIgnoreCase) || args.First().Equals("--version", StringComparison.OrdinalIgnoreCase)))
-        //{
-        //    var console = configuration.Settings.Console.GetConsole();
-        //    console.WriteLine(ResolveApplicationVersion(configuration));
-        //    return 0;
-        //}
-
         // Parse and map the model against the arguments.
         var parsedResult = ParseCommandLineArguments(model, configuration.Settings, args);
 

--- a/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
@@ -27,14 +27,34 @@ internal sealed class CommandExecutor
         _registrar.RegisterInstance(typeof(CommandModel), model);
         _registrar.RegisterDependencies(model);
 
-        // Asking for version? Kind of a hack, but it's alright.
-        // We should probably make this a bit better in the future.
-        if (args.Contains("-v") || args.Contains("--version"))
+        // No default command?
+        if (model.DefaultCommand == null)
         {
-            var console = configuration.Settings.Console.GetConsole();
-            console.WriteLine(ResolveApplicationVersion(configuration));
-            return 0;
+            // Got at least one argument?
+            var firstArgument = args.FirstOrDefault();
+            if (firstArgument != null)
+            {
+                // Asking for version? Kind of a hack, but it's alright.
+                // We should probably make this a bit better in the future.
+                if (firstArgument.Equals("--version", StringComparison.OrdinalIgnoreCase) ||
+                    firstArgument.Equals("-v", StringComparison.OrdinalIgnoreCase))
+                {
+                    var console = configuration.Settings.Console.GetConsole();
+                    console.WriteLine(ResolveApplicationVersion(configuration));
+                    return 0;
+                }
+            }
         }
+
+        //// Asking for version? Kind of a hack, but it's alright.
+        //// We should probably make this a bit better in the future.
+        //if (args.Count() > 0 &&
+        //    (args.First().Equals("-v", StringComparison.OrdinalIgnoreCase) || args.First().Equals("--version", StringComparison.OrdinalIgnoreCase)))
+        //{
+        //    var console = configuration.Settings.Console.GetConsole();
+        //    console.WriteLine(ResolveApplicationVersion(configuration));
+        //    return 0;
+        //}
 
         // Parse and map the model against the arguments.
         var parsedResult = ParseCommandLineArguments(model, configuration.Settings, args);

--- a/test/Spectre.Console.Cli.Tests/Data/Commands/VersionCommand.cs
+++ b/test/Spectre.Console.Cli.Tests/Data/Commands/VersionCommand.cs
@@ -1,0 +1,18 @@
+namespace Spectre.Console.Tests.Data;
+
+public sealed class VersionCommand : Command<VersionSettings>
+{
+    private readonly IAnsiConsole _console;
+
+    public VersionCommand(IAnsiConsole console)
+    {
+        _console = console;
+    }
+
+    public override int Execute(CommandContext context, VersionSettings settings)
+    {
+        _console.WriteLine($"VersionCommand ran, Version: {settings.Version ?? string.Empty}");
+
+        return 0;
+    }
+}

--- a/test/Spectre.Console.Cli.Tests/Data/Settings/VersionSettings.cs
+++ b/test/Spectre.Console.Cli.Tests/Data/Settings/VersionSettings.cs
@@ -1,0 +1,7 @@
+namespace Spectre.Console.Tests.Data;
+
+public sealed class VersionSettings : CommandSettings
+{
+    [CommandOption("-v|--version")]
+    public string Version { get; set; }
+}

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Parsing.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Parsing.cs
@@ -586,5 +586,28 @@ public sealed partial class CommandAppTests
                 result.Output.ShouldBe("Error: Command 'dog' is missing required argument 'AGE'.");
             }
         }
+
+        /// <summary>
+        /// -v or --version switches should result in the Version option being set
+        /// on VersionSettings, and then VersionCommand.Execute(...) being called
+        /// </summary>
+        [InlineData("-v")]
+        [InlineData("--version")]
+        [Theory]
+        public void Should_Run_Custom_Version_Command(string versionOption)
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(configurator =>
+            {
+                configurator.AddCommand<Spectre.Console.Tests.Data.VersionCommand>("CustomVersionCommand");
+            });
+
+            // When
+            var result = app.Run("CustomVersionCommand", versionOption, "1.2.5");
+
+            // Then
+            result.Output.ShouldBe("VersionCommand ran, Version: 1.2.5");
+        }
     }
 }

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Parsing.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Parsing.cs
@@ -591,9 +591,9 @@ public sealed partial class CommandAppTests
         /// -v or --version switches should result in the Version option being set
         /// on VersionSettings, and then VersionCommand.Execute(...) being called
         /// </summary>
+        [Theory]
         [InlineData("-v")]
         [InlineData("--version")]
-        [Theory]
         public void Should_Run_Custom_Version_Command(string versionOption)
         {
             // Given

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
@@ -35,7 +35,7 @@ public sealed partial class CommandAppTests
         }
 
         [Fact]
-        public void Should_Output_Application_Version_To_The_Console_With_Command()
+        public void Should_Execute_Command_Not_Output_Application_Version_To_The_Console()
         {
             // Given
             var fixture = new CommandAppTester();
@@ -50,11 +50,12 @@ public sealed partial class CommandAppTests
             var result = fixture.Run("empty", "--version");
 
             // Then
-            result.Output.ShouldBe("1.0");
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("version", new[] { (string)null });
         }
 
         [Fact]
-        public void Should_Output_Application_Version_To_The_Console_With_Default_Command()
+        public void Should_Execute_Default_Command_Not_Output_Application_Version_To_The_Console()
         {
             // Given
             var fixture = new CommandAppTester();
@@ -68,7 +69,8 @@ public sealed partial class CommandAppTests
             var result = fixture.Run("--version");
 
             // Then
-            result.Output.ShouldBe("1.0");
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("version", new[] { (string)null });
         }
 
         [Fact]


### PR DESCRIPTION

fixes https://github.com/spectreconsole/spectre.console/issues/1400, closes https://github.com/spectreconsole/spectre.console/pull/1399

<!-- formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [X] I have commented on the issue above and discussed the intended changes
- [X] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

Given there is no default command
When `-v` or `--version` is the first command line argument
Then the application version is displayed on the console

---

- Added unit test outlined in https://github.com/spectreconsole/spectre.console/pull/1399
- Reverted the logic handing `-v` and `--version` switches in `CommandExecutor`
- Updated existing unit tests in `Spectre.Console.Tests.Unit.Cli.CommandAppTests.Version` to fall in line with the reverted `CommandExecutor` logic
