### PR TITLE
Updated typo in commandApp.md

### DIFF
--- a/docs/input/cli/commandApp.md
+++ b/docs/input/cli/commandApp.md
@@ -23,7 +23,7 @@ app.Configure(config =>
 
 ## Multiple Commands
 
-In the previous example we have a single command that is configured. For complex command line applications, it is common for them to have multiple commands (or verbs) defined. Examples of applications like this are `git`, `dotnet` and `gh`. For example, git would have a `commit` command and along with other commits like `add` or `rebase`. Each with their own settings and validation. With `Spectre.Console.Cli` we use the `Configure` method to add these commands.
+In the previous example we have a single command that is configured. For complex command line applications, it is common for them to have multiple commands (or verbs) defined. Examples of applications like this are `git`, `dotnet` and `gh`. For example, git would have a `commit` command and along with other commands like `add` or `rebase`. Each with their own settings and validation. With `Spectre.Console.Cli` we use the `Configure` method to add these commands.
 
 For example, to add three different commands to the application:
 


### PR DESCRIPTION
There was a sentence where the word `commits` should have been `commands`.

<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #

<!-- formalities. These are not optional. -->

- [ ] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [ ] All newly added code is adequately covered by tests
- [ ] All existing tests are still running without errors
- [ ] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

Simple typo fix in docs.
