### PR TITLE
Fix strange sentence in docs

### DIFF
--- a/docs/input/prompts/text.md
+++ b/docs/input/prompts/text.md
@@ -154,7 +154,7 @@ var password = AnsiConsole.Prompt(
         .Secret());
 
 // Echo the password back to the terminal
-Console.WriteLine($"Joking is not a secret that your password is {password}");
+Console.WriteLine($"Your password is {password}");
 ```
 
 ## Masks
@@ -183,7 +183,7 @@ var password = AnsiConsole.Prompt(
         .Secret('-'));
 
 // Echo the password back to the terminal
-Console.WriteLine($"Joking is not a secret that your password is {password}");
+Console.WriteLine($"Your password is {password}");
 ```
 
 ## Optional


### PR DESCRIPTION
<!-- formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [X] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

Fixes strange sentence in docs.