### PR TITLE
Bump Spectre.Verify.Extensions to strong-named version

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -11,7 +11,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
     <PackageVersion Include="Shouldly" Version="4.2.1"/>
-    <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.1"/>
+    <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.2-preview.0.1"/>
     <PackageVersion Include="Verify.Xunit" Version="26.2.0"/>
     <PackageVersion Include="xunit" Version="2.9.0"/>
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -5,7 +5,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\..\..\resources\spectre.snk</AssemblyOriginatorKeyFile>
-    <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove NoWarn now that Spectre.Verify.Extensions is strong-named

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

---
Please upvote :+1: this pull request if you are interested in it.