### PR TITLE
Added useful search for larger ListPrompts

### DIFF
--- a/src/Spectre.Console/Prompts/List/ListPromptConstants.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptConstants.cs
@@ -7,6 +7,7 @@ internal sealed class ListPromptConstants
     public const string SelectedCheckbox = "[[[blue]X[/]]]";
     public const string GroupSelectedCheckbox = "[[[grey]X[/]]]";
     public const string InstructionsMarkup = "[grey](Press <space> to select, <enter> to accept)[/]";
+    public const string InstructionsSearchMarkup = "[grey](Press <ctrl + space> to select, <enter> to accept)[/]";
     public const string MoreChoicesMarkup = "[grey](Move up and down to reveal more choices)[/]";
     public const string SearchPlaceholderMarkup = "[grey](Type to search)[/]";
 

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -242,7 +242,15 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
             grid.AddEmptyRow();
         }
 
-        foreach (var item in items)
+        // Filter items based on search text
+        var filteredItems = items
+            .Where(item =>
+            {
+                var text = (Converter ?? TypeConverterHelper.ConvertToString)?.Invoke(item.Node.Data) ?? item.Node.Data.ToString() ?? "?";
+                return string.IsNullOrWhiteSpace(searchText) || text.Contains(searchText, StringComparison.OrdinalIgnoreCase);
+            });
+
+        foreach (var item in filteredItems)
         {
             var current = item.Index == cursorIndex;
             var style = current ? highlightStyle : Style.Plain;

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -171,7 +171,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
             return ListPromptInputResult.Submit;
         }
 
-        if (key.Key == ConsoleKey.Spacebar || key.Key == ConsoleKey.Packet)
+        if ((key.Key == ConsoleKey.Spacebar && key.Modifiers.HasFlag(ConsoleModifiers.Control)) || key.Key == ConsoleKey.Packet)
         {
             var current = state.Items[state.Index];
             var select = !current.IsSelected;
@@ -310,7 +310,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
         }
 
         // Instructions
-        list.Add(new Markup(InstructionsText ?? ListPromptConstants.InstructionsMarkup));
+        list.Add(new Markup(InstructionsText ?? (SearchEnabled ? ListPromptConstants.InstructionsSearchMarkup : ListPromptConstants.InstructionsMarkup)));
 
         // Combine all items
         return new Rows(list);

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -180,7 +180,15 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
             grid.AddEmptyRow();
         }
 
-        foreach (var item in items)
+         // Filter items based on search text
+        var filteredItems = items
+            .Where(item =>
+            {
+                var text = (Converter ?? TypeConverterHelper.ConvertToString)?.Invoke(item.Node.Data) ?? item.Node.Data.ToString() ?? "?";
+                return string.IsNullOrWhiteSpace(searchText) || text.Contains(searchText, StringComparison.OrdinalIgnoreCase);
+            });
+
+        foreach (var item in filteredItems)
         {
             var current = item.Index == cursorIndex;
             var prompt = item.Index == cursorIndex ? ListPromptConstants.Arrow : new string(' ', ListPromptConstants.Arrow.Length);


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #1702, #1665, #1546

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [ ] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [ ] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

- Enable search for MultiSelectionPrompt and use a modifier (ctrl) and space for selection.
- Add filtering to SelectionPrompt and MultiSelection based on the search text.

---
Please upvote :+1: this pull request if you are interested in it.