### PR TITLE
Fix typos xml docs

### DIFF
--- a/src/Spectre.Console.Cli/CommandContext.cs
+++ b/src/Spectre.Console.Cli/CommandContext.cs
@@ -14,7 +14,7 @@ public sealed class CommandContext
     public IRemainingArguments Remaining { get; }
 
     /// <summary>
-    /// Gets all the arguments that were passed to the applicaton.
+    /// Gets all the arguments that were passed to the application.
     /// </summary>
     public IReadOnlyList<string> Arguments { get; }
 

--- a/src/Spectre.Console.Cli/ICommandAppSettings.cs
+++ b/src/Spectre.Console.Cli/ICommandAppSettings.cs
@@ -74,7 +74,7 @@ public interface ICommandAppSettings
     bool StrictParsing { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether or not flags found on the commnd line
+    /// Gets or sets a value indicating whether or not flags found on the command line
     /// that would normally result in a <see cref="CommandParseException"/> being thrown
     /// during parsing with the message "Flags cannot be assigned a value."
     /// should instead be added to the remaining arguments collection.


### PR DESCRIPTION
This PR addresses to minor typos in Spectre Console Cli XML Docs.