### PR TITLE
Allow SelectionPrompt to have an initial selection

### DIFF
--- a/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
+++ b/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
@@ -16,6 +16,13 @@ internal interface IListPromptStrategy<T>
     ListPromptInputResult HandleInput(ConsoleKeyInfo key, ListPromptState<T> state);
 
     /// <summary>
+    /// Calculates the state's initial index.
+    /// </summary>
+    /// <param name="nodes">The nodes that will be shown in the list.</param>
+    /// <returns>The initial index that should be used.</returns>
+    public int CalculateInitialIndex(IReadOnlyList<ListPromptItem<T>> nodes);
+
+    /// <summary>
     /// Calculates the page size.
     /// </summary>
     /// <param name="console">The console.</param>

--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -41,7 +41,14 @@ internal sealed class ListPrompt<T>
         }
 
         var nodes = tree.Traverse().ToList();
-        var state = new ListPromptState<T>(nodes, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, selectionMode, skipUnselectableItems, searchEnabled);
+        var state = new ListPromptState<T>(
+            nodes,
+            _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize),
+            wrapAround,
+            selectionMode,
+            skipUnselectableItems,
+            searchEnabled,
+            _strategy.CalculateInitialIndex(nodes));
         var hook = new ListPromptRenderHook<T>(_console, () => BuildRenderable(state));
 
         using (new RenderHookScope(_console, hook))

--- a/src/Spectre.Console/Prompts/List/ListPromptState.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptState.cs
@@ -16,7 +16,7 @@ internal sealed class ListPromptState<T>
     public ListPromptItem<T> Current => Items[Index];
     public string SearchText { get; private set; }
 
-    public ListPromptState(IReadOnlyList<ListPromptItem<T>> items, int pageSize, bool wrapAround, SelectionMode mode, bool skipUnselectableItems, bool searchEnabled)
+    public ListPromptState(IReadOnlyList<ListPromptItem<T>> items, int pageSize, bool wrapAround, SelectionMode mode, bool skipUnselectableItems, bool searchEnabled, int initialIndex)
     {
         Items = items;
         PageSize = pageSize;
@@ -36,11 +36,18 @@ internal sealed class ListPromptState<T>
                     .ToList()
                     .AsReadOnly();
 
-            Index = _leafIndexes.FirstOrDefault();
+            if (_leafIndexes.Contains(initialIndex))
+            {
+                Index = initialIndex;
+            }
+            else
+            {
+                Index = _leafIndexes.FirstOrDefault();
+            }
         }
         else
         {
-            Index = 0;
+            Index = initialIndex;
         }
     }
 

--- a/src/Spectre.Console/Prompts/List/ListPromptTree.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptTree.cs
@@ -29,6 +29,22 @@ internal sealed class ListPromptTree<T>
         return null;
     }
 
+    public int? IndexOf(T item)
+    {
+        var index = 0;
+        foreach (var node in Traverse())
+        {
+            if (_comparer.Equals(item, node.Data))
+            {
+                return index;
+            }
+
+            index++;
+        }
+
+        return null;
+    }
+
     public void Add(ListPromptItem<T> node)
     {
         _roots.Add(node);

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -278,4 +278,10 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
         // Combine all items
         return new Rows(list);
     }
+
+    /// <inheritdoc/>
+    int IListPromptStrategy<T>.CalculateInitialIndex(IReadOnlyList<ListPromptItem<T>> nodes)
+    {
+        return 0;
+    }
 }

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -69,11 +69,21 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     public bool SearchEnabled { get; set; }
 
     /// <summary>
+    /// Gets or sets the choice to show as selected when the prompt is first displayed.
+    /// By default the first choice is selected.
+    /// </summary>
+    public T? DefaultValue { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="SelectionPrompt{T}"/> class.
     /// </summary>
-    public SelectionPrompt()
+    /// <param name="comparer">
+    /// The <see cref="IEqualityComparer{T}"/> implementation to use when comparing items,
+    /// or <c>null</c> to use the default <see cref="IEqualityComparer{T}"/> for the type of the item.
+    /// </param>
+    public SelectionPrompt(IEqualityComparer<T>? comparer = null)
     {
-        _tree = new ListPromptTree<T>(EqualityComparer<T>.Default);
+        _tree = new ListPromptTree<T>(comparer ?? EqualityComparer<T>.Default);
     }
 
     /// <summary>
@@ -224,5 +234,16 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
         }
 
         return new Rows(list);
+    }
+
+    /// <inheritdoc/>
+    int IListPromptStrategy<T>.CalculateInitialIndex(IReadOnlyList<ListPromptItem<T>> nodes)
+    {
+        if (DefaultValue is not null)
+        {
+            return _tree.IndexOf(DefaultValue) ?? 0;
+        }
+
+        return 0;
     }
 }

--- a/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
@@ -293,4 +293,23 @@ public static class SelectionPromptExtensions
         obj.Converter = displaySelector;
         return obj;
     }
+
+    /// <summary>
+    /// Sets the choice that will be selected when the prompt is first displayed.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="defaultValue">The choice to show as selected when the prompt is first displayed.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static SelectionPrompt<T> DefaultValue<T>(this SelectionPrompt<T> obj, T? defaultValue)
+        where T : notnull
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        obj.DefaultValue = defaultValue;
+        return obj;
+    }
 }

--- a/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
@@ -2,20 +2,22 @@ namespace Spectre.Console.Tests.Unit;
 
 public sealed class ListPromptStateTests
 {
-    private ListPromptState<string> CreateListPromptState(int count, int pageSize, bool shouldWrap, bool searchEnabled)
-        => new(Enumerable.Range(0, count).Select(i => new ListPromptItem<string>(i.ToString())).ToList(), pageSize, shouldWrap, SelectionMode.Independent, true, searchEnabled);
+    private ListPromptState<string> CreateListPromptState(int count, int pageSize, bool shouldWrap, bool searchEnabled, int initialIndex = 0)
+        => new(Enumerable.Range(0, count).Select(i => new ListPromptItem<string>(i.ToString())).ToList(), pageSize, shouldWrap, SelectionMode.Independent, true, searchEnabled, initialIndex);
 
-    [Fact]
-    public void Should_Have_Start_Index_Zero()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void Should_Have_Specified_Start_Index(int index)
     {
         // Given
-        var state = CreateListPromptState(100, 10, false, false);
+        var state = CreateListPromptState(100, 10, false, false, initialIndex: index);
 
         // When
         /* noop */
 
         // Then
-        state.Index.ShouldBe(0);
+        state.Index.ShouldBe(index);
     }
 
     [Theory]

--- a/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -85,4 +85,201 @@ public sealed class SelectionPromptTests
         // Then
         console.Output.ShouldContain($"{ESC}[38;5;12m> Item {ESC}[0m{ESC}[1;38;5;12;48;5;11m1{ESC}[0m");
     }
+
+    [Fact]
+    public void Should_Initially_Select_The_First_Item_When_No_Default_Is_Specified()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one",
+            "          ",
+            "> First   ",
+            "  Second  ",
+            "  Third   ",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Item_When_It_Exists_In_The_Choices()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third")
+                .DefaultValue("Second");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one",
+            "          ",
+            "  First   ",
+            "> Second  ",
+            "  Third   ",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_First_Item_When_Default_Does_Not_Exist_In_The_Choices()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third")
+                .DefaultValue("Fourth");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one",
+            "          ",
+            "> First   ",
+            "  Second  ",
+            "  Third   ",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Item_When_Scrolling_Is_Required_And_Item_Is_Not_Last()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third", "Fourth", "Fifth", "Sixth")
+                .DefaultValue("Third")
+                .PageSize(3);
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one                               ",
+            "                                         ",
+            "  Second                                 ",
+            "> Third                                  ",
+            "  Fourth                                 ",
+            "                                         ",
+            "(Move up and down to reveal more choices)",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Item_When_Scrolling_Is_Required_And_Item_Is_Last()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third", "Fourth", "Fifth", "Sixth")
+                .DefaultValue("Sixth")
+                .PageSize(3);
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one                               ",
+            "                                         ",
+            "  Fourth                                 ",
+            "  Fifth                                  ",
+            "> Sixth                                  ",
+            "                                         ",
+            "(Move up and down to reveal more choices)",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Value_When_Skipping_Unselectable_Items_And_Default_Value_Is_Leaf()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoiceGroup("Group one", "First", "Second")
+                .AddChoiceGroup("Group two", "Third", "Fourth")
+                .Mode(SelectionMode.Leaf)
+                .DefaultValue("Third");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one  ",
+            "            ",
+            "  Group one ",
+            "    First   ",
+            "    Second  ",
+            "  Group two ",
+            "  > Third   ",
+            "    Fourth  ",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_First_Leaf_When_Skipping_Unselectable_Items_And_Default_Value_Is_Not_Leaf()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoiceGroup("Group one", "First", "Second")
+                .AddChoiceGroup("Group two", "Third", "Fourth")
+                .Mode(SelectionMode.Leaf)
+                .DefaultValue("Group two");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one  ",
+            "            ",
+            "  Group one ",
+            "  > First   ",
+            "    Second  ",
+            "  Group two ",
+            "    Third   ",
+            "    Fourth  ",
+        ]);
+    }
 }


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #508

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

<!-- describe the changes you made. -->

`SelectionPrompt` now has a `DefaultValue` property that can be used to set the item that should be initially selected.

---
Please upvote :+1: this pull request if you are interested in it.