### PR TITLE
Add SearchHighlightStyle method to SelectionPromptExtensions

### DIFF
--- a/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
@@ -257,6 +257,25 @@ public static class SelectionPromptExtensions
     }
 
     /// <summary>
+    /// Sets the highlight style of the search results.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="style">The highlight style of the selected choice.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static SelectionPrompt<T> SearchHighlightStyle<T>(this SelectionPrompt<T> obj, Style style)
+        where T : notnull
+    {
+        if (obj is null)
+        {
+            throw new ArgumentNullException(nameof(obj));
+        }
+
+        obj.SearchHighlightStyle = style;
+        return obj;
+    }
+
+    /// <summary>
     /// Sets the text that will be displayed if there are more choices to show.
     /// </summary>
     /// <typeparam name="T">The prompt result type.</typeparam>


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [ ] All newly added code is adequately covered by tests
- [ ] All existing tests are still running without errors
- [ ] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

<!-- describe the changes you made. -->

I added the extension method for defining `SearchHighlightStyle` same as we have for `HighlightStyle`.

This allows us to specify `SearchHighlightStyle` using a fluent style like this:
```c#
AnsiConsole.Prompt(
  new SelectionPrompt<CustomSelectionItem>()
    .Title("Select one")
    .EnableSearch()
    .UseConverter(o => o.Name)
    .HighlightStyle(Color.Green)
    .SearchHighlightStyle(Color.DarkGreen) //<--
    .AddChoices(choices));
```

---
Please upvote :+1: this pull request if you are interested in it.