### PR TITLE
This fixes issue #1472 to stop ElapsedTimeRemaining from updating

### DIFF
--- a/src/Spectre.Console/Live/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Live/Progress/ProgressTask.cs
@@ -201,6 +201,7 @@ public sealed class ProgressTask : IProgress<double>
             if (_value > _maxValue)
             {
                 _value = _maxValue;
+                StopTime ??= DateTime.Now;
             }
 
             var timestamp = DateTime.Now;


### PR DESCRIPTION
This fixes issue #1472. I read the issue and thought it should not be too hard and perfrect for a first PR. It turns out it is caused due to StopTime not being set when the maxValue is reached. I simply added one line to fix this which fixed the issue.


- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [ ] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] No documentation changes are required.

## Changes

The issue occurs due to StopTime not being set when the MaxValue is readed. The Isfinished bool checks both StopTime and Value > MaxValue, but since the ElapsedTime simple checks whether StopTime is set, and that is never set except when StopTask is called this keeps on counting. By adding the assignment to StopTime in the Update method when _value > _maxValue this fixes the issue.

P.S. I did not comment on the issue since it is not a behaviour change but simply a bugfix.

---
Please upvote :+1: this pull request if you are interested in it.