### PR TITLE
Update documentation packages to latest versions

### DIFF
--- a/docs/Docs.csproj
+++ b/docs/Docs.csproj
@@ -33,13 +33,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Playwright" Version="1.19.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Statiq.CodeAnalysis" Version="1.0.0-beta.58" />
-    <PackageReference Include="Statiq.Common" Version="1.0.0-beta.58" />
-    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.44" />
-    <PackageReference Include="MinVer" PrivateAssets="All" Version="2.5.0" />
-    <PackageReference Include="Statiq.Web.Netlify" Version="1.0.0-beta.44" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.49.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Statiq.CodeAnalysis" Version="1.0.0-beta.72" />
+    <PackageReference Include="Statiq.Common" Version="1.0.0-beta.72" />
+    <PackageReference Include="Statiq.Web" Version="1.0.0-beta.60" />
+    <PackageReference Include="MinVer" PrivateAssets="All" Version="6.0.0" />
+    <PackageReference Include="Statiq.Web.Netlify" Version="1.0.0-beta.60" />
   </ItemGroup>
 
   <ItemGroup>

--- a/docs/Program.cs
+++ b/docs/Program.cs
@@ -23,8 +23,8 @@ namespace Docs
                 {
                     "../../src/Spectre.Console/**/{!bin,!obj,!packages,!*.Tests,}/**/*.cs",
                     "../../src/Spectre.Console.Cli/**/{!bin,!obj,!packages,!*.Tests,}/**/*.cs",
-                    "../../src/Spectre.Console.ImageSharp/**/{!bin,!obj,!packages,!*.Tests,}/**/*.cs",
-                    "../../src/Spectre.Console.Json/**/{!bin,!obj,!packages,!*.Tests,}/**/*.cs"
+                    "../../src/Extensions/Spectre.Console.ImageSharp/**/{!bin,!obj,!packages,!*.Tests,}/**/*.cs",
+                    "../../src/Extensions/Spectre.Console.Json/**/{!bin,!obj,!packages,!*.Tests,}/**/*.cs"
                 })
                 .AddSetting(Constants.ExampleSourceFiles, new List<string>
                     {

--- a/docs/input/appendix/spinners.md
+++ b/docs/input/appendix/spinners.md
@@ -10,7 +10,7 @@ For all available spinners, see https://jsfiddle.net/sindresorhus/2eLtsbey/embed
 
 ## Usage
 
-Spinners can be used with [Progress](xref:progress) and [Status](xref:status).
+Spinners can be used with [Progress](xref:live-progress) and [Status](xref:live-status).
 
 ```csharp
 AnsiConsole.Status()

--- a/docs/input/appendix/styles.md
+++ b/docs/input/appendix/styles.md
@@ -6,6 +6,7 @@ Highlights:
     - Dim, Invert
     - Conceal, slowblink, rapidblink
     - Links
+Xref: appendix-styles
 ---
 
 Note that what styles that can be used is defined by the system or your terminal software, and may not appear as they should.
@@ -48,7 +49,7 @@ Note that what styles that can be used is defined by the system or your terminal
         <td>Shows text with a horizontal line through the center</td>
     </tr>
     <tr>
-        <td><code>link</link></td>
+        <td><code>link</code></td>
         <td>Creates a clickable link within text</td>
     </tr>
 </table>

--- a/docs/input/blog/posts/2023-11-22-spectre-console-0.48-released.md
+++ b/docs/input/blog/posts/2023-11-22-spectre-console-0.48-released.md
@@ -26,9 +26,9 @@ New features have been added, such as the ability to show separators between tab
 ## Rendering
 
 * Add .NET 8 support by [@patriksvensson](https://github.com/patriksvensson) in [#1367](https://github.com/spectreconsole/spectre.console/pull/1367)
-* Fixed render issue where writeline inside status caused corrupt output #415 #694 by [@fredrikbentzen](https://github.com/fredrikbentzen) in [#1132]([#1132](https://github.com/spectreconsole/spectre.console/pull/1132))
-* Relax the SDK requirements by rolling forward to the latest feature by [@0xced](https://github.com/0xced) in [#1237]([#1237](https://github.com/spectreconsole/spectre.console/pull/1237))
-* Add fix to avoid exception on rows with no children by [@jeppevammenkristensen](https://github.com/jeppevammenkristensen) in [#1241]([#1241](https://github.com/spectreconsole/spectre.console/pull/1241))
+* Fixed render issue where writeline inside status caused corrupt output #415 #694 by [@fredrikbentzen](https://github.com/fredrikbentzen) in [#1132](https://github.com/spectreconsole/spectre.console/pull/1132))
+* Relax the SDK requirements by rolling forward to the latest feature by [@0xced](https://github.com/0xced) in [#1237](https://github.com/spectreconsole/spectre.console/pull/1237))
+* Add fix to avoid exception on rows with no children by [@jeppevammenkristensen](https://github.com/jeppevammenkristensen) in [#1241](https://github.com/spectreconsole/spectre.console/pull/1241))
 * Set `end_of_line` to `LF` instead of `CRLF` by [@0xced](https://github.com/0xced) in [#1256](https://github.com/spectreconsole/spectre.console/pull/1256)
 * Fix `Rule` widget docs by [@tomaszprasolek](https://github.com/tomaszprasolek) in [#1257](https://github.com/spectreconsole/spectre.console/pull/1257)
 * Added the missing columns-cast by [@nils](https://github.com/nils)-a in [#1294](https://github.com/spectreconsole/spectre.console/pull/1294)
@@ -46,7 +46,7 @@ New features have been added, such as the ability to show separators between tab
 
 ## CLI
 * Add async command unit tests by [@FrankRay78](https://github.com/FrankRay78) in [#1228](https://github.com/spectreconsole/spectre.console/pull/1228)
-* Add support for async delegate by [@icalvo](https://github.com/icalvo) in [#1215]([#1215](https://github.com/spectreconsole/spectre.console/pull/1215))
+* Add support for async delegate by [@icalvo](https://github.com/icalvo) in [#1215](https://github.com/spectreconsole/spectre.console/pull/1215))
 * Remove unnecessary `[NotNull]` attributes by [@0xced](https://github.com/0xced) in [#1255](https://github.com/spectreconsole/spectre.console/pull/1255)
 * Allow custom help providers by [@FrankRay78](https://github.com/FrankRay78) in [#1259](https://github.com/spectreconsole/spectre.console/pull/1259)
 * Specified details for settings for the argument vector by [@nils](https://github.com/nils)-a in [#1301](https://github.com/spectreconsole/spectre.console/pull/1301)

--- a/docs/input/cli/command-help.md
+++ b/docs/input/cli/command-help.md
@@ -41,7 +41,7 @@ Removing all styling from help text is also possible, a good choice for ensuring
 config.Settings.HelpProviderStyles = null;
 ```
 
-See [Markup](../markup) for information about the use of markup in Spectre.Console, and [Styles](xref:styles) for a listing of supported styles.
+See [Markup](../markup) for information about the use of markup in Spectre.Console, and [Styles](xref:appendix-styles) for a listing of supported styles.
 
 ## Custom help providers
 

--- a/docs/input/cli/composing.md
+++ b/docs/input/cli/composing.md
@@ -1,8 +1,8 @@
 Title: Composing Commands
 RedirectFrom: introduction
 Order: 8
-Description: "The underlying philosophy behind *Spectre.Console.Cli* is to rely on the .NET type system to
-declare the commands, but tie everything together via composition."
+Description: The underlying philosophy behind *Spectre.Console.Cli* is 
+             to rely on the .NET type system to declare the commands, but tie everything together via composition.
 ---
 
 The underlying philosophy behind `Spectre.Console.Cli` is to rely on the .NET type system to

--- a/docs/input/cli/introduction.md
+++ b/docs/input/cli/introduction.md
@@ -1,8 +1,8 @@
 Title: Introduction
 Order: 1
 Description: "*Spectre.Console.Cli* is a modern library for parsing command line arguments. While it's extremely
-opinionated in what it does, it tries to follow established industry conventions, and draws
-its inspiration from applications you use everyday."
+             opinionated in what it does, it tries to follow established industry conventions, and draws
+             its inspiration from applications you use everyday."
 ---
 
 `Spectre.Console.Cli` is a modern library for parsing command line arguments. While it's extremely

--- a/docs/input/live/progress.md
+++ b/docs/input/live/progress.md
@@ -9,6 +9,7 @@ Highlights:
 Reference: 
     - T:Spectre.Console.Progress
     - M:Spectre.Console.AnsiConsole.Progress
+Xref: live-progress
 ---
 
 Spectre.Console can display information about long running tasks in the console. 

--- a/docs/input/live/status.md
+++ b/docs/input/live/status.md
@@ -8,6 +8,7 @@ Highlights:
 Reference:
     - T:Spectre.Console.Status
     - M:Spectre.Console.AnsiConsole.Status
+Xref: live-status
 ---
 
 Spectre.Console can display information about long running tasks in the console. 

--- a/docs/src/SocialCards/index.cshtml
+++ b/docs/src/SocialCards/index.cshtml
@@ -15,7 +15,7 @@
 
   <div id="container">
     <div id="console">
-        <div class="line"><span style="color:var(--brightBlack)">╭─</span><span style="color:var(--folder)">&#xe0b2;</span><span style="background-color:var(--folder);color:var(--black)"> ~/spectre.console</span><span style="color:var(--folder);background-color:var(--dotnet)">&#xe0b0;</span><span style="background-color:var(--blue)"> .NET 8.0 </span><span style="color:var(--dotnet);background-color:var(--git)">&#xe0b0;</span><span style="background-color:var(--git);color:var(--background)"> &#xe0a0; main </span><span style="color:var(--git)">&#xe0b4;</span></div>
+        <div class="line"><span style="color:var(--brightBlack)">╭─</span><span style="color:var(--folder)">&#xe0b2;</span><span style="background-color:var(--folder);color:var(--black)"> ~/spectre.console</span><span style="color:var(--folder);background-color:var(--dotnet)">&#xe0b0;</span><span style="background-color:var(--blue)"> .NET 9.0 </span><span style="color:var(--dotnet);background-color:var(--git)">&#xe0b0;</span><span style="background-color:var(--git);color:var(--background)"> &#xe0a0; main </span><span style="color:var(--git)">&#xe0b4;</span></div>
         <div class="line"><span style="color:var(--brightBlack)">╰─</span> dotnet run</div>
         <div class="line"></div>
         <div class="line">╭────────────────────────────────────────────────────────╮</div>

--- a/docs/src/Utilities/HighlightService.cs
+++ b/docs/src/Utilities/HighlightService.cs
@@ -58,21 +58,31 @@ internal static class HighlightService
         }
 
         var text = await syntaxReference.SyntaxTree.GetTextAsync();
-        // we need a workspace, but it seems it is only used to resolve a few services and nothing else so an empty one will suffice
-        return HighlightElement(_emptyWorkspace, model, text, textSpan, indent);
+
+        // we need a document for the syntax highlighter, so create a temporary solution and project to hold it.
+        var workspace = new AdhocWorkspace();
+        var solution = workspace.CurrentSolution
+            .AddProject("TempProject", "TempProject", "C#")
+            .AddDocument("TempDocument", await syntaxReference.SyntaxTree.GetTextAsync());
+
+        var document = solution.Project.Documents.First();
+
+        var highlightElement = await HighlightElement(document, text, textSpan, indent);
+        return highlightElement;
     }
 
     private static int GetIndent(SyntaxTriviaList leadingTrivia)
     {
-        var whitespace = leadingTrivia.FirstOrDefault(i => i.Kind() == SyntaxKind.WhitespaceTrivia);
+        var whitespace = leadingTrivia.FirstOrDefault(i => i.IsKind(SyntaxKind.WhitespaceTrivia));
         return whitespace == default ? 0 : whitespace.Span.Length;
     }
 
-    private static string HighlightElement(Workspace workspace, SemanticModel semanticModel, SourceText fullSourceText,
+    private static async Task<string> HighlightElement(Document document,
+        SourceText fullSourceText,
         TextSpan textSpan, int indent)
     {
 
-        var classifiedSpans = Classifier.GetClassifiedSpans(semanticModel, textSpan, workspace);
+        var classifiedSpans = await Classifier.GetClassifiedSpansAsync(document, textSpan);
         return HighlightElement(classifiedSpans, fullSourceText, indent);
     }
 


### PR DESCRIPTION
* HighlightService was modified to support GetClassifiedSpansAsync method
* Updated Program.cs to pull in the proper location of the Json and ImageSharp extension projects
* Statiq must have changed how they are doing xrefs, so I adjusted those to be more specific with a few links

Hopefully once this is in, the RenovateBot will be appeased and stop chirping on every PR merge.