### PR TITLE
Add token representation to remaining arguments

### DIFF
--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs
@@ -302,11 +302,7 @@ internal class CommandTreeParser
         var valueToken = stream.Peek();
         if (valueToken?.TokenKind == CommandTreeToken.Kind.String)
         {
-            var parseValue = true;
-            if (token.TokenKind == CommandTreeToken.Kind.ShortOption && token.IsGrouped)
-            {
-                parseValue = false;
-            }
+            bool parseValue = token is not { TokenKind: CommandTreeToken.Kind.ShortOption, IsGrouped: true };
 
             if (context.State == State.Normal && parseValue)
             {
@@ -333,7 +329,7 @@ internal class CommandTreeParser
                                     {
                                         value = stream.Consume(CommandTreeToken.Kind.String)?.Value;
 
-                                        context.AddRemainingArgument(token.Value, value);
+                                        context.AddRemainingArgument(token.Representation, value);
 
                                         // Prevent the option and it's non-boolean value from being added to
                                         // mapped parameters (otherwise an exception will be thrown later
@@ -364,14 +360,14 @@ internal class CommandTreeParser
                         // In relaxed parsing mode?
                         if (context.ParsingMode == ParsingMode.Relaxed)
                         {
-                            context.AddRemainingArgument(token.Value, value);
+                            context.AddRemainingArgument(token.Representation, value);
                         }
                     }
                 }
             }
             else
             {
-                context.AddRemainingArgument(token.Value, parseValue ? valueToken.Value : null);
+                context.AddRemainingArgument(token.Representation, parseValue ? valueToken.Value : null);
             }
         }
         else
@@ -379,7 +375,7 @@ internal class CommandTreeParser
             if (parameter == null && // Only add tokens which have not been matched to a command parameter
                 (context.State == State.Remaining || context.ParsingMode == ParsingMode.Relaxed))
             {
-                context.AddRemainingArgument(token.Value, null);
+                context.AddRemainingArgument(token.Representation, null);
             }
         }
 

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
@@ -171,7 +171,7 @@ internal static class CommandTreeTokenizer
             }
 
             // Encountered a separator?
-            if (current == '=' || current == ':')
+            if (current is '=' or ':')
             {
                 break;
             }
@@ -184,7 +184,7 @@ internal static class CommandTreeTokenizer
                 var value = current.ToString(CultureInfo.InvariantCulture);
                 result.Add(result.Count == 0
                     ? new CommandTreeToken(CommandTreeToken.Kind.ShortOption, position, value, $"-{value}")
-                    : new CommandTreeToken(CommandTreeToken.Kind.ShortOption, position + result.Count, value, value));
+                    : new CommandTreeToken(CommandTreeToken.Kind.ShortOption, position + result.Count, value, $"-{value}"));
             }
             else if (result.Count == 0 && char.IsDigit(current))
             {

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
@@ -89,7 +89,7 @@ public sealed partial class CommandAppTests
                 //cat.Name.ShouldBe("Kitty"); //<-- Should normally be correct, but instead name will be added to the remaining arguments (see below).
             });
             result.Context.Remaining.Parsed.Count.ShouldBe(1);
-            result.Context.ShouldHaveRemainingArgument("name", values: new[] { "Kitty", });
+            result.Context.ShouldHaveRemainingArgument("--name", values: new[] { "Kitty", });
         }
 
         [Fact]

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
@@ -56,7 +56,7 @@ public sealed partial class CommandAppTests
 
             // Then
             result.Context.Remaining.Parsed.Count.ShouldBe(1);
-            result.Context.ShouldHaveRemainingArgument(unknownFlag.TrimStart('-'), values: new[] { (string)null });
+            result.Context.ShouldHaveRemainingArgument(unknownFlag, values: new[] { (string)null });
             result.Context.Remaining.Raw.Count.ShouldBe(0);
         }
 
@@ -80,7 +80,7 @@ public sealed partial class CommandAppTests
 
             // Then
             result.Context.Remaining.Parsed.Count.ShouldBe(1);
-            result.Context.ShouldHaveRemainingArgument("r", values: new[] { (string)null });
+            result.Context.ShouldHaveRemainingArgument("-r", values: new[] { (string)null });
             result.Context.Remaining.Raw.Count.ShouldBe(0);
         }
 
@@ -189,10 +189,10 @@ public sealed partial class CommandAppTests
 
             // Then
             result.Context.Remaining.Parsed.Count.ShouldBe(4);
-            result.Context.ShouldHaveRemainingArgument("foo", values: new[] { "bar", "baz" });
-            result.Context.ShouldHaveRemainingArgument("b", values: new[] { (string)null });
-            result.Context.ShouldHaveRemainingArgument("a", values: new[] { (string)null });
-            result.Context.ShouldHaveRemainingArgument("r", values: new[] { (string)null });
+            result.Context.ShouldHaveRemainingArgument("--foo", values: new[] { "bar", "baz" });
+            result.Context.ShouldHaveRemainingArgument("-b", values: new[] { (string)null });
+            result.Context.ShouldHaveRemainingArgument("-a", values: new[] { (string)null });
+            result.Context.ShouldHaveRemainingArgument("-r", values: new[] { (string)null });
         }
 
         [Fact]
@@ -280,7 +280,7 @@ public sealed partial class CommandAppTests
 
             // Then
             result.Context.Remaining.Parsed.Count.ShouldBe(1);
-            result.Context.ShouldHaveRemainingArgument("good-boy", values: new[] { "Please be good Rufus!" });
+            result.Context.ShouldHaveRemainingArgument("--good-boy", values: new[] { "Please be good Rufus!" });
 
             result.Context.Remaining.Raw.Count.ShouldBe(0); // nb. there are no "raw" remaining arguments on the command line
         }

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
@@ -51,7 +51,7 @@ public sealed partial class CommandAppTests
 
             // Then
             result.Output.ShouldBe(string.Empty);
-            result.Context.ShouldHaveRemainingArgument("version", new[] { (string)null });
+            result.Context.ShouldHaveRemainingArgument("--version", new[] { (string)null });
         }
 
         [Fact]
@@ -70,7 +70,7 @@ public sealed partial class CommandAppTests
 
             // Then
             result.Output.ShouldBe(string.Empty);
-            result.Context.ShouldHaveRemainingArgument("version", new[] { (string)null });
+            result.Context.ShouldHaveRemainingArgument("--version", new[] { (string)null });
         }
 
         [Fact]

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.cs
@@ -215,7 +215,7 @@ public sealed partial class CommandAppTests
             dog.Name.ShouldBe("\" -Rufus --' ");
         });
         result.Context.Remaining.Parsed.Count.ShouldBe(1);
-        result.Context.ShouldHaveRemainingArgument("order-by", values: new[] { "\"-size\"", " ", string.Empty });
+        result.Context.ShouldHaveRemainingArgument("--order-by", values: new[] { "\"-size\"", " ", string.Empty });
     }
 
     [Fact]
@@ -844,7 +844,7 @@ public sealed partial class CommandAppTests
         // Then
         result.Context.ShouldNotBeNull();
         result.Context.Remaining.Parsed.Count.ShouldBe(1);
-        result.Context.ShouldHaveRemainingArgument("foo", values: new[] { "bar" });
+        result.Context.ShouldHaveRemainingArgument("--foo", values: new[] { "bar" });
     }
 
     [Fact]
@@ -875,8 +875,8 @@ public sealed partial class CommandAppTests
         // Then
         result.Context.ShouldNotBeNull();
         result.Context.Remaining.Parsed.Count.ShouldBe(2);
-        result.Context.ShouldHaveRemainingArgument("foo", values: new[] { "bar" });
-        result.Context.ShouldHaveRemainingArgument("f", values: new[] { "baz" });
+        result.Context.ShouldHaveRemainingArgument("--foo", values: new[] { "bar" });
+        result.Context.ShouldHaveRemainingArgument("-f", values: new[] { "baz" });
         result.Context.Remaining.Raw.Count.ShouldBe(5);
         result.Context.Remaining.Raw.ShouldBe(new[]
         {
@@ -909,7 +909,7 @@ public sealed partial class CommandAppTests
         // Then
         result.Context.ShouldNotBeNull();
         result.Context.Remaining.Parsed.Count.ShouldBe(1);
-        result.Context.ShouldHaveRemainingArgument("foo", values: new[] { (string)null });
+        result.Context.ShouldHaveRemainingArgument("--foo", values: new[] { (string)null });
     }
 
     [Fact]


### PR DESCRIPTION
Before, when adding parsed information to the IRemainingArguments.Parsed, we used the name of the parsed option (`foo`) instead of its representation (`--foo`).