### PR TITLE
Improved the visual appeal of SelectionPrompt and MultiSelectionPrompt (text wrapping)

### DIFF
--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -234,7 +234,8 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
         }
 
         var grid = new Grid();
-        grid.AddColumn(new GridColumn().Padding(0, 0, 1, 0).NoWrap());
+        grid.AddColumns(new GridColumn().Padding(0, 0, 1, 0).NoWrap(),
+                        new GridColumn().Padding(0, 0, 1, 0));
 
         if (Title != null)
         {
@@ -260,7 +261,9 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
                     ? ListPromptConstants.GroupSelectedCheckbox : ListPromptConstants.SelectedCheckbox)
                 : ListPromptConstants.Checkbox;
 
-            grid.AddRow(new Markup(indent + prompt + " " + checkbox + " " + text, style));
+            //grid.AddRow(new Markup(indent + prompt + " " + checkbox + " " + text, style));
+            grid.AddRow(new Markup(indent + prompt + " " + checkbox, style),
+                        new Markup(text, style));
         }
 
         list.Add(grid);

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -234,8 +234,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
         }
 
         var grid = new Grid();
-        grid.AddColumns(new GridColumn().Padding(0, 0, 1, 0).NoWrap(),
-                        new GridColumn().Padding(0, 0, 1, 0));
+        grid.AddColumns(new GridColumn().Padding(0, 0, 1, 0).NoWrap(), new GridColumn().Padding(0, 0, 1, 0));
 
         if (Title != null)
         {
@@ -261,9 +260,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
                     ? ListPromptConstants.GroupSelectedCheckbox : ListPromptConstants.SelectedCheckbox)
                 : ListPromptConstants.Checkbox;
 
-            //grid.AddRow(new Markup(indent + prompt + " " + checkbox + " " + text, style));
-            grid.AddRow(new Markup(indent + prompt + " " + checkbox, style),
-                        new Markup(text, style));
+            grid.AddRow(new Markup(indent + prompt + " " + checkbox, style), new Markup(text, style));
         }
 
         list.Add(grid);

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -157,6 +157,9 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
         return requestedPageSize;
     }
 
+    private static readonly GridColumn[] _columns = [new GridColumn().Padding(0, 0, 1, 0), new GridColumn().Padding(0, 0, 1, 0)];
+    private static readonly Text _emptyLine = new(string.Empty);
+
     /// <inheritdoc/>
     IRenderable IListPromptStrategy<T>.Render(IAnsiConsole console, bool scrollable, int cursorIndex,
         IEnumerable<(int Index, ListPromptItem<T> Node)> items, bool skipUnselectableItems, string searchText)
@@ -171,12 +174,9 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
             list.Add(new Markup(Title));
         }
 
-        var grid = new Grid();
-        grid.AddColumns(new GridColumn().Padding(0, 0, 1, 0).NoWrap(), new GridColumn().Padding(0, 0, 1, 0));
-
         if (Title != null)
         {
-            grid.AddEmptyRow();
+            list.Add(_emptyLine);
         }
 
         foreach (var item in items)
@@ -200,10 +200,35 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
                 text = text.Highlight(searchText, searchHighlightStyle);
             }
 
-            grid.AddRow(new Markup(indent + prompt, style), new Markup(text, style));
-        }
+            if (item.Node.IsGroup)
+            {
+                list.Add(new Text(indent + prompt + " " + text, style));
+            }
+            else
+            {
+                IRenderable[] rows = [
+                    new Markup(indent + prompt, style),
+                    new Markup(text, style)
+                ];
 
-        list.Add(grid);
+                var last = list.LastOrDefault();
+                Grid grid;
+
+                // Optimization to not create a new Grid for each option.
+                if (last is not Grid)
+                {
+                    grid = new Grid()
+                        .AddColumns(_columns);
+                    list.Add(grid);
+                }
+                else
+                {
+                    grid = (Grid)last;
+                }
+
+                grid.AddRow(rows);
+            }
+        }
 
         if (SearchEnabled || scrollable)
         {

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -172,7 +172,8 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
         }
 
         var grid = new Grid();
-        grid.AddColumn(new GridColumn().Padding(0, 0, 1, 0).NoWrap());
+        grid.AddColumns(new GridColumn().Padding(0, 0, 1, 0).NoWrap(),
+                        new GridColumn().Padding(0, 0, 1, 0));
 
         if (Title != null)
         {
@@ -200,7 +201,8 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
                 text = text.Highlight(searchText, searchHighlightStyle);
             }
 
-            grid.AddRow(new Markup(indent + prompt + " " + text, style));
+            grid.AddRow(new Markup(indent + prompt, style),
+                        new Markup(text, style));
         }
 
         list.Add(grid);

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -172,8 +172,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
         }
 
         var grid = new Grid();
-        grid.AddColumns(new GridColumn().Padding(0, 0, 1, 0).NoWrap(),
-                        new GridColumn().Padding(0, 0, 1, 0));
+        grid.AddColumns(new GridColumn().Padding(0, 0, 1, 0).NoWrap(), new GridColumn().Padding(0, 0, 1, 0));
 
         if (Title != null)
         {
@@ -201,8 +200,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
                 text = text.Highlight(searchText, searchHighlightStyle);
             }
 
-            grid.AddRow(new Markup(indent + prompt, style),
-                        new Markup(text, style));
+            grid.AddRow(new Markup(indent + prompt, style), new Markup(text, style));
         }
 
         list.Add(grid);

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -158,7 +158,6 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     }
 
     private static readonly GridColumn[] _columns = [new GridColumn().Padding(0, 0, 1, 0), new GridColumn().Padding(0, 0, 1, 0)];
-    private static readonly Text _emptyLine = new(string.Empty);
 
     /// <inheritdoc/>
     IRenderable IListPromptStrategy<T>.Render(IAnsiConsole console, bool scrollable, int cursorIndex,
@@ -176,7 +175,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
 
         if (Title != null)
         {
-            list.Add(_emptyLine);
+            list.Add(Text.Empty);
         }
 
         foreach (var item in items)

--- a/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -83,6 +83,6 @@ public sealed class SelectionPromptTests
         prompt.Show(console);
 
         // Then
-        console.Output.ShouldContain($"{ESC}[38;5;12m> Item {ESC}[0m{ESC}[1;38;5;12;48;5;11m1{ESC}[0m");
+        console.Output.ShouldContain($"{ESC}[38;5;12m>{ESC}[0m {ESC}[38;5;12mItem {ESC}[0m{ESC}[1;38;5;12;48;5;11m1{ESC}[0m");
     }
 }


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #1577 

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

I've modified how `SelectionPrompt<T>` and `MultiSelectionPrompt<T>` render the prompt. Instead of using `Grid` with only one column, I split the row into two columns, where one is the indentation, arrow, or checkbox and the second column is the text itself. This makes the wrapping look better.

Before the change:
![image](https://github.com/spectreconsole/spectre.console/assets/168128663/3b957de5-975c-4ea5-a2fa-802bbd52b27a)

After the change:
![image](https://github.com/spectreconsole/spectre.console/assets/168128663/a9a20046-6ec8-4ca5-b0c5-d61f6c05cee0)

---
Please upvote :+1: this pull request if you are interested in it.