### PR TITLE
Improve XmlDoc output

### DIFF
--- a/src/Spectre.Console.Cli/Internal/Commands/XmlDocCommand.cs
+++ b/src/Spectre.Console.Cli/Internal/Commands/XmlDocCommand.cs
@@ -84,6 +84,13 @@ internal sealed class XmlDocCommand : Command<XmlDocCommand.Settings>
 
         node.SetNullableAttribute("Settings", command.SettingsType?.FullName);
 
+        if (!string.IsNullOrWhiteSpace(command.Description))
+        {
+            var descriptionNode = doc.CreateElement("Description");
+            descriptionNode.InnerText = command.Description;
+            node.AppendChild(descriptionNode);
+        }
+
         // Parameters
         if (command.Parameters.Count > 0)
         {

--- a/src/Spectre.Console.Cli/Internal/Commands/XmlDocCommand.cs
+++ b/src/Spectre.Console.Cli/Internal/Commands/XmlDocCommand.cs
@@ -110,6 +110,27 @@ internal sealed class XmlDocCommand : Command<XmlDocCommand.Settings>
             node.AppendChild(CreateCommandNode(doc, childCommand));
         }
 
+        // Examples
+        if (command.Examples.Count > 0)
+        {
+            var exampleRootNode = doc.CreateElement("Examples");
+            foreach (var example in command.Examples.SelectMany(static x => x))
+            {
+                var exampleNode = CreateExampleNode(doc, example);
+                exampleRootNode.AppendChild(exampleNode);
+            }
+
+            node.AppendChild(exampleRootNode);
+        }
+
+        return node;
+    }
+
+    private static XmlNode CreateExampleNode(XmlDocument document, string example)
+    {
+        var node = document.CreateElement("Example");
+        node.SetAttribute("commandLine", example);
+
         return node;
     }
 

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_1.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_1.Output.verified.txt
@@ -21,6 +21,7 @@
       </Parameters>
       <!--DOG-->
       <Command Name="dog" IsBranch="false" ClrType="Spectre.Console.Tests.Data.DogCommand" Settings="Spectre.Console.Tests.Data.DogSettings">
+        <Description>The dog command.</Description>
         <Parameters>
           <Argument Name="AGE" Position="0" Required="true" Kind="scalar" ClrType="System.Int32" />
           <Option Short="g" Long="good-boy" Value="NULL" Required="false" Kind="flag" ClrType="System.Boolean" />
@@ -28,6 +29,7 @@
       </Command>
       <!--HORSE-->
       <Command Name="horse" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
+        <Description>The horse command.</Description>
         <Parameters>
           <Option Short="d" Long="day" Value="MON|TUE" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
           <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_10.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_10.Output.verified.txt
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Model>
+  <!--DOG-->
+  <Command Name="dog" IsBranch="false" ClrType="Spectre.Console.Tests.Data.DogCommand" Settings="Spectre.Console.Tests.Data.DogSettings">
+    <Description>The dog command.</Description>
+    <Parameters>
+      <Argument Name="LEGS" Position="0" Required="false" Kind="scalar" ClrType="System.Int32">
+        <Description>The number of legs.</Description>
+        <Validators>
+          <Validator ClrType="Spectre.Console.Tests.Data.EvenNumberValidatorAttribute" Message="Animals must have an even number of legs." />
+          <Validator ClrType="Spectre.Console.Tests.Data.PositiveNumberValidatorAttribute" Message="Number of legs must be greater than 0." />
+        </Validators>
+      </Argument>
+      <Argument Name="AGE" Position="1" Required="true" Kind="scalar" ClrType="System.Int32" />
+      <Option Short="a" Long="alive,not-dead" Value="NULL" Required="false" Kind="flag" ClrType="System.Boolean">
+        <Description>Indicates whether or not the animal is alive.</Description>
+      </Option>
+      <Option Short="g" Long="good-boy" Value="NULL" Required="false" Kind="flag" ClrType="System.Boolean" />
+      <Option Short="n,p" Long="name,pet-name" Value="VALUE" Required="false" Kind="scalar" ClrType="System.String" />
+    </Parameters>
+    <Examples>
+      <Example commandLine="dog -g" />
+      <Example commandLine="dog --good-boy" />
+    </Examples>
+  </Command>
+</Model>

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_2.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_2.Output.verified.txt
@@ -2,6 +2,7 @@
 <Model>
   <!--DOG-->
   <Command Name="dog" IsBranch="false" ClrType="Spectre.Console.Tests.Data.DogCommand" Settings="Spectre.Console.Tests.Data.DogSettings">
+    <Description>The dog command.</Description>
     <Parameters>
       <Argument Name="LEGS" Position="0" Required="false" Kind="scalar" ClrType="System.Int32">
         <Description>The number of legs.</Description>

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_3.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_3.Output.verified.txt
@@ -16,6 +16,7 @@
     </Parameters>
     <!--DOG-->
     <Command Name="dog" IsBranch="false" ClrType="Spectre.Console.Tests.Data.DogCommand" Settings="Spectre.Console.Tests.Data.DogSettings">
+      <Description>The dog command.</Description>
       <Parameters>
         <Argument Name="AGE" Position="0" Required="true" Kind="scalar" ClrType="System.Int32" />
         <Option Short="g" Long="good-boy" Value="NULL" Required="false" Kind="flag" ClrType="System.Boolean" />
@@ -24,6 +25,7 @@
     </Command>
     <!--HORSE-->
     <Command Name="horse" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
+      <Description>The horse command.</Description>
       <Parameters>
         <Option Short="d" Long="day" Value="MON|TUE" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
         <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_4.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_4.Output.verified.txt
@@ -16,6 +16,7 @@
     </Parameters>
     <!--DOG-->
     <Command Name="dog" IsBranch="false" ClrType="Spectre.Console.Tests.Data.DogCommand" Settings="Spectre.Console.Tests.Data.DogSettings">
+      <Description>The dog command.</Description>
       <Parameters>
         <Argument Name="AGE" Position="0" Required="true" Kind="scalar" ClrType="System.Int32" />
         <Option Short="g" Long="good-boy" Value="NULL" Required="false" Kind="flag" ClrType="System.Boolean" />

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_6.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_6.Output.verified.txt
@@ -2,6 +2,7 @@
 <Model>
   <!--DEFAULT COMMAND-->
   <Command Name="__default_command" IsBranch="false" IsDefault="true" ClrType="Spectre.Console.Tests.Data.DogCommand" Settings="Spectre.Console.Tests.Data.DogSettings">
+    <Description>The dog command.</Description>
     <Parameters>
       <Argument Name="LEGS" Position="0" Required="false" Kind="scalar" ClrType="System.Int32">
         <Description>The number of legs.</Description>
@@ -20,6 +21,7 @@
   </Command>
   <!--HORSE-->
   <Command Name="horse" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
+    <Description>The horse command.</Description>
     <Parameters>
       <Argument Name="LEGS" Position="0" Required="false" Kind="scalar" ClrType="System.Int32">
         <Description>The number of legs.</Description>

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_7.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_7.Output.verified.txt
@@ -21,6 +21,7 @@
       </Parameters>
       <!--__DEFAULT_COMMAND-->
       <Command Name="__default_command" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
+        <Description>The horse command.</Description>
         <Parameters>
           <Option Short="d" Long="day" Value="MON|TUE" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
           <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_8.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_8.Output.verified.txt
@@ -16,6 +16,7 @@
     </Parameters>
     <!--DOG-->
     <Command Name="dog" IsBranch="false" ClrType="Spectre.Console.Tests.Data.DogCommand" Settings="Spectre.Console.Tests.Data.DogSettings">
+      <Description>The dog command.</Description>
       <Parameters>
         <Argument Name="AGE" Position="0" Required="true" Kind="scalar" ClrType="System.Int32" />
         <Option Short="g" Long="good-boy" Value="NULL" Required="false" Kind="flag" ClrType="System.Boolean" />
@@ -24,6 +25,7 @@
     </Command>
     <!--__DEFAULT_COMMAND-->
     <Command Name="__default_command" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
+      <Description>The horse command.</Description>
       <Parameters>
         <Option Short="d" Long="day" Value="MON|TUE" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
         <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />

--- a/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_9.Output.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Xml/Test_9.Output.verified.txt
@@ -18,6 +18,7 @@
     </Parameters>
     <!--DOG-->
     <Command Name="dog" IsBranch="false" ClrType="Spectre.Console.Tests.Data.DogCommand" Settings="Spectre.Console.Tests.Data.DogSettings">
+      <Description>The dog command.</Description>
       <Parameters>
         <Argument Name="AGE" Position="0" Required="true" Kind="scalar" ClrType="System.Int32" />
         <Option Short="g" Long="good-boy" Value="NULL" Required="false" Kind="flag" ClrType="System.Boolean" />
@@ -26,6 +27,7 @@
     </Command>
     <!--__DEFAULT_COMMAND-->
     <Command Name="__default_command" IsBranch="false" ClrType="Spectre.Console.Tests.Data.HorseCommand" Settings="Spectre.Console.Tests.Data.HorseSettings">
+      <Description>The horse command.</Description>
       <Parameters>
         <Option Short="d" Long="day" Value="MON|TUE" Required="false" Kind="scalar" ClrType="System.DayOfWeek" />
         <Option Short="" Long="directory" Value="NULL" Required="false" Kind="scalar" ClrType="System.IO.DirectoryInfo" />

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Xml.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Xml.cs
@@ -111,6 +111,26 @@ public sealed partial class CommandAppTests
         }
 
         [Fact]
+        [Expectation("Test_10")]
+        public Task Should_Dump_Correct_Model_For_Case_6()
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.Configure(config =>
+            {
+                config.AddCommand<DogCommand>("dog")
+                    .WithExample("dog -g")
+                    .WithExample("dog --good-boy");
+            });
+
+            // When
+            var result = fixture.Run(Constants.XmlDocCommand);
+
+            // Then
+            return Verifier.Verify(result.Output);
+        }
+
+        [Fact]
         [Expectation("Test_6")]
         public Task Should_Dump_Correct_Model_For_Model_With_Default_Command()
         {


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #1115 

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

This PR adds improves the XML output by adding the command description and the example list.

The command description is added with the same pattern as the `Parameters` (i.e. as inner text with a dedicated sub node).

The examples are are added on their own subtree as follows
```xml
    <Examples>
      <Example commandLine="dog -g" />
      <Example commandLine="dog --good-boy" />
    </Examples>
```
I didn't find anything suitable in the existing attributes, therefore I chose `commandLine`, which needs a second opinion since I am not fully happy with that.

