### PR TITLE
Feature/3digithexcodes

### DIFF
--- a/src/Spectre.Console/Color.cs
+++ b/src/Spectre.Console/Color.cs
@@ -230,6 +230,11 @@ public partial struct Color : IEquatable<Color>
             hex = hex.Substring(1);
         }
 
+        if (hex.Length == 3)
+        {
+            hex = string.Concat(hex.Select(c => new string(c, 2)));
+        }
+
         var r = byte.Parse(hex.Substring(0, 2), NumberStyles.HexNumber);
         var g = byte.Parse(hex.Substring(2, 2), NumberStyles.HexNumber);
         var b = byte.Parse(hex.Substring(4, 2), NumberStyles.HexNumber);

--- a/src/Spectre.Console/Color.cs
+++ b/src/Spectre.Console/Color.cs
@@ -230,6 +230,8 @@ public partial struct Color : IEquatable<Color>
             hex = hex.Substring(1);
         }
 
+        // 3 digit hex codes are expanded to 6 digits
+        // by doubling each digit, conform to CSS color codes
         if (hex.Length == 3)
         {
             hex = string.Concat(hex.Select(c => new string(c, 2)));

--- a/src/Tests/Spectre.Console.Tests/Unit/ColorTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/ColorTests.cs
@@ -68,6 +68,23 @@ public sealed class ColorTests
             color.ShouldBe(Color.Default);
         }
 
+        [Theory]
+        [InlineData("ffffff")]
+        [InlineData("#ffffff")]
+        [InlineData("fff")]
+        [InlineData("#fff")]
+        public void Should_Parse_3_Digit_Hex_Colors_From_Hex(string color)
+        {
+            // Given
+            var expected = new Color(255, 255, 255);
+
+            // When
+            var result = Color.FromHex(color);
+
+            // Then
+            result.ShouldBe(expected);
+        }
+
         [Fact]
         public void Should_Consider_Color_And_Non_Color_Equal()
         {


### PR DESCRIPTION
fixes #1686

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

I've added character doubling functionality to the ```fromHex``` method if the sanitized string contains exactly 3 characters.
I've also added some tests to confirm the resulting color matches the color when using the 6-digit representation.

I did not update any docs, as the docs of the original ```fromHex``` seems adequate to me.

---
Please upvote :+1: this pull request if you are interested in it.