### PR TITLE
Delete [UsesVerify] which has become obsolete through the latest update.

### DIFF
--- a/test/Spectre.Console.Tests/Unit/Widgets/ProgressBarTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Widgets/ProgressBarTests.cs
@@ -1,6 +1,5 @@
 namespace Spectre.Console.Tests.Unit;
 
-[UsesVerify]
 [ExpectationPath("Widgets/ProgressBar")]
 public class ProgressBarTests
 {


### PR DESCRIPTION
fixes #1455

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [X ] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

Delete [UsesVerify] in one spot. It has become obsolete by a recent update of VerifyTests.
