### PR TITLE
Fixing #1507 AddDelegate uses an abstract type when used in a branch

### DIFF
--- a/src/Spectre.Console.Cli/ConfiguratorExtensions.cs
+++ b/src/Spectre.Console.Cli/ConfiguratorExtensions.cs
@@ -324,11 +324,16 @@ public static class ConfiguratorExtensions
     /// <param name="func">The delegate to execute as part of command execution.</param>
     /// <returns>A command configurator that can be used to configure the command further.</returns>
     public static ICommandConfigurator AddDelegate<TSettings>(
-        this IConfigurator<TSettings> configurator,
+        this IConfigurator<TSettings>? configurator,
         string name,
         Func<CommandContext, int> func)
-            where TSettings : CommandSettings
+        where TSettings : CommandSettings
     {
+        if (typeof(TSettings).IsAbstract)
+        {
+            AddDelegate(configurator as IConfigurator<EmptyCommandSettings>, name, func);
+        }
+
         if (configurator == null)
         {
             throw new ArgumentNullException(nameof(configurator));

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.cs
@@ -161,55 +161,6 @@ public sealed partial class CommandAppTests
     }
 
     [Fact]
-    public void Should_Pass_Case_7()
-    {
-        // Given
-        var app = new CommandAppTester();
-        app.Configure(cfg =>
-        {
-            cfg.AddBranch("a", d =>
-            {
-                d.AddDelegate("b", _ =>
-                {
-                    AnsiConsole.MarkupLine("[red]Complete[/]");
-                    return 0;
-                });
-            });
-        });
-
-        // When
-        var result = app.Run([
-            "a", "b"
-        ]);
-
-        // Then
-        result.ExitCode.ShouldBe(0);
-    }
-
-    [Fact]
-    public void Should_Pass_Case_8()
-    {
-        // Given
-        var app = new CommandAppTester();
-        app.Configure(cfg =>
-        {
-            cfg.AddDelegate("a", _ =>
-            {
-                AnsiConsole.MarkupLine("[red]Complete[/]");
-                return 0;
-            });
-        });
-
-        // When
-        var result = app.Run([
-            "a"
-        ]);
-
-        // Then
-        result.ExitCode.ShouldBe(0);
-    }
-
-    [Fact]
     public void Should_Pass_Case_3()
     {
         // Given
@@ -1183,6 +1134,55 @@ public sealed partial class CommandAppTests
             dog.Age.ShouldBe(12);
             dog.Legs.ShouldBe(4);
             data.ShouldBe(2);
+        }
+
+        [Fact]
+        public void Should_Execute_Nested_Delegate_Empty_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(cfg =>
+            {
+                cfg.AddBranch("a", d =>
+                {
+                    d.AddDelegate("b", _ =>
+                    {
+                        AnsiConsole.MarkupLine("[red]Complete[/]");
+                        return 0;
+                    });
+                });
+            });
+
+            // When
+            var result = app.Run([
+                "a", "b"
+            ]);
+
+            // Then
+            result.ExitCode.ShouldBe(0);
+        }
+
+        [Fact]
+        public void Should_Execute_Delegate_Empty_Command_At_Root_Level()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(cfg =>
+            {
+                cfg.AddDelegate("a", _ =>
+                {
+                    AnsiConsole.MarkupLine("[red]Complete[/]");
+                    return 0;
+                });
+            });
+
+            // When
+            var result = app.Run([
+                "a"
+            ]);
+
+            // Then
+            result.ExitCode.ShouldBe(0);
         }
 
         [Fact]

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.cs
@@ -161,6 +161,55 @@ public sealed partial class CommandAppTests
     }
 
     [Fact]
+    public void Should_Pass_Case_7()
+    {
+        // Given
+        var app = new CommandAppTester();
+        app.Configure(cfg =>
+        {
+            cfg.AddBranch("a", d =>
+            {
+                d.AddDelegate("b", _ =>
+                {
+                    AnsiConsole.MarkupLine("[red]Complete[/]");
+                    return 0;
+                });
+            });
+        });
+
+        // When
+        var result = app.Run([
+            "a", "b"
+        ]);
+
+        // Then
+        result.ExitCode.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Should_Pass_Case_8()
+    {
+        // Given
+        var app = new CommandAppTester();
+        app.Configure(cfg =>
+        {
+            cfg.AddDelegate("a", _ =>
+            {
+                AnsiConsole.MarkupLine("[red]Complete[/]");
+                return 0;
+            });
+        });
+
+        // When
+        var result = app.Run([
+            "a"
+        ]);
+
+        // Then
+        result.ExitCode.ShouldBe(0);
+    }
+
+    [Fact]
     public void Should_Pass_Case_3()
     {
         // Given


### PR DESCRIPTION
fixes #1507 

<!-- formalities. These are not optional. -->

- [ x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [ x] I have commented on the issue above and discussed the intended changes
- [ x] A maintainer has signed off on the changes and the issue was assigned to me
- [ x] All newly added code is adequately covered by tests
- [ x] All existing tests are still running without errors
- [ x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes
Adds a check if the settings used in the add delegate call have been defined and are therefor not abstract, if not it uses empty command settings. 

Added tests for both single and double nested calls.

There may be another C# feature to accomplish this but I was unable to find any!
