### PR TITLE
Top Issues GitHub Action

### DIFF
--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -13,6 +13,7 @@ jobs:
         env:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         with:
+          top_list_size: 10
           label: true
           dashboard: true
           dashboard_show_total_reactions: true

--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -1,0 +1,23 @@
+name: Top issues action.
+on:
+  schedule:
+    - cron: '0 0 */1 * *'
+
+jobs:
+  ShowAndLabelTopIssues:
+    name: Display and label top issues.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Top Issues action
+        uses: rickstaa/top-issues-action@v1.3.99
+        env:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          label: true
+          dashboard: true
+          dashboard_show_total_reactions: true
+          top_issues: true
+          top_bugs: true
+          top_features: true
+          feature_label: feature
+          top_pull_requests: true


### PR DESCRIPTION
spectre.console contributions are largely made by a small set of dedicated contributors/maintainers, whom have less time than open issues (fairly common occurence in the OSS world). As such, we've been discussing how to stay motivated in the face of a growing backlog, fairly prioritise the outstanding issues, potentially introduce some kind of overall roadmap planning and guidance. 

At one point, we even discussed and considered blanket closing inactive issues and PR's after a certain age, see the RFC for this idea here: https://github.com/spectreconsole/spectre.console/discussions/1422, "Mark PR's as stale after 300 days, close them after another 60 if no activity"

**Proposal**
[github-readme-stats](https://github.com/anuraghazra/github-readme-stats) have addressed this exact issue through up/downvotes against issues/features/bugs/PRs, to give their contributor community a very clear steer what to focus their efforts on. Here's what you will find featured fairly prominently on their repository readme:

> We're a small team, and to prioritize, we rely on upvotes 👍. We use the Top Issues dashboard for tracking community demand (see https://github.com/anuraghazra/github-readme-stats/issues/1935). Do not hesitate to upvote the issues and pull requests you are interested in. We will work on the most upvoted first.

This seems like a great approach for spectre.console to adopt provisionally, and road test. This PR includes the GitHub Action workflow to generate the 'top issues dashboard', making use of this marketplace action: https://github.com/marketplace/actions/top-issues-action

**Follow on work required, once this PR has been merged**
Once the action has executed successfully for the first time and the 'top issues dashboard' been created (ie. the issue # for the dashboard will be known), then I will submit a second PR for:

1. Instructions in spectre.console readme.md to upvote favourite issues
2. Instructions in the new issue template, to search for existing issues before creating a new one, and upvote issues found as necessary
3. Pin a discussion with instructions to upvote favourite issues

**Testing**
I've successfully implemented the Top Issues Dashboard on a public repo I own, experimenting with different settings, see: https://github.com/FrankRay78/PatienceOS/issues