### PR TITLE
Fix outdated issue label reference 'up for grabs' -> 'good first issue'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Any new code should also have reasonable unit test coverage.
      information and a link back to the discussion.
   * Once you get a nod from someone in the Spectre.Console Team, you can start on the feature.
   * Alternatively, if a feature is on the issues list with the
-   [Up For Grabs](https://github.com/spectreconsole/spectre.console/labels/up-for-grabs) label,
+   [good first issue](https://github.com/spectreconsole/spectre.console/labels/good%20first%20issue) label,
    it is open for a community member (contributor) to patch. You should comment that you are signing up for it on
    the issue so someone else doesn't also sign up for the work.
 


### PR DESCRIPTION
## Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- ~~[ ] I have commented on the issue above and discussed the intended changes~~
- ~~[ ] A maintainer has signed off on the changes and the issue was assigned to me~~
- ~~[ ] All newly added code is adequately covered by tests~~
- ~~[ ] All existing tests are still running without errors~~
- ~~[ ] The documentation was modified to reflect the changes _OR_ no documentation changes are required.~~
