### PR TITLE
Direct contributors to the current CONTRIBUTING.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@ fixes #
 
 <!-- formalities. These are not optional. -->
 
-- [ ] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
+- [ ] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
 - [ ] I have commented on the issue above and discussed the intended changes
 - [ ] A maintainer has signed off on the changes and the issue was assigned to me
 - [ ] All newly added code is adequately covered by tests


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes # _no issue logged, this is a simple spot suggestion_

<!-- formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [ ] All newly added code is adequately covered by tests
- [ ] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

The current PR template contains a link to `CONTRIBUTING.md`. However, when clicking on it, Github redirects to a 404:

![image](https://github.com/spectreconsole/spectre.console/assets/26346866/55f9d9de-eecd-4250-97e1-f6d2a88210f1)

In short, the URL is missing `/blob/main`. This PR fixes the issue, and so contributors don't have to look too deeply.
