### PR TITLE
ProgressTask.GetPercentage() returns 100 when max value is 0

### DIFF
--- a/src/Spectre.Console/Live/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Live/Progress/ProgressTask.cs
@@ -224,6 +224,11 @@ public sealed class ProgressTask : IProgress<double>
 
     private double GetPercentage()
     {
+        if (MaxValue == 0)
+        {
+            return 100;
+        }
+
         var percentage = (Value / MaxValue) * 100;
         percentage = Math.Min(100, Math.Max(0, percentage));
         return percentage;

--- a/src/Tests/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
@@ -119,6 +119,31 @@ public sealed class ProgressTests
     }
 
     [Fact]
+    public void Setting_Max_Value_To_Zero_Should_Make_Percentage_OneHundred()
+    {
+        // Given
+        var console = new TestConsole()
+            .Interactive();
+
+        var task = default(ProgressTask);
+        var progress = new Progress(console)
+            .Columns(new[] { new ProgressBarColumn() })
+            .AutoRefresh(false)
+            .AutoClear(false);
+
+        // When
+        progress.Start(ctx =>
+        {
+            task = ctx.AddTask("foo");
+            task.MaxValue = 0;
+        });
+
+        // Then
+        task.Value.ShouldBe(0);
+        task.Percentage.ShouldBe(100);
+    }
+
+    [Fact]
     public void Setting_Value_Should_Override_Incremented_Value()
     {
         // Given


### PR DESCRIPTION
fixes #981

<!-- formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

ProgressTask.GetPercentage() returns 100 when max value is 0.

---
Please upvote :+1: this pull request if you are interested in it.