### PR TITLE
Changes Emoji dictionary to OrdinalIgnoreCase for performance

### DIFF
--- a/resources/scripts/Generator/Templates/Emoji.Generated.template
+++ b/resources/scripts/Generator/Templates/Emoji.Generated.template
@@ -18,7 +18,7 @@ namespace Spectre.Console
     public static partial class Emoji
     {
         private static readonly Dictionary<string, string> _emojis
-            = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
+            = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             {{~ for emoji in emojis ~}}
             { "{{ emoji.identifier }}", Emoji.Known.{{ emoji.name }} },

--- a/src/Spectre.Console/Emoji.Generated.cs
+++ b/src/Spectre.Console/Emoji.Generated.cs
@@ -18,7 +18,7 @@ namespace Spectre.Console
     public static partial class Emoji
     {
         private static readonly Dictionary<string, string> _emojis
-            = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
+            = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             { "abacus", Emoji.Known.Abacus },
             { "ab_button_blood_type", Emoji.Known.AbButtonBloodType },


### PR DESCRIPTION
While working on the AOT stuff I was also profiling some code and ran across this taking up a huge chunk of the time spent initializing the app. Switching to OrdinalIgnoreCase actually gave a 100% boost in my TTFRE (time to first rocketship emoji) benchmark.


![before](https://github.com/user-attachments/assets/006958ed-444c-43c5-b9d9-7f37c935300e)

![before-profiler](https://github.com/user-attachments/assets/b40cb074-2508-40e3-9233-6700bb564e08)

![after-profiler](https://github.com/user-attachments/assets/d6679430-c61f-4e4d-8902-28b9df20f493)

![after](https://github.com/user-attachments/assets/6d1bfea3-d40c-488c-a443-d42df46eb880)


And fwiw, this puts Spectre.Console a few MS off of regular Console.WriteLine...
![image](https://github.com/user-attachments/assets/e92f3d27-eb60-4e64-82e4-10343dcf9d13)
