### PR TITLE
Consider -? as an alias to -h

### DIFF
--- a/src/Spectre.Console.Cli/Internal/Configuration/TemplateParser.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/TemplateParser.cs
@@ -86,7 +86,7 @@ internal static class TemplateParser
 
                 foreach (var character in token.Value)
                 {
-                    if (!char.IsLetterOrDigit(character) && character != '-' && character != '_')
+                    if (!char.IsLetterOrDigit(character) && character != '-' && character != '_' && character != '?')
                     {
                         throw CommandTemplateException.InvalidCharacterInOptionName(template, token, character);
                     }

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs
@@ -21,7 +21,7 @@ internal class CommandTreeParser
     {
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _parsingMode = parsingMode ?? _configuration.ParsingMode;
-        _help = new CommandOptionAttribute("-h|--help");
+        _help = new CommandOptionAttribute("-?|-h|--help");
         _convertFlagsToRemainingArguments = convertFlagsToRemainingArguments ?? false;
 
         CaseSensitivity = caseSensitivity;

--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeTokenizer.cs
@@ -176,7 +176,7 @@ internal static class CommandTreeTokenizer
                 break;
             }
 
-            if (char.IsLetter(current))
+            if (char.IsLetter(current) || current is '?')
             {
                 context.AddRemaining(current);
                 reader.Read(); // Consume

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/Root.QuestionMark.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/Root.QuestionMark.verified.txt
@@ -1,0 +1,10 @@
+USAGE:
+    myapp [OPTIONS] <COMMAND>
+
+OPTIONS:
+    -h, --help    Prints help information
+
+COMMANDS:
+    dog <AGE>           The dog command
+    horse               The horse command
+    giraffe <LENGTH>    The giraffe command

--- a/test/Spectre.Console.Cli.Tests/Expectations/Help/Root_Command.QuestionMark.verified.txt
+++ b/test/Spectre.Console.Cli.Tests/Expectations/Help/Root_Command.QuestionMark.verified.txt
@@ -1,0 +1,17 @@
+DESCRIPTION:
+The horse command.
+
+USAGE:
+    myapp horse [LEGS] [OPTIONS]
+
+ARGUMENTS:
+    [LEGS]    The number of legs
+
+OPTIONS:
+                           DEFAULT
+    -h, --help                         Prints help information
+    -a, --alive                        Indicates whether or not the animal is alive
+    -n, --name <VALUE>
+    -d, --day <MON|TUE>
+        --file             food.txt
+        --directory

--- a/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
+++ b/test/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
@@ -29,6 +29,27 @@ public sealed partial class CommandAppTests
         }
 
         [Fact]
+        [Expectation("Root", "QuestionMark")]
+        public Task Should_Output_Root_Correctly_QuestionMark()
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationName("myapp");
+                configurator.AddCommand<DogCommand>("dog");
+                configurator.AddCommand<HorseCommand>("horse");
+                configurator.AddCommand<GiraffeCommand>("giraffe");
+            });
+
+            // When
+            var result = fixture.Run("-?");
+
+            // Then
+            return Verifier.Verify(result.Output);
+        }
+
+        [Fact]
         [Expectation("Root_Command")]
         public Task Should_Output_Root_Command_Correctly()
         {
@@ -44,6 +65,27 @@ public sealed partial class CommandAppTests
 
             // When
             var result = fixture.Run("horse", "--help");
+
+            // Then
+            return Verifier.Verify(result.Output);
+        }
+
+        [Fact]
+        [Expectation("Root_Command", "QuestionMark")]
+        public Task Should_Output_Root_Command_Correctly_QuestionMark()
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationName("myapp");
+                configurator.AddCommand<DogCommand>("dog");
+                configurator.AddCommand<HorseCommand>("horse");
+                configurator.AddCommand<GiraffeCommand>("giraffe");
+            });
+
+            // When
+            var result = fixture.Run("horse", "-?");
 
             // Then
             return Verifier.Verify(result.Output);


### PR DESCRIPTION
Given that it's quite a common switch and extremely unlikely to be already in use for something else, we can just consider it to be the same as having entered `-h` as an arg.

Fixes #1547