### PR TITLE
Fixing #1495 AnsiConsole.Write(string value) uses format string

### DIFF
--- a/src/Spectre.Console/AnsiConsole.Write.cs
+++ b/src/Spectre.Console/AnsiConsole.Write.cs
@@ -11,7 +11,7 @@ public static partial class AnsiConsole
     /// <param name="value">The value to write.</param>
     public static void Write(string value)
     {
-        Write(value, CurrentStyle);
+        Console.Write(value, CurrentStyle);
     }
 
     /// <summary>


### PR DESCRIPTION
Restore parity between write and write line

<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #1495 

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes
Updating Write to be inline with the functionality of WriteLine where string format is only used when an args object array is included in the method call.
<!-- describe the changes you made. -->
