### PR TITLE
Don't erase secret prompt text upon backspace when mask is null

### DIFF
--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
@@ -53,7 +53,11 @@ public static partial class AnsiConsoleExtensions
                 if (text.Length > 0)
                 {
                     text = text.Substring(0, text.Length - 1);
-                    console.Write("\b \b");
+
+                    if (mask != null)
+                    {
+                        console.Write("\b \b");
+                    }
                 }
 
                 continue;

--- a/test/Spectre.Console.Tests/Expectations/Prompts/Text/SecretValueBackspaceNullMask.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Prompts/Text/SecretValueBackspaceNullMask.Output.verified.txt
@@ -1,0 +1,1 @@
+﻿Favorite fruit? 

--- a/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -249,6 +249,25 @@ public sealed class TextPromptTests
     }
 
     [Fact]
+    [Expectation("SecretValueBackspaceNullMask")]
+    public Task Should_Not_Erase_Prompt_Text_On_Backspace_If_Prompt_Is_Secret_And_Mask_Is_Null()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Input.PushText("Bananas");
+        console.Input.PushKey(ConsoleKey.Backspace);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        console.Prompt(
+            new TextPrompt<string>("Favorite fruit?")
+                .Secret(null));
+
+        // Then
+        return Verifier.Verify(console.Output);
+    }
+
+    [Fact]
     [Expectation("SecretDefaultValueCustomMask")]
     public Task Should_Choose_Custom_Masked_Default_Value_If_Nothing_Is_Entered_And_Prompt_Is_Secret_And_Mask_Is_Custom()
     {


### PR DESCRIPTION
fixes #1457

Note: This builds upon an ealier PR that I made because it wouldn't build otherwise. I will rebase this PR accordingly.

- [X ] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X ] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [X ] All newly added code is adequately covered by tests
- [X ] All existing tests are still running without errors
- [X ] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

<!-- describe the changes you made. -->
