### PR TITLE
CLI improvements for 1.0 release (Draft)

### DIFF
--- a/src/Spectre.Console.Cli/CommandParseException.cs
+++ b/src/Spectre.Console.Cli/CommandParseException.cs
@@ -113,4 +113,9 @@ public sealed class CommandParseException : CommandRuntimeException
         var text = $"[red]Error:[/] The value '[white]{value}[/]' is not in a correct format";
         return new CommandParseException("Could not parse value", new Markup(text));
     }
+
+    internal static CommandParseException UnknownParsingError()
+    {
+        return new CommandParseException("An unknown error occured when parsing the arguments.");
+    }
 }

--- a/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
@@ -114,23 +114,28 @@ internal sealed class CommandExecutor
         {
             // CASE: Failed to parse in Strict Mode.
 
-            // Adjust for any parsed remaining arguments by
-            // inserting the the default command ahead of them.
-            var position = tokenizerResult.Tokens.Position - 1;
-            position = position < 0 ? 0 : position;
+            for (int i = 0; i < args.Count; i++)
+            {
+                // Insert this branch's default command into the command line
+                // arguments and try again to see if it will parse.
+                // Try this for every position of the arguments.
+                // A brute force approach is required.
+                var argsWithDefaultCommand = new List<string>(args);
+                argsWithDefaultCommand.Insert(args.Count - i, "__default_command");
 
-            // Insert this branch's default command into the command line
-            // arguments and try again to see if it will parse.
-            var argsWithDefaultCommand = new List<string>(args);
-            argsWithDefaultCommand.Insert(position, "__default_command");
+                (parsedResult, tokenizerResult) = InternalParseCommandLineArguments(model, settings, argsWithDefaultCommand, swallowParseExceptions: true);
 
-            (parsedResult, tokenizerResult) = InternalParseCommandLineArguments(model, settings, argsWithDefaultCommand, swallowParseExceptions: true);
+                if (parsedResult != null)
+                {
+                    break;
+                }
+            }
 
             if (parsedResult == null)
             {
                 // CASE: Failed to parse in Strict Mode after inserting the default command.
                 // Repeat the parsing of the original arguments to throw the correct exception.
-                // nb. I expect the following line to always throw an exception.
+                // I expect the following line to always throw an exception.
                 (parsedResult, tokenizerResult) = InternalParseCommandLineArguments(model, settings, args, swallowParseExceptions: false);
             }
         }

--- a/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
@@ -115,11 +115,19 @@ internal sealed class CommandExecutor
             lastParsedCommand.IsBranch && !lastParsedLeaf.ShowHelp &&
             lastParsedCommand.DefaultCommand != null)
         {
+            // Adjust for any parsed remaining arguments by
+            // inserting the the default command ahead of them.
+            var position = tokenizerResult.Tokens.Position;
+            foreach (var parsedRemaining in parsedResult.Remaining.Parsed)
+            {
+                position--;
+                position -= parsedRemaining.Count(value => value != null);
+            }
+
             // Insert this branch's default command into the command line
             // arguments and try again to see if it will parse.
             var argsWithDefaultCommand = new List<string>(args);
-
-            argsWithDefaultCommand.Insert(tokenizerResult.Tokens.Position, lastParsedCommand.DefaultCommand.Name);
+            argsWithDefaultCommand.Insert(position, lastParsedCommand.DefaultCommand.Name);
 
             parserContext = new CommandTreeParserContext(argsWithDefaultCommand, settings.ParsingMode);
             tokenizerResult = CommandTreeTokenizer.Tokenize(argsWithDefaultCommand);

--- a/src/Tests/Spectre.Console.Cli.Tests/Data/Settings/VersionSettings.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Data/Settings/VersionSettings.cs
@@ -3,5 +3,6 @@ namespace Spectre.Console.Tests.Data;
 public sealed class VersionSettings : CommandSettings
 {
     [CommandOption("-v|--version")]
+    [Description("The command version")]
     public string Version { get; set; }
 }

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
@@ -4,13 +4,16 @@ public sealed partial class CommandAppTests
 {
     public sealed class Branches
     {
-        [Fact]
-        public void Should_Run_The_Default_Command_On_Branch()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Run_The_Default_Command_On_Branch(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -29,13 +32,16 @@ public sealed partial class CommandAppTests
             result.Settings.ShouldBeOfType<CatSettings>();
         }
 
-        [Fact]
-        public void Should_Throw_When_No_Default_Command_On_Branch()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Throw_When_No_Default_Command_On_Branch(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal => { });
             });
@@ -131,13 +137,16 @@ public sealed partial class CommandAppTests
             result.Context.Remaining.Raw.Count.ShouldBe(2);
         }
 
-        [Fact]
-        public void Should_Run_The_Default_Command_On_Branch_On_Branch()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Run_The_Default_Command_On_Branch_On_Branch(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -159,13 +168,16 @@ public sealed partial class CommandAppTests
             result.Settings.ShouldBeOfType<CatSettings>();
         }
 
-        [Fact]
-        public void Should_Run_The_Default_Command_On_Branch_On_Branch_With_Arguments()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Run_The_Default_Command_On_Branch_On_Branch_With_Arguments(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -191,13 +203,16 @@ public sealed partial class CommandAppTests
             });
         }
 
-        [Fact]
-        public void Should_Run_The_Default_Command_Not_The_Named_Command_On_Branch()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Run_The_Default_Command_Not_The_Named_Command_On_Branch(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -218,13 +233,16 @@ public sealed partial class CommandAppTests
             result.Settings.ShouldBeOfType<CatSettings>();
         }
 
-        [Fact]
-        public void Should_Run_The_Named_Command_Not_The_Default_Command_On_Branch()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Run_The_Named_Command_Not_The_Default_Command_On_Branch(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -251,13 +269,16 @@ public sealed partial class CommandAppTests
             });
         }
 
-        [Fact]
-        public void Should_Allow_Multiple_Branches_Multiple_Commands()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Allow_Multiple_Branches_Multiple_Commands(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -287,13 +308,16 @@ public sealed partial class CommandAppTests
             });
         }
 
-        [Fact]
-        public void Should_Allow_Single_Branch_Multiple_Commands()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Allow_Single_Branch_Multiple_Commands(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -320,13 +344,16 @@ public sealed partial class CommandAppTests
             });
         }
 
-        [Fact]
-        public void Should_Allow_Single_Branch_Single_Command()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Allow_Single_Branch_Single_Command(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
@@ -59,7 +59,7 @@ public sealed partial class CommandAppTests
         [SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1515:SingleLineCommentMustBePrecededByBlankLine", Justification = "Helps to illustrate the expected behaviour of this unit test.")]
         [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1005:SingleLineCommentsMustBeginWithSingleSpace", Justification = "Helps to illustrate the expected behaviour of this unit test.")]
         [Fact]
-        public void Should_Be_Unable_To_Parse_Default_Command_Arguments_Relaxed_Parsing()
+        public void Should_Parse_Default_Command_Arguments_Relaxed_Parsing()
         {
             // Given
             var app = new CommandAppTester();
@@ -75,7 +75,7 @@ public sealed partial class CommandAppTests
             // When
             var result = app.Run(new[]
             {
-                // The CommandTreeParser should be unable to determine which command line
+                // The CommandTreeParser should determine which command line
                 // arguments belong to the branch and which belong to the branch's
                 // default command (once inserted).
                 "animal", "4", "--name", "Kitty",
@@ -86,10 +86,9 @@ public sealed partial class CommandAppTests
             result.Settings.ShouldBeOfType<CatSettings>().And(cat =>
             {
                 cat.Legs.ShouldBe(4);
-                //cat.Name.ShouldBe("Kitty"); //<-- Should normally be correct, but instead name will be added to the remaining arguments (see below).
+                cat.Name.ShouldBe("Kitty");
             });
-            result.Context.Remaining.Parsed.Count.ShouldBe(1);
-            result.Context.ShouldHaveRemainingArgument("--name", values: new[] { "Kitty", });
+            result.Context.Remaining.Parsed.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -112,9 +111,12 @@ public sealed partial class CommandAppTests
             {
                 app.Run(new[]
                 {
-                    // The CommandTreeParser should be unable to determine which command line
-                    // arguments belong to the branch and which belong to the branch's
-                    // default command (once inserted).
+                    // The CommandTreeParser should error when parsing the following
+                    // command line arguments in strict mode because 'Name' is a property
+                    // on MammalSettings, which CatSettings inherits from, whilst the
+                    // 'animal' branch is restricted to AnimalSettings. A parse exception
+                    // should be thrown on the first pass, preventing the CommandExecutor
+                    // from inserting the default command into arguments and trying again.
                     "animal", "4", "--name", "Kitty",
                 });
             });

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
@@ -56,8 +56,6 @@ public sealed partial class CommandAppTests
             });
         }
 
-        [SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1515:SingleLineCommentMustBePrecededByBlankLine", Justification = "Helps to illustrate the expected behaviour of this unit test.")]
-        [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1005:SingleLineCommentsMustBeginWithSingleSpace", Justification = "Helps to illustrate the expected behaviour of this unit test.")]
         [Fact]
         public void Should_Parse_Default_Command_Arguments_Relaxed_Parsing()
         {

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
@@ -76,17 +76,21 @@ public sealed partial class CommandAppTests
                 // The CommandTreeParser should determine which command line
                 // arguments belong to the branch and which belong to the branch's
                 // default command (once inserted).
-                "animal", "4", "--name", "Kitty",
+                "animal", "4", "-a", "false", "--name", "Kitty", "--agility", "four", "--nick-name", "Felix"
             });
 
             // Then
             result.ExitCode.ShouldBe(0);
             result.Settings.ShouldBeOfType<CatSettings>().And(cat =>
             {
+                cat.IsAlive.ShouldBeFalse();
                 cat.Legs.ShouldBe(4);
                 cat.Name.ShouldBe("Kitty");
+                cat.Agility.ShouldBe(4);
             });
-            result.Context.Remaining.Parsed.Count.ShouldBe(0);
+            result.Context.Remaining.Parsed.Count.ShouldBe(1);
+            result.Context.ShouldHaveRemainingArgument("--nick-name", values: new[] { "Felix" });
+            result.Context.Remaining.Raw.Count.ShouldBe(0);
         }
 
         [Fact]
@@ -110,17 +114,21 @@ public sealed partial class CommandAppTests
                 // The CommandTreeParser should determine which command line
                 // arguments belong to the branch and which belong to the branch's
                 // default command (once inserted).
-                "animal", "4", "--name", "Kitty",
+                "animal", "4", "-a", "false", "--name", "Kitty", "--agility", "four", "--", "--nick-name", "Felix"
             });
 
             // Then
             result.ExitCode.ShouldBe(0);
             result.Settings.ShouldBeOfType<CatSettings>().And(cat =>
             {
+                cat.IsAlive.ShouldBeFalse();
                 cat.Legs.ShouldBe(4);
                 cat.Name.ShouldBe("Kitty");
+                cat.Agility.ShouldBe(4);
             });
-            result.Context.Remaining.Parsed.Count.ShouldBe(0);
+            result.Context.Remaining.Parsed.Count.ShouldBe(1);
+            result.Context.ShouldHaveRemainingArgument("--nick-name", values: new[] { "Felix" });
+            result.Context.Remaining.Raw.Count.ShouldBe(2);
         }
 
         [Fact]

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
@@ -4,6 +4,129 @@ public sealed partial class CommandAppTests
 {
     public sealed class Remaining
     {
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Default_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.SetDefaultCommand<EmptyCommand>();
+
+            // When
+            var result = app.Run("--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.AddCommand<EmptyCommand>("empty");
+            });
+
+            // When
+            var result = app.Run("empty", "--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Branch_Default_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.AddBranch<EmptyCommandSettings>("branch", branch =>
+                {
+                    branch.SetDefaultCommand<EmptyCommand>();
+                });
+            });
+
+            // When
+            var result = app.Run("branch", "--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Branch_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.AddBranch<EmptyCommandSettings>("branch", branch =>
+                {
+                    branch.AddCommand<EmptyCommand>("hello");
+                });
+            });
+
+            // When
+            var result = app.Run("branch", "hello", "--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Branch_Branch_Default_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.AddBranch<EmptyCommandSettings>("branch", branch =>
+                {
+                    branch.AddBranch<EmptyCommandSettings>("hello", hello =>
+                    {
+                        hello.SetDefaultCommand<EmptyCommand>();
+                    });
+                });
+            });
+
+            // When
+            var result = app.Run("branch", "hello", "--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Branch_Branch_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.AddBranch<EmptyCommandSettings>("branch", branch =>
+                {
+                    branch.AddBranch<EmptyCommandSettings>("hello", hello =>
+                    {
+                        hello.AddCommand<EmptyCommand>("world");
+                    });
+                });
+            });
+
+            // When
+            var result = app.Run("branch", "hello", "world", "--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
         [Theory]
         [InlineData("-a")]
         [InlineData("--alive")]

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
@@ -382,14 +382,14 @@ public sealed partial class CommandAppTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void Should_Convert_Flags_To_Remaining_Arguments_If_Cannot_Be_Assigned(bool useStrictParsing)
+        public void Should_Convert_Flags_To_Remaining_Arguments_If_Cannot_Be_Assigned(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
                 config.Settings.ConvertFlagsToRemainingArguments = true;
-                config.Settings.StrictParsing = useStrictParsing;
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddCommand<DogCommand>("dog");
             });

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.Help.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.Help.cs
@@ -1,0 +1,242 @@
+namespace Spectre.Console.Tests.Unit.Cli;
+
+public sealed partial class CommandAppTests
+{
+    public sealed partial class Version
+    {
+        public sealed class Help
+        {
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Application_Version_Flag_With_No_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                });
+
+                // When
+                var result = fixture.Run(helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Not_Include_Application_Version_Flag_If_Not_Specified(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.AddCommand<EmptyCommand>("empty");
+                });
+
+                // When
+                var result = fixture.Run(helpOption);
+
+                // Then
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Not_Include_Application_Version_Flag_For_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddCommand<EmptyCommand>("empty");
+                });
+
+                // When
+                var result = fixture.Run("empty", helpOption);
+
+                // Then
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Application_Version_Flag_For_Default_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.SetDefaultCommand<EmptyCommand>();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                });
+
+                // When
+                var result = fixture.Run(helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Not_Include_Application_Version_Flag_For_Branch_Default_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddBranch<EmptyCommandSettings>("branch", branch =>
+                    {
+                        branch.SetDefaultCommand<EmptyCommand>();
+                    });
+                });
+
+                // When
+                var result = fixture.Run("branch", helpOption);
+
+                // Then
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Not_Include_Application_Version_Flag_For_Branch_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddBranch<EmptyCommandSettings>("branch", branch =>
+                    {
+                        branch.AddCommand<EmptyCommand>("hello");
+                    });
+                });
+
+                // When
+                var result = fixture.Run("branch", "hello", helpOption);
+
+                // Then
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Command_Version_Flag_For_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddCommand<Spectre.Console.Tests.Data.VersionCommand>("empty");
+                });
+
+                // When
+                var result = fixture.Run("empty", helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    The command version");
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            /// <summary>
+            /// When a command with a version flag in the settings is set as the application default command,
+            /// then override the in-built Application Version flag with the command version flag instead.
+            /// Rationale: This behaviour makes the most sense because the other flags for the default command
+            /// will be shown in the help output and the user can set any of these when executing the application.
+            /// </summary>
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Command_Version_Flag_For_Default_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.SetDefaultCommand<Spectre.Console.Tests.Data.VersionCommand>();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                });
+
+                // When
+                var result = fixture.Run(helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    The command version");
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Command_Version_Flag_For_Branch_Default_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddBranch<VersionSettings>("branch", branch =>
+                    {
+                        branch.SetDefaultCommand<Spectre.Console.Tests.Data.VersionCommand>();
+                    });
+                });
+
+                // When
+                var result = fixture.Run("branch", helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    The command version");
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Command_Version_Flag_For_Branch_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddBranch<VersionSettings>("branch", branch =>
+                    {
+                        branch.AddCommand<Spectre.Console.Tests.Data.VersionCommand>("hello");
+                    });
+                });
+
+                // When
+                var result = fixture.Run("branch", "hello", helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    The command version");
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+
+        }
+    }
+}

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.Help.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.Help.cs
@@ -34,34 +34,9 @@ public sealed partial class CommandAppTests
             {
                 // Given
                 var fixture = new CommandAppTester();
-                fixture.Configure(configurator =>
-                {
-                    configurator.AddCommand<EmptyCommand>("empty");
-                });
 
                 // When
                 var result = fixture.Run(helpOption);
-
-                // Then
-                result.Output.ShouldNotContain("-v, --version    Prints version information");
-            }
-
-            [Theory]
-            [InlineData("-?")]
-            [InlineData("-h")]
-            [InlineData("--help")]
-            public void Help_Should_Not_Include_Application_Version_Flag_For_Command(string helpOption)
-            {
-                // Given
-                var fixture = new CommandAppTester();
-                fixture.Configure(configurator =>
-                {
-                    configurator.SetApplicationVersion("1.0");
-                    configurator.AddCommand<EmptyCommand>("empty");
-                });
-
-                // When
-                var result = fixture.Run("empty", helpOption);
 
                 // Then
                 result.Output.ShouldNotContain("-v, --version    Prints version information");
@@ -86,6 +61,27 @@ public sealed partial class CommandAppTests
 
                 // Then
                 result.Output.ShouldContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Not_Include_Application_Version_Flag_For_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddCommand<EmptyCommand>("empty");
+                });
+
+                // When
+                var result = fixture.Run("empty", helpOption);
+
+                // Then
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
             }
 
             [Theory]
@@ -125,36 +121,14 @@ public sealed partial class CommandAppTests
                     configurator.SetApplicationVersion("1.0");
                     configurator.AddBranch<EmptyCommandSettings>("branch", branch =>
                     {
-                        branch.AddCommand<EmptyCommand>("hello");
+                        branch.AddCommand<EmptyCommand>("empty");
                     });
                 });
 
                 // When
-                var result = fixture.Run("branch", "hello", helpOption);
+                var result = fixture.Run("branch", "empty", helpOption);
 
                 // Then
-                result.Output.ShouldNotContain("-v, --version    Prints version information");
-            }
-
-            [Theory]
-            [InlineData("-?")]
-            [InlineData("-h")]
-            [InlineData("--help")]
-            public void Help_Should_Include_Command_Version_Flag_For_Command(string helpOption)
-            {
-                // Given
-                var fixture = new CommandAppTester();
-                fixture.Configure(configurator =>
-                {
-                    configurator.SetApplicationVersion("1.0");
-                    configurator.AddCommand<Spectre.Console.Tests.Data.VersionCommand>("empty");
-                });
-
-                // When
-                var result = fixture.Run("empty", helpOption);
-
-                // Then
-                result.Output.ShouldContain("-v, --version    The command version");
                 result.Output.ShouldNotContain("-v, --version    Prints version information");
             }
 
@@ -180,6 +154,28 @@ public sealed partial class CommandAppTests
 
                 // When
                 var result = fixture.Run(helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    The command version");
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Command_Version_Flag_For_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddCommand<Spectre.Console.Tests.Data.VersionCommand>("hello");
+                });
+
+                // When
+                var result = fixture.Run("hello", helpOption);
 
                 // Then
                 result.Output.ShouldContain("-v, --version    The command version");
@@ -235,8 +231,6 @@ public sealed partial class CommandAppTests
                 result.Output.ShouldContain("-v, --version    The command version");
                 result.Output.ShouldNotContain("-v, --version    Prints version information");
             }
-
-
         }
     }
 }

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
@@ -1,5 +1,3 @@
-using System.Runtime.InteropServices;
-
 namespace Spectre.Console.Tests.Unit.Cli;
 
 public sealed partial class CommandAppTests

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
@@ -2,7 +2,7 @@ namespace Spectre.Console.Tests.Unit.Cli;
 
 public sealed partial class CommandAppTests
 {
-    public sealed class Version
+    public sealed partial class Version
     {
         [Fact]
         public void Should_Output_CLI_Version_To_The_Console()

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
@@ -43,10 +43,6 @@ public sealed partial class CommandAppTests
         {
             // Given
             var fixture = new CommandAppTester();
-            fixture.Configure(configurator =>
-            {
-                configurator.AddCommand<EmptyCommand>("empty");
-            });
 
             // When
             var result = fixture.Run(versionOption);
@@ -54,6 +50,26 @@ public sealed partial class CommandAppTests
             // Then
             result.ExitCode.ShouldNotBe(0);
             result.Output.ShouldStartWith($"Error: Unexpected option '{versionOption.Replace("-", "")}'");
+        }
+
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Output_Application_Version_To_The_Console_With_Default_Command(string versionOption)
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.SetDefaultCommand<EmptyCommand>();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationVersion("1.0");
+            });
+
+            // When
+            var result = fixture.Run(versionOption);
+
+            // Then
+            result.Output.ShouldBe("1.0");
         }
 
         [Theory]
@@ -75,26 +91,6 @@ public sealed partial class CommandAppTests
             // Then
             result.Output.ShouldBe(string.Empty);
             result.Context.ShouldHaveRemainingArgument(versionOption, new[] { (string)null });
-        }
-
-        [Theory]
-        [InlineData("-v")]
-        [InlineData("--version")]
-        public void Should_Output_Application_Version_To_The_Console_With_Default_Command(string versionOption)
-        {
-            // Given
-            var fixture = new CommandAppTester();
-            fixture.SetDefaultCommand<EmptyCommand>();
-            fixture.Configure(configurator =>
-            {
-                configurator.SetApplicationVersion("1.0");
-            });
-
-            // When
-            var result = fixture.Run(versionOption);
-
-            // Then
-            result.Output.ShouldBe("1.0");
         }
 
         [Theory]
@@ -156,16 +152,106 @@ public sealed partial class CommandAppTests
                 configurator.SetApplicationVersion("1.0");
                 configurator.AddBranch<EmptyCommandSettings>("branch", branch =>
                 {
-                    branch.AddCommand<EmptyCommand>("hello");
+                    branch.AddCommand<EmptyCommand>("empty");
                 });
             });
 
             // When
-            var result = fixture.Run("branch", "hello", versionOption);
+            var result = fixture.Run("branch", "empty", versionOption);
 
             // Then
             result.Output.ShouldBe(string.Empty);
             result.Context.ShouldHaveRemainingArgument(versionOption, new[] { (string)null });
+        }
+
+        /// <summary>
+        /// When a command with a version flag in the settings is set as the application default command,
+        /// then execute this command instead of displaying the explicitly set Application Version.
+        /// </summary>
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Execute_Default_VersionCommand_Not_Output_Application_Version_To_The_Console(string versionOption)
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.SetDefaultCommand<Spectre.Console.Tests.Data.VersionCommand>();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationVersion("1.0");
+            });
+
+            // When
+            var result = fixture.Run(versionOption, "X.Y.Z");
+
+            // Then
+            result.Output.ShouldBe("VersionCommand ran, Version: X.Y.Z");
+        }
+
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Execute_VersionCommand_Not_Output_Application_Version_To_The_Console(string versionOption)
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationVersion("1.0");
+                configurator.AddCommand<Spectre.Console.Tests.Data.VersionCommand>("hello");
+            });
+
+            // When
+            var result = fixture.Run("hello", versionOption, "X.Y.Z");
+
+            // Then
+            result.Output.ShouldBe("VersionCommand ran, Version: X.Y.Z");
+        }
+
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Execute_Branch_Default_VersionCommand_Not_Output_Application_Version_To_The_Console(string versionOption)
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationVersion("1.0");
+                configurator.AddBranch<VersionSettings>("branch", branch =>
+                {
+                    branch.SetDefaultCommand<Spectre.Console.Tests.Data.VersionCommand>();
+                });
+            });
+
+            // When
+            var result = fixture.Run("branch", versionOption, "X.Y.Z");
+
+            // Then
+            result.Output.ShouldBe("VersionCommand ran, Version: X.Y.Z");
+        }
+
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Execute_Branch_VersionCommand_Not_Output_Application_Version_To_The_Console(string versionOption)
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationVersion("1.0");
+                configurator.AddBranch<VersionSettings>("branch", branch =>
+                {
+                    branch.AddCommand<Spectre.Console.Tests.Data.VersionCommand>("hello");
+                });
+            });
+
+            // When
+            var result = fixture.Run("branch", "hello", versionOption, "X.Y.Z");
+
+            // Then
+            result.Output.ShouldBe("VersionCommand ran, Version: X.Y.Z");
         }
     }
 }

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Spectre.Console.Tests.Unit.Cli;
 
 public sealed partial class CommandAppTests
@@ -17,8 +19,10 @@ public sealed partial class CommandAppTests
             result.Output.ShouldStartWith("Spectre.Cli version ");
         }
 
-        [Fact]
-        public void Should_Output_Application_Version_To_The_Console_With_No_Command()
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Output_Application_Version_To_The_Console_With_No_Command(string versionOption)
         {
             // Given
             var fixture = new CommandAppTester();
@@ -28,14 +32,16 @@ public sealed partial class CommandAppTests
             });
 
             // When
-            var result = fixture.Run("--version");
+            var result = fixture.Run(versionOption);
 
             // Then
             result.Output.ShouldBe("1.0");
         }
 
-        [Fact]
-        public void Should_Not_Display_Version_If_Not_Specified()
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Not_Display_Version_If_Not_Specified(string versionOption)
         {
             // Given
             var fixture = new CommandAppTester();
@@ -45,15 +51,17 @@ public sealed partial class CommandAppTests
             });
 
             // When
-            var result = fixture.Run("--version");
+            var result = fixture.Run(versionOption);
 
             // Then
             result.ExitCode.ShouldNotBe(0);
-            result.Output.ShouldStartWith("Error: Unexpected option 'version'");
+            result.Output.ShouldStartWith($"Error: Unexpected option '{versionOption.Replace("-", "")}'");
         }
 
-        [Fact]
-        public void Should_Execute_Command_Not_Output_Application_Version_To_The_Console()
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Execute_Command_Not_Output_Application_Version_To_The_Console(string versionOption)
         {
             // Given
             var fixture = new CommandAppTester();
@@ -64,15 +72,17 @@ public sealed partial class CommandAppTests
             });
 
             // When
-            var result = fixture.Run("empty", "--version");
+            var result = fixture.Run("empty", versionOption);
 
             // Then
             result.Output.ShouldBe(string.Empty);
-            result.Context.ShouldHaveRemainingArgument("--version", new[] { (string)null });
+            result.Context.ShouldHaveRemainingArgument(versionOption, new[] { (string)null });
         }
 
-        [Fact]
-        public void Should_Execute_Default_Command_Not_Output_Application_Version_To_The_Console()
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Output_Application_Version_To_The_Console_With_Default_Command(string versionOption)
         {
             // Given
             var fixture = new CommandAppTester();
@@ -83,15 +93,16 @@ public sealed partial class CommandAppTests
             });
 
             // When
-            var result = fixture.Run("--version");
+            var result = fixture.Run(versionOption);
 
             // Then
-            result.Output.ShouldBe(string.Empty);
-            result.Context.ShouldHaveRemainingArgument("--version", new[] { (string)null });
+            result.Output.ShouldBe("1.0");
         }
 
-        [Fact]
-        public void Should_Output_Application_Version_To_The_Console_With_Branch_Default_Command()
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Output_Application_Version_To_The_Console_With_Branch_Default_Command(string versionOption)
         {
             // Given
             var fixture = new CommandAppTester();
@@ -105,10 +116,58 @@ public sealed partial class CommandAppTests
             });
 
             // When
-            var result = fixture.Run("--version");
+            var result = fixture.Run(versionOption);
 
             // Then
             result.Output.ShouldBe("1.0");
+        }
+
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Execute_Branch_Default_Command_Not_Output_Application_Version_To_The_Console(string versionOption)
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationVersion("1.0");
+                configurator.AddBranch<EmptyCommandSettings>("branch", branch =>
+                {
+                    branch.SetDefaultCommand<EmptyCommand>();
+                });
+            });
+
+            // When
+            var result = fixture.Run("branch", versionOption);
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument(versionOption, new[] { (string)null });
+        }
+
+        [Theory]
+        [InlineData("-v")]
+        [InlineData("--version")]
+        public void Should_Execute_Branch_Command_Not_Output_Application_Version_To_The_Console(string versionOption)
+        {
+            // Given
+            var fixture = new CommandAppTester();
+            fixture.Configure(configurator =>
+            {
+                configurator.SetApplicationVersion("1.0");
+                configurator.AddBranch<EmptyCommandSettings>("branch", branch =>
+                {
+                    branch.AddCommand<EmptyCommand>("hello");
+                });
+            });
+
+            // When
+            var result = fixture.Run("branch", "hello", versionOption);
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument(versionOption, new[] { (string)null });
         }
     }
 }


### PR DESCRIPTION
**DRAFT PR - do not review/merge**

---

Unit tests pushed to this PR cover changes required to address the following issues:

- #1607
- #1216
- #1567  (nb. **Expected behaviour:** --version MUST NOT be displayed by default as part of --help output for subcommands that do not have explicitly defined --version option.)
- #1479 (nb: **Expected behaviour:** The help text for the `hello` command should not erroneously include the `-v, --version` associated at the application root)

TBD - Issues I'd like to cover in the PR, but which I haven't yet authored/pushed unit tests for:

-