### PR TITLE
Fixed docs examples URLs redirecting to the examples repository

### DIFF
--- a/docs/input/cli/command-help.md
+++ b/docs/input/cli/command-help.md
@@ -71,5 +71,5 @@ public static class Program
 }
 ```
 
-There is a working [example of a custom help provider](https://github.com/spectreconsole/spectre.console/tree/main/examples/Cli/Help) demonstrating this.
+There is a working [example of a custom help provider](https://github.com/spectreconsole/examples/tree/main/examples/Cli/Help) demonstrating this.
 

--- a/docs/input/cli/commandApp.md
+++ b/docs/input/cli/commandApp.md
@@ -75,7 +75,7 @@ var app = new CommandApp<DefaultCommand>(registrar);
 return app.Run(args);
 ```
 
-`TypeRegistrar` is a custom class that must be created by the user. This [example using `Microsoft.Extensions.DependencyInjection` as the container](https://github.com/spectreconsole/spectre.console/tree/main/examples/Cli/Injection) provides an example `TypeRegistrar` and `TypeResolver` that can be added to your application with small adjustments for your DI container.
+`TypeRegistrar` is a custom class that must be created by the user. This [example using `Microsoft.Extensions.DependencyInjection` as the container](https://github.com/spectreconsole/examples/tree/main/examples/Cli/Injection) provides an example `TypeRegistrar` and `TypeResolver` that can be added to your application with small adjustments for your DI container.
 
 Hint: If you do write your own implementation of `TypeRegistrar` and `TypeResolver` and you have some form of unit tests in place for your project,
 there is a utility `TypeRegistrarBaseTests` available that can be used to ensure your implementations adhere to the required implementation. Simply call `TypeRegistrarBaseTests.RunAllTests()` and expect no `TypeRegistrarBaseTests.TestFailedException` to be thrown.
@@ -89,4 +89,4 @@ This provides an opportunity to modify the result and also to tear down any infr
 
 The `Intercept`-Method of each interceptor is run before the command is executed and the `InterceptResult`-Method is run after it. These are typically used for configuring logging or other infrastructure concerns.
 
-For an example of using the interceptor to configure logging, see the [Serilog demo](https://github.com/spectreconsole/spectre.console/tree/main/examples/Cli/Logging).
+For an example of using the interceptor to configure logging, see the [Serilog demo](https://github.com/spectreconsole/examples/tree/main/examples/Cli/Logging).


### PR DESCRIPTION
resolves #1667

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
<!--- [ ] A maintainer has signed off on the changes and the issue was assigned to me -->
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

As per #1667 - the docs examples URLs currently lead to a Github HTTP 404 as they refer to a directory named `examples/` which I suppose recently had been moved to the examples repository and it bothered me every time I go to the docs, so I just had to do this PR.

---
Please upvote :+1: this pull request if you are interested in it.