### PR TITLE
Fix deadlock when cancelling prompts

### DIFF
--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
@@ -19,6 +19,7 @@ public static partial class AnsiConsoleExtensions
 
         while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var rawKey = await console.Input.ReadKeyAsync(true, cancellationToken).ConfigureAwait(false);
             if (rawKey == null)
             {

--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -48,6 +48,7 @@ internal sealed class ListPrompt<T>
 
             while (true)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var rawKey = await _console.Input.ReadKeyAsync(true, cancellationToken).ConfigureAwait(false);
                 if (rawKey == null)
                 {


### PR DESCRIPTION
fixes #1077 
fixes #1076 

## Changes

Because [`ReadKeyAsync`](https://github.com/spectreconsole/spectre.console/blob/63c22575eaa4ddf5bdd30fd1d85c7247e050d81f/src/Spectre.Console/Internal/DefaultInput.cs#L43) returns null if the cancellationToken is cancelled, this creates infinite loops in the `AnsiConsoleExtensions.ReadLine` method and the `ListPrompt.Show` method. 
