### PR TITLE
Fix Console Display Issue with Deleting Wide Characters

### DIFF
--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
@@ -52,11 +52,19 @@ public static partial class AnsiConsoleExtensions
             {
                 if (text.Length > 0)
                 {
+                    var lastChar = text.Last();
                     text = text.Substring(0, text.Length - 1);
 
                     if (mask != null)
                     {
-                        console.Write("\b \b");
+                        if (UnicodeCalculator.GetWidth(lastChar) == 1)
+                        {
+                            console.Write("\b \b");
+                        }
+                        else if (UnicodeCalculator.GetWidth(lastChar) == 2)
+                        {
+                            console.Write("\b \b\b \b");
+                        }
                     }
                 }
 


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #1406 

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

<!-- describe the changes you made. -->
- Added logic to handle the correct deletion of wide characters.
- The `UnicodeCalculator.GetWidth` method is used to determine the width of the last character.
- If the character width is 1, the console deletes the character with `\b \b`.
- If the character width is 2, the console deletes the character with `\b \b\b \b`.
- These changes ensure that the console accurately deletes characters, preventing display issues with wide characters.

---
Please upvote :+1: this pull request if you are interested in it.