### PR TITLE
Make method reference to Markup.Escape more obvious

### DIFF
--- a/docs/input/best-practices.md
+++ b/docs/input/best-practices.md
@@ -60,7 +60,7 @@ Spectre.Console will tell your terminal to use the color that is configured in t
 If you are using an 8 or 24-bit color for the foreground text, it is recommended that you also set an appropriate
 background color to match.
 
-**Do** escape data when outputting any user input or any external data via Markup using the [`EscapeMarkup`](xref:M:Spectre.Console.Markup.Escape(System.String)) method on the data. Any user input containing `[` or `]` will likely cause a runtime error while rendering otherwise.
+**Do** escape data when outputting any user input or any external data via Markup using the [`Markup.Escape`](xref:M:Spectre.Console.Markup.Escape(System.String)) method on the data. Any user input containing `[` or `]` will likely cause a runtime error while rendering otherwise.
 
 **Consider** replacing `Markup` and `MarkupLine` with [`MarkupInterpolated`](xref:M:Spectre.Console.AnsiConsole.MarkupInterpolated(System.FormattableString)) and [`MarkupLineInterpolated`](xref:M:Spectre.Console.AnsiConsole.MarkupLineInterpolated(System.FormattableString)). Both these methods will automatically escape all data in the interpolated string holes. When working with widgets such as the Table and Tree, consider using [`Markup.FromInterpolated`](xref:M:Spectre.Console.Markup.FromInterpolated(System.FormattableString,Spectre.Console.Style)) to generate an `IRenderable` from an interpolated string.
 


### PR DESCRIPTION
best-practices refers and links to the `Markup.Escape` method but labeled it `EscapeMarkup`.

I got quite confused trying to find EscapeMarkup. Using the typical *class dot method* pattern seems preferable. It also matches what you write in code.

*Despite the caps NOT I hope it's okay to create this PR as-is, for this trivial obvious change instead of first creating a Discussion and then a ticket and the the PR.*

## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- ~~[ ] I have commented on the issue above and discussed the intended changes~~
- ~~[ ] A maintainer has signed off on the changes and the issue was assigned to me~~
- ~~[ ] All newly added code is adequately covered by tests~~
- [x] All existing tests are still running without errors
- ~~[ ] The documentation was modified to reflect the changes _OR_ no documentation changes are required.~~
