### PR TITLE
Remove [DebuggerDisplay] from Paragraph

### DIFF
--- a/src/Spectre.Console/Widgets/Paragraph.cs
+++ b/src/Spectre.Console/Widgets/Paragraph.cs
@@ -4,7 +4,6 @@ namespace Spectre.Console;
 /// A paragraph of text where different parts
 /// of the paragraph can have individual styling.
 /// </summary>
-[DebuggerDisplay("{_text,nq}")]
 public sealed class Paragraph : Renderable, IHasJustification, IOverflowable
 {
     private readonly List<SegmentLine> _lines;


### PR DESCRIPTION
Fixes #1476

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [ ] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] No documentation changes are required.

## Changes

Remove broken `[DebuggerDisplay]` attribute.
