### PR TITLE
Pipe character for listing options (issue 1434)

### DIFF
--- a/src/Spectre.Console.Cli/Internal/Configuration/TemplateParser.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/TemplateParser.cs
@@ -124,7 +124,7 @@ internal static class TemplateParser
                 foreach (var character in token.Value)
                 {
                     if (!char.IsLetterOrDigit(character) &&
-                        character != '=' && character != '-' && character != '_')
+                        character != '=' && character != '-' && character != '_' && character != '|')
                     {
                         throw CommandTemplateException.InvalidCharacterInValueName(template, token, character);
                     }

--- a/test/Spectre.Console.Cli.Tests/Data/Settings/HorseSettings.cs
+++ b/test/Spectre.Console.Cli.Tests/Data/Settings/HorseSettings.cs
@@ -4,7 +4,7 @@ namespace Spectre.Console.Tests.Data;
 
 public class HorseSettings : MammalSettings
 {
-    [CommandOption("-d|--day")]
+    [CommandOption("-d|--day <Mon|Tue>")]
     public DayOfWeek Day { get; set; }
 
     [CommandOption("--file")]

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/Root_Command.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/Root_Command.Output.verified.txt
@@ -1,0 +1,18 @@
+DESCRIPTION:
+The horse command.
+
+USAGE:
+    myapp horse [LEGS] [OPTIONS]
+
+ARGUMENTS:
+    [LEGS]    The number of legs
+
+OPTIONS:
+                           DEFAULT
+    -h, --help                         Prints help information
+    -v, --version                      Prints version information
+    -a, --alive                        Indicates whether or not the animal is alive
+    -n, --name <VALUE>
+    -d, --day <MON|TUE>
+        --file             food.txt
+        --directory

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_1.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_1.Output.verified.txt
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Model>
   <!--ANIMAL-->
   <Command Name="animal" IsBranch="true" Settings="Spectre.Console.Tests.Data.AnimalSettings">
@@ -29,7 +29,7 @@
       <!--HORSE-->
       <Command Name="horse" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
         <Parameters>
-          <Option Short="d" Long="day" Value="NULL" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
+          <Option Short="d" Long="day" Value="MON|TUE" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
           <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />
           <Option Short="" Long="file" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.FileInfo" />
         </Parameters>

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_3.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_3.Output.verified.txt
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Model>
   <!--ANIMAL-->
   <Command Name="animal" IsBranch="true" Settings="Spectre.Console.Tests.Data.AnimalSettings">
@@ -25,7 +25,7 @@
     <!--HORSE-->
     <Command Name="horse" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
       <Parameters>
-        <Option Short="d" Long="day" Value="NULL" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
+        <Option Short="d" Long="day" Value="MON|TUE" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
         <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />
         <Option Short="" Long="file" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.FileInfo" />
         <Option Short="n,p" Long="name,pet-name" Value="VALUE" Required="false" Kind="scalar" ClrType="System.String" />

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_6.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_6.Output.verified.txt
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Model>
   <!--DEFAULT COMMAND-->
   <Command Name="__default_command" IsBranch="false" IsDefault="true" ClrType="Spectre.Console.Tests.Data.DogCommand" Settings="Spectre.Console.Tests.Data.DogSettings">
@@ -31,7 +31,7 @@
       <Option Short="a" Long="alive,not-dead" Value="NULL" Required="false" Kind="flag" ClrType="System.Boolean">
         <Description>Indicates whether or not the animal is alive.</Description>
       </Option>
-      <Option Short="d" Long="day" Value="NULL" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
+      <Option Short="d" Long="day" Value="MON|TUE" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
       <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />
       <Option Short="" Long="file" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.FileInfo" />
       <Option Short="n,p" Long="name,pet-name" Value="VALUE" Required="false" Kind="scalar" ClrType="System.String" />

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_7.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_7.Output.verified.txt
@@ -22,7 +22,7 @@
       <!--__DEFAULT_COMMAND-->
       <Command Name="__default_command" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
         <Parameters>
-          <Option Short="d" Long="day" Value="NULL" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
+          <Option Short="d" Long="day" Value="MON|TUE" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
           <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />
           <Option Short="" Long="file" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.FileInfo" />
         </Parameters>

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_8.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_8.Output.verified.txt
@@ -25,7 +25,7 @@
     <!--__DEFAULT_COMMAND-->
     <Command Name="__default_command" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
       <Parameters>
-        <Option Short="d" Long="day" Value="NULL" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
+        <Option Short="d" Long="day" Value="MON|TUE" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
         <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />
         <Option Short="" Long="file" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.FileInfo" />
         <Option Short="n,p" Long="name,pet-name" Value="VALUE" Required="false" Kind="scalar" ClrType="System.String" />

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_9.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_9.Output.verified.txt
@@ -27,7 +27,7 @@
     <!--__DEFAULT_COMMAND-->
     <Command Name="__default_command" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
       <Parameters>
-        <Option Short="d" Long="day" Value="NULL" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
+        <Option Short="d" Long="day" Value="MON|TUE" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
         <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />
         <Option Short="" Long="file" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.FileInfo" />
         <Option Short="n,p" Long="name,pet-name" Value="VALUE" Required="false" Kind="scalar" ClrType="System.String" />

--- a/test/Spectre.Console.Cli.Tests/Unit/Annotations/CommandOptionAttributeTests.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/Annotations/CommandOptionAttributeTests.cs
@@ -23,14 +23,16 @@ public sealed partial class CommandOptionAttributeTests
     }
 
     [Theory]
-    [InlineData("<VALUE>")]
-    public void Should_Parse_Value_Correctly(string value)
+    [InlineData("<VALUE>", "VALUE")]
+    [InlineData("<VALUE1>", "VALUE1")]
+    [InlineData("<VALUE1|VALUE2>", "VALUE1|VALUE2")]
+    public void Should_Parse_Value_Correctly(string value, string expected)
     {
         // Given, When
         var option = new CommandOptionAttribute($"-o|--option {value}");
 
         // Then
-        option.ValueName.ShouldBe("VALUE");
+        option.ValueName.ShouldBe(expected);
     }
 
     [Fact]

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
@@ -29,6 +29,27 @@ public sealed partial class CommandAppTests
         }
 
         [Fact]
+        [Expectation("Root_Command")]
+        public Task Should_Output_Root_Command_Correctly()
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationName("myapp");
+                configurator.AddCommand<DogCommand>("dog");
+                configurator.AddCommand<HorseCommand>("horse");
+                configurator.AddCommand<GiraffeCommand>("giraffe");
+            });
+
+            // When
+            var result = fixture.Run("horse", "--help");
+
+            // Then
+            return Verifier.Verify(result.Output);
+        }
+
+        [Fact]
         [Expectation("Hidden_Commands")]
         public Task Should_Skip_Hidden_Commands()
         {


### PR DESCRIPTION
fixes #1434

<!-- formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have commented on the issue above and discussed the intended changes
- [X] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes
Allow the pipe character for listing options e.g. --option [RED|GREEN|BLUE]

![image](https://github.com/spectreconsole/spectre.console/assets/52075808/48a8f400-d421-4974-b192-80e1714d4e6e)

nb. Aligns with `CommandLine`, see:

![image](https://github.com/spectreconsole/spectre.console/assets/52075808/f94389ea-1d02-41c9-8deb-e3c3a6460953)

https://learn.microsoft.com/en-us/dotnet/standard/commandline/define-commands