### PR TITLE
Cleanup the prompt tests

### DIFF
--- a/src/Tests/Spectre.Console.Tests/Unit/Prompts/MultiSelectionPromptTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Prompts/MultiSelectionPromptTests.cs
@@ -2,25 +2,6 @@ namespace Spectre.Console.Tests.Unit;
 
 public sealed class MultiSelectionPromptTests
 {
-    private class CustomItem
-    {
-        public int X { get; set; }
-        public int Y { get; set; }
-
-        public class Comparer : IEqualityComparer<CustomItem>
-        {
-            public bool Equals(CustomItem x, CustomItem y)
-            {
-                return x.X == y.X && x.Y == y.Y;
-            }
-
-            public int GetHashCode(CustomItem obj)
-            {
-                throw new NotSupportedException();
-            }
-        }
-    }
-
     [Fact]
     public void Should_Not_Mark_Item_As_Selected_By_Default()
     {
@@ -145,5 +126,24 @@ public sealed class MultiSelectionPromptTests
 
         // Then
         action.ShouldThrow<ArgumentOutOfRangeException>();
+    }
+}
+
+file sealed class CustomItem
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+
+    public class Comparer : IEqualityComparer<CustomItem>
+    {
+        public bool Equals(CustomItem x, CustomItem y)
+        {
+            return x.X == y.X && x.Y == y.Y;
+        }
+
+        public int GetHashCode(CustomItem obj)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -85,4 +85,45 @@ public sealed class SelectionPromptTests
         // Then
         console.Output.ShouldContain($"{ESC}[38;5;12m> Item {ESC}[0m{ESC}[1;38;5;12;48;5;11m1{ESC}[0m");
     }
+
+    [Fact]
+    public void Should_Search_In_Remapped_Result()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.EmitAnsiSequences();
+        console.Input.PushText("2");
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        var choices = new List<CustomSelectionItem>
+        {
+            new(33, "Item 1"),
+            new(34, "Item 2"),
+        };
+
+        var prompt = new SelectionPrompt<CustomSelectionItem>()
+            .Title("Select one")
+            .EnableSearch()
+            .UseConverter(o => o.Name)
+            .AddChoices(choices);
+
+        // When
+        var selection = prompt.Show(console);
+
+        // Then
+        selection.ShouldBe(choices[1]);
+    }
+}
+
+file sealed class CustomSelectionItem
+{
+    public int Value { get; }
+    public string Name { get; }
+
+    public CustomSelectionItem(int value, string name)
+    {
+        Value = value;
+        Name = name ?? throw new ArgumentNullException(nameof(name));
+    }
 }

--- a/src/Tests/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -410,45 +410,4 @@ public sealed class TextPromptTests
         // Then
         return Verifier.Verify(console.Output);
     }
-
-    [Fact]
-    public void Should_Search_In_Remapped_Result()
-    {
-        // Given
-        var console = new TestConsole();
-        console.Profile.Capabilities.Interactive = true;
-        console.EmitAnsiSequences();
-        console.Input.PushText("2");
-        console.Input.PushKey(ConsoleKey.Enter);
-
-        var choices = new List<CustomSelectionItem>
-        {
-            new(33, "Item 1"),
-            new(34, "Item 2"),
-        };
-
-        var prompt = new SelectionPrompt<CustomSelectionItem>()
-            .Title("Select one")
-            .EnableSearch()
-            .UseConverter(o => o.Name)
-            .AddChoices(choices);
-
-        // When
-        var selection = prompt.Show(console);
-
-        // Then
-        selection.ShouldBe(choices[1]);
-    }
-}
-
-file sealed class CustomSelectionItem
-{
-    public int Value { get; }
-    public string Name { get; }
-
-    public CustomSelectionItem(int value, string name)
-    {
-        Value = value;
-        Name = name ?? throw new ArgumentNullException(nameof(name));
-    }
 }


### PR DESCRIPTION
* Move `Should_Search_In_Remapped_Result` into the `SelectionPromptTests` class where it belongs
* Use `file sealed class` for `CustomItem`, like it's done with `CustomSelectionItem` in the selection prompt tests