### PR TITLE
Added NoStackTrace to ExceptionFormats

### DIFF
--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionFormat.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionFormat.cs
@@ -35,4 +35,9 @@ public enum ExceptionFormats
     /// Shortens everything that can be shortened.
     /// </summary>
     ShortenEverything = ShortenMethods | ShortenTypes | ShortenPaths,
+
+    /// <summary>
+    /// Whether or not to show the exception stack trace.
+    /// </summary>
+    NoStackTrace = 16,
 }

--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
@@ -50,6 +50,11 @@ internal static class ExceptionFormatter
         }
 
         // Stack frames
+        if ((settings.Format & ExceptionFormats.NoStackTrace) != 0)
+        {
+            return grid;
+        }
+
         var stackTrace = new StackTrace(ex, fNeedFileInfo: true);
         var frames = stackTrace
             .GetFrames()

--- a/test/Spectre.Console.Tests/Expectations/Exception/NoStackTrace.Output.verified.txt
+++ b/test/Spectre.Console.Tests/Expectations/Exception/NoStackTrace.Output.verified.txt
@@ -1,0 +1,2 @@
+﻿System.InvalidOperationException: Something threw!
+   System.InvalidOperationException: Throwing!

--- a/test/Spectre.Console.Tests/Unit/ExceptionTests.cs
+++ b/test/Spectre.Console.Tests/Unit/ExceptionTests.cs
@@ -108,6 +108,21 @@ public sealed class ExceptionTests
         return Verifier.Verify(result);
     }
 
+    [Fact]
+    [Expectation("NoStackTrace")]
+    public Task Should_Write_Exception_With_No_StackTrace()
+    {
+        // Given
+        var console = new TestConsole().Width(1024);
+        var dex = GetException(() => TestExceptions.ThrowWithInnerException());
+
+        // When
+        var result = console.WriteNormalizedException(dex, ExceptionFormats.NoStackTrace);
+
+        // Then
+        return Verifier.Verify(result);
+    }
+
     public static Exception GetException(Action action)
     {
         try


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #1485

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [ ] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

Added a new ExceptionFormat (`ExceptionFormats.NoStackTrace`) to not render the exception stack trace.