### PR TITLE
Disable the GitHub 'Blank issue' option offered to users

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
<!-- formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors
- [X] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

Users are now being given the 'Blank issue' option when rasing a new issue, in addition to our customised Bug Request/Feature Request templates that collect the required information

This PR disables the GitHub 'Blank issue' option offered to users

---
Please upvote :+1: this pull request if you are interested in it.