### PR TITLE
Add parsed unknown flag to remaining arguments for a branch with a default command

### DIFF
--- a/src/Spectre.Console.Cli/CommandParseException.cs
+++ b/src/Spectre.Console.Cli/CommandParseException.cs
@@ -113,4 +113,9 @@ public sealed class CommandParseException : CommandRuntimeException
         var text = $"[red]Error:[/] The value '[white]{value}[/]' is not in a correct format";
         return new CommandParseException("Could not parse value", new Markup(text));
     }
+
+    internal static CommandParseException UnknownParsingError()
+    {
+        return new CommandParseException("An unknown error occured when parsing the arguments.");
+    }
 }

--- a/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
@@ -1,3 +1,5 @@
+using static Spectre.Console.Cli.CommandTreeTokenizer;
+
 namespace Spectre.Console.Cli;
 
 internal sealed class CommandExecutor
@@ -101,7 +103,89 @@ internal sealed class CommandExecutor
         }
     }
 
+    [SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1513:Closing brace should be followed by blank line", Justification = "Improves code readability by grouping together related statements into a block")]
     private CommandTreeParserResult ParseCommandLineArguments(CommandModel model, CommandAppSettings settings, IReadOnlyList<string> args)
+    {
+        CommandTreeParserResult? parsedResult = null;
+        CommandTreeTokenizerResult tokenizerResult;
+
+        try
+        {
+            (parsedResult, tokenizerResult) = InternalParseCommandLineArguments(model, settings, args);
+
+            var lastParsedLeaf = parsedResult.Tree?.GetLeafCommand();
+            var lastParsedCommand = lastParsedLeaf?.Command;
+
+            if (lastParsedLeaf != null && lastParsedCommand != null &&
+            lastParsedCommand.IsBranch && !lastParsedLeaf.ShowHelp &&
+            lastParsedCommand.DefaultCommand != null)
+            {
+                // Adjust for any parsed remaining arguments by
+                // inserting the the default command ahead of them.
+                var position = tokenizerResult.Tokens.Position;
+                foreach (var parsedRemaining in parsedResult.Remaining.Parsed)
+                {
+                    position--;
+                    position -= parsedRemaining.Count(value => value != null);
+                }
+                position = position < 0 ? 0 : position;
+
+                // Insert this branch's default command into the command line
+                // arguments and try again to see if it will parse.
+                var argsWithDefaultCommand = new List<string>(args);
+                argsWithDefaultCommand.Insert(position, lastParsedCommand.DefaultCommand.Name);
+
+                (parsedResult, tokenizerResult) = InternalParseCommandLineArguments(model, settings, argsWithDefaultCommand);
+            }
+        }
+        catch (CommandParseException) when (parsedResult == null && settings.ParsingMode == ParsingMode.Strict)
+        {
+            // The parsing exception might be resolved by adding in the default command,
+            // but we can't know for sure. Take a brute force approach and try this for
+            // every position between the arguments.
+            for (int i = 0; i < args.Count; i++)
+            {
+                var argsWithDefaultCommand = new List<string>(args);
+                argsWithDefaultCommand.Insert(args.Count - i, "__default_command");
+
+                try
+                {
+                    (parsedResult, tokenizerResult) = InternalParseCommandLineArguments(model, settings, argsWithDefaultCommand);
+
+                    break;
+                }
+                catch (CommandParseException)
+                {
+                    // Continue.
+                }
+            }
+
+            if (parsedResult == null)
+            {
+                // Failed to parse having inserted the default command between each argument.
+                // Repeat the parsing of the original arguments to throw the correct exception.
+                InternalParseCommandLineArguments(model, settings, args);
+            }
+        }
+
+        if (parsedResult == null)
+        {
+            // The arguments failed to parse despite everything we tried above.
+            // Exceptions should be thrown above before ever getting this far,
+            // however the following is the ulimately backstop and avoids
+            // the compiler from complaining about returning null.
+            throw CommandParseException.UnknownParsingError();
+        }
+
+        return parsedResult;
+    }
+
+    /// <summary>
+    /// Parse the command line arguments using the specified <see cref="CommandModel"/> and <see cref="CommandAppSettings"/>,
+    /// returning the parser and tokenizer results.
+    /// </summary>
+    /// <returns>The parser and tokenizer results as a tuple.</returns>
+    private (CommandTreeParserResult ParserResult, CommandTreeTokenizerResult TokenizerResult) InternalParseCommandLineArguments(CommandModel model, CommandAppSettings settings, IReadOnlyList<string> args)
     {
         var parser = new CommandTreeParser(model, settings.CaseSensitivity, settings.ParsingMode, settings.ConvertFlagsToRemainingArguments);
 
@@ -109,24 +193,7 @@ internal sealed class CommandExecutor
         var tokenizerResult = CommandTreeTokenizer.Tokenize(args);
         var parsedResult = parser.Parse(parserContext, tokenizerResult);
 
-        var lastParsedLeaf = parsedResult.Tree?.GetLeafCommand();
-        var lastParsedCommand = lastParsedLeaf?.Command;
-        if (lastParsedLeaf != null && lastParsedCommand != null &&
-            lastParsedCommand.IsBranch && !lastParsedLeaf.ShowHelp &&
-            lastParsedCommand.DefaultCommand != null)
-        {
-            // Insert this branch's default command into the command line
-            // arguments and try again to see if it will parse.
-            var argsWithDefaultCommand = new List<string>(args);
-
-            argsWithDefaultCommand.Insert(tokenizerResult.Tokens.Position, lastParsedCommand.DefaultCommand.Name);
-
-            parserContext = new CommandTreeParserContext(argsWithDefaultCommand, settings.ParsingMode);
-            tokenizerResult = CommandTreeTokenizer.Tokenize(argsWithDefaultCommand);
-            parsedResult = parser.Parse(parserContext, tokenizerResult);
-        }
-
-        return parsedResult;
+        return (parsedResult, tokenizerResult);
     }
 
     private static async Task<int> Execute(

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Branches.cs
@@ -4,13 +4,16 @@ public sealed partial class CommandAppTests
 {
     public sealed class Branches
     {
-        [Fact]
-        public void Should_Run_The_Default_Command_On_Branch()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Run_The_Default_Command_On_Branch(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -29,13 +32,16 @@ public sealed partial class CommandAppTests
             result.Settings.ShouldBeOfType<CatSettings>();
         }
 
-        [Fact]
-        public void Should_Throw_When_No_Default_Command_On_Branch()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Throw_When_No_Default_Command_On_Branch(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal => { });
             });
@@ -126,13 +132,16 @@ public sealed partial class CommandAppTests
             });
         }
 
-        [Fact]
-        public void Should_Run_The_Default_Command_On_Branch_On_Branch()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Run_The_Default_Command_On_Branch_On_Branch(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -154,13 +163,16 @@ public sealed partial class CommandAppTests
             result.Settings.ShouldBeOfType<CatSettings>();
         }
 
-        [Fact]
-        public void Should_Run_The_Default_Command_On_Branch_On_Branch_With_Arguments()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Run_The_Default_Command_On_Branch_On_Branch_With_Arguments(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -186,13 +198,16 @@ public sealed partial class CommandAppTests
             });
         }
 
-        [Fact]
-        public void Should_Run_The_Default_Command_Not_The_Named_Command_On_Branch()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Run_The_Default_Command_Not_The_Named_Command_On_Branch(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -213,13 +228,16 @@ public sealed partial class CommandAppTests
             result.Settings.ShouldBeOfType<CatSettings>();
         }
 
-        [Fact]
-        public void Should_Run_The_Named_Command_Not_The_Default_Command_On_Branch()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Run_The_Named_Command_Not_The_Default_Command_On_Branch(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -246,13 +264,16 @@ public sealed partial class CommandAppTests
             });
         }
 
-        [Fact]
-        public void Should_Allow_Multiple_Branches_Multiple_Commands()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Allow_Multiple_Branches_Multiple_Commands(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -282,13 +303,16 @@ public sealed partial class CommandAppTests
             });
         }
 
-        [Fact]
-        public void Should_Allow_Single_Branch_Multiple_Commands()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Allow_Single_Branch_Multiple_Commands(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {
@@ -315,13 +339,16 @@ public sealed partial class CommandAppTests
             });
         }
 
-        [Fact]
-        public void Should_Allow_Single_Branch_Single_Command()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Should_Allow_Single_Branch_Single_Command(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddBranch<AnimalSettings>("animal", animal =>
                 {

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
@@ -4,6 +4,129 @@ public sealed partial class CommandAppTests
 {
     public sealed class Remaining
     {
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Default_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.SetDefaultCommand<EmptyCommand>();
+
+            // When
+            var result = app.Run("--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.AddCommand<EmptyCommand>("empty");
+            });
+
+            // When
+            var result = app.Run("empty", "--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Branch_Default_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.AddBranch<EmptyCommandSettings>("branch", branch =>
+                {
+                    branch.SetDefaultCommand<EmptyCommand>();
+                });
+            });
+
+            // When
+            var result = app.Run("branch", "--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Branch_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.AddBranch<EmptyCommandSettings>("branch", branch =>
+                {
+                    branch.AddCommand<EmptyCommand>("hello");
+                });
+            });
+
+            // When
+            var result = app.Run("branch", "hello", "--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Branch_Branch_Default_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.AddBranch<EmptyCommandSettings>("branch", branch =>
+                {
+                    branch.AddBranch<EmptyCommandSettings>("hello", hello =>
+                    {
+                        hello.SetDefaultCommand<EmptyCommand>();
+                    });
+                });
+            });
+
+            // When
+            var result = app.Run("branch", "hello", "--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
+        [Fact]
+        public void Should_Add_Unknown_Flags_To_Remaining_Arguments_Branch_Branch_Command()
+        {
+            // Given
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.AddBranch<EmptyCommandSettings>("branch", branch =>
+                {
+                    branch.AddBranch<EmptyCommandSettings>("hello", hello =>
+                    {
+                        hello.AddCommand<EmptyCommand>("world");
+                    });
+                });
+            });
+
+            // When
+            var result = app.Run("branch", "hello", "world", "--felix");
+
+            // Then
+            result.Output.ShouldBe(string.Empty);
+            result.Context.ShouldHaveRemainingArgument("--felix", new[] { (string)null });
+        }
+
         [Theory]
         [InlineData("-a")]
         [InlineData("--alive")]

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Remaining.cs
@@ -382,14 +382,14 @@ public sealed partial class CommandAppTests
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void Should_Convert_Flags_To_Remaining_Arguments_If_Cannot_Be_Assigned(bool useStrictParsing)
+        public void Should_Convert_Flags_To_Remaining_Arguments_If_Cannot_Be_Assigned(bool strictParsing)
         {
             // Given
             var app = new CommandAppTester();
             app.Configure(config =>
             {
                 config.Settings.ConvertFlagsToRemainingArguments = true;
-                config.Settings.StrictParsing = useStrictParsing;
+                config.Settings.StrictParsing = strictParsing;
                 config.PropagateExceptions();
                 config.AddCommand<DogCommand>("dog");
             });


### PR DESCRIPTION
**This PR is part of a series of CLI bug fixes/enhancements intended to be released prior to Spectre.Console V1.0**

They should be individually reviewed and merged (and then the open ones rebased) in the following order, given they have been successively branched from each other (Rationale: earlier changes, particularly to CommandExecutor, are relied upon later). Separate PRs should aid the reviewer.

1. https://github.com/spectreconsole/spectre.console/pull/1660 _**(this one)**_
2. https://github.com/spectreconsole/spectre.console/pull/1663
3. https://github.com/spectreconsole/spectre.console/pull/1664

---

fixes #1607

<!-- formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

- New unit tests to ensure unknown flags are added to remaining args
- Add strict parsing to almost all branches tests (an obvious omission from a prior PR)
- Fixed tests with incorrect validation that were in the main branch
- Significant improvement to the command line parsing to implement the above

---
Please upvote :+1: this pull request if you are interested in it.