### PR TITLE
Update Docs SDK version to 9.0.100, disable NuGetAudit temporarily, a…

### DIFF
--- a/docs/Docs.csproj
+++ b/docs/Docs.csproj
@@ -7,6 +7,11 @@
     <DefaultItemExcludes>$(DefaultItemExcludes);output\**;.gitignore</DefaultItemExcludes>
     <NoWarn>MVC1000</NoWarn>
     <MinVerSkip>true</MinVerSkip>
+    <!-- 
+    Disable NuGetAudit for now, there is an in progress PR with Statiq regarding these packages,
+    but since since this is just a generator we are safe to ignore this for now.
+     -->
+    <NuGetAudit>false</NuGetAudit>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/dotnet-tools.json
+++ b/docs/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "microsoft.playwright.cli": {
-      "version": "1.2.2",
+      "version": "1.2.3",
       "commands": [
         "playwright"
       ]

--- a/docs/global.json
+++ b/docs/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/resources/scripts/Generator/Generator.csproj
+++ b/resources/scripts/Generator/Generator.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="AngleSharp" Version="1.1.2" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Scriban" Version="5.10.0" />
+    <PackageReference Include="Scriban" Version="5.12.0" />
     <PackageReference Include="Spectre.IO" Version="0.18.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Update Docs SDK version to 9.0.100, disable NuGetAudit temporarily, and upgrade Scriban to version 5.12.0 for generator

Statiq has some out of date packages that raise the NugetAudit alerts. The nature of the doc generator doesn't make the alerts a concern, but hopefully with a 1.0 release this setting can be removed. While I was in there, I also updated Scriban for the generator project.

Fingers cross this will hush the renovate bot about these projects and let it be more valuable for the end user facing projects.