### PR TITLE
Improve exception if a (multi)selection prompt is used incorrectly

### DIFF
--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -42,6 +42,11 @@ internal sealed class ListPrompt<T>
         }
 
         var nodes = tree.Traverse().ToList();
+        if (nodes.Count == 0)
+        {
+            throw new InvalidOperationException("Cannot show an empty selection prompt. Please call the AddChoice() method to configure the prompt.");
+        }
+
         var state = new ListPromptState<T>(nodes, converter, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, selectionMode, skipUnselectableItems, searchEnabled);
         var hook = new ListPromptRenderHook<T>(_console, () => BuildRenderable(state));
 

--- a/src/Tests/Spectre.Console.Tests/Unit/Prompts/MultiSelectionPromptTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Prompts/MultiSelectionPromptTests.cs
@@ -127,6 +127,23 @@ public sealed class MultiSelectionPromptTests
         // Then
         action.ShouldThrow<ArgumentOutOfRangeException>();
     }
+
+    [Fact] public void Should_Throw_Meaningful_Exception_For_Empty_Prompt()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Spacebar);
+
+        var prompt = new MultiSelectionPrompt<string>();
+
+        // When
+        Action action = () => prompt.Show(console);
+
+        // Then
+        var exception = action.ShouldThrow<InvalidOperationException>();
+        exception.Message.ShouldBe("Cannot show an empty selection prompt. Please call the AddChoice() method to configure the prompt.");
+    }
 }
 
 file sealed class CustomItem

--- a/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -114,6 +114,22 @@ public sealed class SelectionPromptTests
         // Then
         selection.ShouldBe(choices[1]);
     }
+
+    [Fact] public void Should_Throw_Meaningful_Exception_For_Empty_Prompt()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+
+        var prompt = new SelectionPrompt<string>();
+
+        // When
+        Action action = () => prompt.Show(console);
+
+        // Then
+        var exception = action.ShouldThrow<InvalidOperationException>();
+        exception.Message.ShouldBe("Cannot show an empty selection prompt. Please call the AddChoice() method to configure the prompt.");
+    }
 }
 
 file sealed class CustomSelectionItem


### PR DESCRIPTION
Before this commit, the selection prompt would throw an `InvalidOperationException` (Sequence contains no elements) and the multi selection prompt would throw an `ArgumentOutOfRangeException` (Index was out of range. Must be non-negative and less than the size of the collection.)

Both would occur because the prompts were never meant to be empty.

Maybe we should change the `SelectionPrompt` and `MultiSelectionPrompt` constructors to always require at least one item so that this situation could never occur? But that would be a breaking change and should be discussed in a separate issue. This one is not breaking and just provides a more understandable error message.

---
Please upvote :+1: this pull request if you are interested in it.