### PR TITLE
Trimming of TestConsole output by CommandAppTester is user configurable.

### DIFF
--- a/src/Spectre.Console.Testing/Cli/CommandAppResult.cs
+++ b/src/Spectre.Console.Testing/Cli/CommandAppResult.cs
@@ -31,10 +31,5 @@ public sealed class CommandAppResult
         Output = output ?? string.Empty;
         Context = context;
         Settings = settings;
-
-        Output = Output
-            .NormalizeLineEndings()
-            .TrimLines()
-            .Trim();
     }
 }

--- a/src/Spectre.Console.Testing/Cli/CommandAppTester.cs
+++ b/src/Spectre.Console.Testing/Cli/CommandAppTester.cs
@@ -9,18 +9,34 @@ public sealed class CommandAppTester
     private Action<IConfigurator>? _configuration;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CommandAppTester"/> class.
-    /// </summary>
-    /// <param name="registrar">The registrar.</param>
-    public CommandAppTester(ITypeRegistrar? registrar = null)
-    {
-        Registrar = registrar;
-    }
-
-    /// <summary>
     /// Gets or sets the Registrar to use in the CommandApp.
     /// </summary>
     public ITypeRegistrar? Registrar { get; set; }
+
+    /// <summary>
+    /// Gets or sets the settings for the <see cref="CommandAppTester"/>.
+    /// </summary>
+    public CommandAppTesterSettings TestSettings { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandAppTester"/> class.
+    /// </summary>
+    /// <param name="registrar">The registrar.</param>
+    /// <param name="settings">The settings.</param>
+    public CommandAppTester(ITypeRegistrar? registrar = null, CommandAppTesterSettings? settings = null)
+    {
+        Registrar = registrar;
+        TestSettings = settings ?? new CommandAppTesterSettings();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CommandAppTester"/> class.
+    /// </summary>
+    /// <param name="settings">The settings.</param>
+    public CommandAppTester(CommandAppTesterSettings settings)
+    {
+        TestSettings = settings;
+    }
 
     /// <summary>
     /// Sets the default command.
@@ -135,10 +151,8 @@ public sealed class CommandAppTester
 
         var result = app.Run(args);
 
-        var output = console.Output
-            .NormalizeLineEndings()
-            .TrimLines()
-            .Trim();
+        var output = console.Output.NormalizeLineEndings();
+        output = TestSettings.TrimConsoleOutput ? output.TrimLines().Trim() : output;
 
         return new CommandAppResult(result, output, context, settings);
     }
@@ -181,10 +195,8 @@ public sealed class CommandAppTester
 
         var result = await app.RunAsync(args);
 
-        var output = console.Output
-            .NormalizeLineEndings()
-            .TrimLines()
-            .Trim();
+        var output = console.Output.NormalizeLineEndings();
+        output = TestSettings.TrimConsoleOutput ? output.TrimLines().Trim() : output;
 
         return new CommandAppResult(result, output, context, settings);
     }

--- a/src/Spectre.Console.Testing/Cli/CommandAppTesterSettings.cs
+++ b/src/Spectre.Console.Testing/Cli/CommandAppTesterSettings.cs
@@ -1,0 +1,15 @@
+namespace Spectre.Console.Testing;
+
+/// <summary>
+/// Represents the configuration settings for the <see cref="CommandAppTester"/> class.
+/// </summary>
+public sealed class CommandAppTesterSettings
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether whitespace should be trimmed from the console output.
+    /// </summary>
+    /// <remarks>
+    /// When enabled, leading and trailing whitespace from the console output and trailing whitespace from each line will be trimmed.
+    /// </remarks>
+    public bool TrimConsoleOutput { get; set; } = true;
+}

--- a/src/Tests/Spectre.Console.Cli.Tests/Data/Commands/AsynchronousCommand.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Data/Commands/AsynchronousCommand.cs
@@ -20,7 +20,7 @@ public sealed class AsynchronousCommand : AsyncCommand<AsynchronousCommandSettin
         }
         else
         {
-            _console.WriteLine($"Finished executing asynchronously");
+            _console.Write($"Finished executing asynchronously");
         }
 
         return 0;

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/Testing/CommandAppTesterTests.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/Testing/CommandAppTesterTests.cs
@@ -1,0 +1,47 @@
+
+using System;
+
+namespace Spectre.Console.Tests.Unit.Cli.Testing;
+
+public sealed class CommandAppTesterTests
+{
+    private class CommandAppTesterCommand : Command<OptionalArgumentWithDefaultValueSettings>
+    {
+        private readonly IAnsiConsole _console;
+
+        public CommandAppTesterCommand(IAnsiConsole console)
+        {
+            _console = console;
+        }
+
+        public override int Execute(CommandContext context, OptionalArgumentWithDefaultValueSettings settings)
+        {
+            _console.Write(settings.Greeting);
+            return 0;
+        }
+    }
+
+    [Theory]
+    [InlineData(false, " Hello ", " Hello ")]
+    [InlineData(true, " Hello ", "Hello")]
+    [InlineData(false, " Hello \n World ", " Hello \n World ")]
+    [InlineData(true, " Hello \n World ", "Hello\n World")]
+    public void Should_Respect_Trim_Setting(bool trim, string actual, string expected)
+    {
+        // Given
+        var settings = new CommandAppTesterSettings { TrimConsoleOutput = trim };
+
+        var app = new CommandAppTester(settings);
+        app.SetDefaultCommand<CommandAppTesterCommand>();
+        app.Configure(config =>
+        {
+            config.PropagateExceptions();
+        });
+
+        // When
+        var result = app.Run(actual);
+
+        // Then
+        result.Output.ShouldBe(expected);
+    }
+}


### PR DESCRIPTION
fixes #1738. CommandAppTester is trimming TestConsole output, requiring expected outputs to be manually adjusted

<!-- formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have commented on the issue above and discussed the intended changes
- [X] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

Trimming of TestConsole output by CommandAppTester is user configurable.

CommandAppTester now accepts a CommandAppTesterSettings class, containing the TrimConsoleOutput property.

TrimConsoleOutput defaults to true, preserving existing behaviour and ensuring the change is backward compatible.

---
Please upvote :+1: this pull request if you are interested in it.