### PR TITLE
Help output correctly decides when to show the version option

### DIFF
--- a/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
+++ b/src/Spectre.Console.Cli/Internal/CommandExecutor.cs
@@ -36,8 +36,8 @@ internal sealed class CommandExecutor
         if (firstArgument != null)
         {
             // Asking for version?
-            if (firstArgument.Equals("--version", StringComparison.OrdinalIgnoreCase) ||
-                firstArgument.Equals("-v", StringComparison.OrdinalIgnoreCase))
+            if (firstArgument.Equals("-v", StringComparison.OrdinalIgnoreCase) ||
+                firstArgument.Equals("--version", StringComparison.OrdinalIgnoreCase))
             {
                 if (configuration.Settings.ApplicationVersion != null)
                 {

--- a/src/Tests/Spectre.Console.Cli.Tests/Data/Settings/VersionSettings.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Data/Settings/VersionSettings.cs
@@ -3,5 +3,6 @@ namespace Spectre.Console.Tests.Data;
 public sealed class VersionSettings : CommandSettings
 {
     [CommandOption("-v|--version")]
+    [Description("The command version")]
     public string Version { get; set; }
 }

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.Help.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.Help.cs
@@ -1,0 +1,242 @@
+namespace Spectre.Console.Tests.Unit.Cli;
+
+public sealed partial class CommandAppTests
+{
+    public sealed partial class Version
+    {
+        public sealed class Help
+        {
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Application_Version_Flag_With_No_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                });
+
+                // When
+                var result = fixture.Run(helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Not_Include_Application_Version_Flag_If_Not_Specified(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.AddCommand<EmptyCommand>("empty");
+                });
+
+                // When
+                var result = fixture.Run(helpOption);
+
+                // Then
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Not_Include_Application_Version_Flag_For_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddCommand<EmptyCommand>("empty");
+                });
+
+                // When
+                var result = fixture.Run("empty", helpOption);
+
+                // Then
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Application_Version_Flag_For_Default_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.SetDefaultCommand<EmptyCommand>();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                });
+
+                // When
+                var result = fixture.Run(helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Not_Include_Application_Version_Flag_For_Branch_Default_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddBranch<EmptyCommandSettings>("branch", branch =>
+                    {
+                        branch.SetDefaultCommand<EmptyCommand>();
+                    });
+                });
+
+                // When
+                var result = fixture.Run("branch", helpOption);
+
+                // Then
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Not_Include_Application_Version_Flag_For_Branch_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddBranch<EmptyCommandSettings>("branch", branch =>
+                    {
+                        branch.AddCommand<EmptyCommand>("hello");
+                    });
+                });
+
+                // When
+                var result = fixture.Run("branch", "hello", helpOption);
+
+                // Then
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Command_Version_Flag_For_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddCommand<Spectre.Console.Tests.Data.VersionCommand>("empty");
+                });
+
+                // When
+                var result = fixture.Run("empty", helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    The command version");
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            /// <summary>
+            /// When a command with a version flag in the settings is set as the application default command,
+            /// then override the in-built Application Version flag with the command version flag instead.
+            /// Rationale: This behaviour makes the most sense because the other flags for the default command
+            /// will be shown in the help output and the user can set any of these when executing the application.
+            /// </summary>
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Command_Version_Flag_For_Default_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.SetDefaultCommand<Spectre.Console.Tests.Data.VersionCommand>();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                });
+
+                // When
+                var result = fixture.Run(helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    The command version");
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Command_Version_Flag_For_Branch_Default_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddBranch<VersionSettings>("branch", branch =>
+                    {
+                        branch.SetDefaultCommand<Spectre.Console.Tests.Data.VersionCommand>();
+                    });
+                });
+
+                // When
+                var result = fixture.Run("branch", helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    The command version");
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Command_Version_Flag_For_Branch_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddBranch<VersionSettings>("branch", branch =>
+                    {
+                        branch.AddCommand<Spectre.Console.Tests.Data.VersionCommand>("hello");
+                    });
+                });
+
+                // When
+                var result = fixture.Run("branch", "hello", helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    The command version");
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+
+        }
+    }
+}

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.Help.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.Help.cs
@@ -34,34 +34,9 @@ public sealed partial class CommandAppTests
             {
                 // Given
                 var fixture = new CommandAppTester();
-                fixture.Configure(configurator =>
-                {
-                    configurator.AddCommand<EmptyCommand>("empty");
-                });
 
                 // When
                 var result = fixture.Run(helpOption);
-
-                // Then
-                result.Output.ShouldNotContain("-v, --version    Prints version information");
-            }
-
-            [Theory]
-            [InlineData("-?")]
-            [InlineData("-h")]
-            [InlineData("--help")]
-            public void Help_Should_Not_Include_Application_Version_Flag_For_Command(string helpOption)
-            {
-                // Given
-                var fixture = new CommandAppTester();
-                fixture.Configure(configurator =>
-                {
-                    configurator.SetApplicationVersion("1.0");
-                    configurator.AddCommand<EmptyCommand>("empty");
-                });
-
-                // When
-                var result = fixture.Run("empty", helpOption);
 
                 // Then
                 result.Output.ShouldNotContain("-v, --version    Prints version information");
@@ -86,6 +61,27 @@ public sealed partial class CommandAppTests
 
                 // Then
                 result.Output.ShouldContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Not_Include_Application_Version_Flag_For_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddCommand<EmptyCommand>("empty");
+                });
+
+                // When
+                var result = fixture.Run("empty", helpOption);
+
+                // Then
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
             }
 
             [Theory]
@@ -125,36 +121,14 @@ public sealed partial class CommandAppTests
                     configurator.SetApplicationVersion("1.0");
                     configurator.AddBranch<EmptyCommandSettings>("branch", branch =>
                     {
-                        branch.AddCommand<EmptyCommand>("hello");
+                        branch.AddCommand<EmptyCommand>("empty");
                     });
                 });
 
                 // When
-                var result = fixture.Run("branch", "hello", helpOption);
+                var result = fixture.Run("branch", "empty", helpOption);
 
                 // Then
-                result.Output.ShouldNotContain("-v, --version    Prints version information");
-            }
-
-            [Theory]
-            [InlineData("-?")]
-            [InlineData("-h")]
-            [InlineData("--help")]
-            public void Help_Should_Include_Command_Version_Flag_For_Command(string helpOption)
-            {
-                // Given
-                var fixture = new CommandAppTester();
-                fixture.Configure(configurator =>
-                {
-                    configurator.SetApplicationVersion("1.0");
-                    configurator.AddCommand<Spectre.Console.Tests.Data.VersionCommand>("empty");
-                });
-
-                // When
-                var result = fixture.Run("empty", helpOption);
-
-                // Then
-                result.Output.ShouldContain("-v, --version    The command version");
                 result.Output.ShouldNotContain("-v, --version    Prints version information");
             }
 
@@ -180,6 +154,28 @@ public sealed partial class CommandAppTests
 
                 // When
                 var result = fixture.Run(helpOption);
+
+                // Then
+                result.Output.ShouldContain("-v, --version    The command version");
+                result.Output.ShouldNotContain("-v, --version    Prints version information");
+            }
+
+            [Theory]
+            [InlineData("-?")]
+            [InlineData("-h")]
+            [InlineData("--help")]
+            public void Help_Should_Include_Command_Version_Flag_For_Command(string helpOption)
+            {
+                // Given
+                var fixture = new CommandAppTester();
+                fixture.Configure(configurator =>
+                {
+                    configurator.SetApplicationVersion("1.0");
+                    configurator.AddCommand<Spectre.Console.Tests.Data.VersionCommand>("hello");
+                });
+
+                // When
+                var result = fixture.Run("hello", helpOption);
 
                 // Then
                 result.Output.ShouldContain("-v, --version    The command version");
@@ -235,8 +231,6 @@ public sealed partial class CommandAppTests
                 result.Output.ShouldContain("-v, --version    The command version");
                 result.Output.ShouldNotContain("-v, --version    Prints version information");
             }
-
-
         }
     }
 }

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Version.cs
@@ -2,7 +2,7 @@ namespace Spectre.Console.Tests.Unit.Cli;
 
 public sealed partial class CommandAppTests
 {
-    public sealed class Version
+    public sealed partial class Version
     {
         [Theory]
         [InlineData(false)]


### PR DESCRIPTION
**This PR is part of a series of CLI bug fixes/enhancements intended to be released prior to Spectre.Console V1.0**

They should be individually reviewed and merged (and then the open ones rebased) in the following order, given they have been successively branched from each other (Rationale: earlier changes, particularly to CommandExecutor, are relied upon later). Separate PRs should aid the reviewer.

1. https://github.com/spectreconsole/spectre.console/pull/1660
2. https://github.com/spectreconsole/spectre.console/pull/1663
3. https://github.com/spectreconsole/spectre.console/pull/1664 _**(this one)**_

---

fixes #1567, #1479

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

---

## Changes

Version information applies to the entire CLI application.
Whether to show the "-v|--version" option in the help is determined as per:
```
- If an application version has been set, and
-- When at the root of the application, or
-- When at the root of the application with a default command, unless
--- The default command has a version option in its settings
```

---
Please upvote :+1: this pull request if you are interested in it.