### PR TITLE
Add `net9.0` support, remove legacy TFM:s

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
 
       - name: Build
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,9 +32,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            6.0.x
-            7.0.x
             8.0.x
+            9.0.x
 
       - name: Publish
         shell: bash

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,15 +3,9 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "commands": [
         "dotnet-cake"
-      ]
-    },
-    "dotnet-example": {
-      "version": "3.1.0",
-      "commands": [
-        "dotnet-example"
       ]
     },
     "verify.tool": {

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/global",
   "sdk": {
-    "version": "8.0.401",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -2,29 +2,25 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup Label="Dependencies">
-    <PackageVersion Include="MinVer" PrivateAssets="All" Version="6.0.0"/>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="8.0.0"/>
-    <PackageVersion Include="Wcwidth.Sources" Version="2.0.0"/>
-    <PackageVersion Include="IsExternalInit" Version="1.0.3"/>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0"/>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1"/>
-    <PackageVersion Include="Shouldly" Version="4.2.1"/>
-    <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.2-preview.0.1"/>
-    <PackageVersion Include="Verify.Xunit" Version="26.4.5"/>
-    <PackageVersion Include="xunit" Version="2.9.0"/>
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
-    <PackageVersion Include="System.Memory" Version="4.5.5" />
+    <PackageVersion Include="MinVer" PrivateAssets="All" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" Version="8.0.0" />
+    <PackageVersion Include="Wcwidth.Sources" Version="2.0.0" />
+    <PackageVersion Include="IsExternalInit" Version="1.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.2-preview.0.1" />
+    <PackageVersion Include="Verify.Xunit" Version="28.2.1" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.5" />
-
-    <PackageVersion Include="Nullable" Version="1.3.1"/>
+    <PackageVersion Include="Nullable" Version="1.3.1" />
     <PackageVersion Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" />
   </ItemGroup>
-
   <ItemGroup Label="Static Analysis">
-    <PackageVersion Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.2.0-beta.556"/>
-    <PackageVersion Include="Roslynator.Analyzers" PrivateAssets="All" Version="4.12.5"/>
+    <PackageVersion Include="StyleCop.Analyzers" PrivateAssets="All" Version="1.2.0-beta.556" />
+    <PackageVersion Include="Roslynator.Analyzers" PrivateAssets="All" Version="4.12.9" />
   </ItemGroup>
-
 </Project>

--- a/src/Extensions/Spectre.Console.ImageSharp/Spectre.Console.ImageSharp.csproj
+++ b/src/Extensions/Spectre.Console.ImageSharp/Spectre.Console.ImageSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Description>A library that extends Spectre.Console with ImageSharp superpowers.</Description>
   </PropertyGroup>

--- a/src/Extensions/Spectre.Console.Json/Spectre.Console.Json.csproj
+++ b/src/Extensions/Spectre.Console.Json/Spectre.Console.Json.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks> 
+    <TargetFrameworks>net9.0;net8.0;netstandard2.0</TargetFrameworks> 
     <ImplicitUsings>true</ImplicitUsings>
     <IsPackable>true</IsPackable>
     <Description>A library that extends Spectre.Console with JSON superpowers.</Description>

--- a/src/Spectre.Console.Cli/Spectre.Console.Cli.csproj
+++ b/src/Spectre.Console.Cli/Spectre.Console.Cli.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Spectre.Console.Testing/Spectre.Console.Testing.csproj
+++ b/src/Spectre.Console.Testing/Spectre.Console.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;netstandard2.0</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <IsPackable>true</IsPackable>
     <Description>Contains testing utilities for Spectre.Console.</Description>

--- a/src/Spectre.Console/Spectre.Console.csproj
+++ b/src/Spectre.Console/Spectre.Console.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;netstandard2.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <DefineConstants>$(DefineConstants)TRACE;WCWIDTH_VISIBILITY_INTERNAL</DefineConstants>
   </PropertyGroup>

--- a/src/Tests/Spectre.Console.Cli.Tests/Spectre.Console.Cli.Tests.csproj
+++ b/src/Tests/Spectre.Console.Cli.Tests/Spectre.Console.Cli.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Spectre.Console.Tests/Spectre.Console.Tests.csproj
+++ b/src/Tests/Spectre.Console.Tests/Spectre.Console.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #1680, #1681

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have commented on the issue above and discussed the intended changes
- [X] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.