### PR TITLE
Fix generic exception formatting

### DIFF
--- a/src/Spectre.Console/Widgets/Exceptions/TypeNameHelper.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/TypeNameHelper.cs
@@ -39,11 +39,12 @@ internal static class TypeNameHelper
     /// <param name="type">The <see cref="Type"/>.</param>
     /// <param name="fullName"><c>true</c> to print a fully qualified name.</param>
     /// <param name="includeGenericParameterNames"><c>true</c> to include generic parameter names.</param>
+    /// <param name="includeSystemNamespace"><c>true</c> to include the <c>System</c> namespace.</param>
     /// <returns>The pretty printed type name.</returns>
-    public static string GetTypeDisplayName(Type type, bool fullName = false, bool includeGenericParameterNames = true)
+    public static string GetTypeDisplayName(Type type, bool fullName = false, bool includeGenericParameterNames = true, bool includeSystemNamespace = false)
     {
         var builder = new StringBuilder();
-        ProcessType(builder, type, new DisplayNameOptions(fullName, includeGenericParameterNames));
+        ProcessType(builder, type, new DisplayNameOptions(fullName, includeGenericParameterNames, includeSystemNamespace));
         return builder.ToString();
     }
 
@@ -71,7 +72,7 @@ internal static class TypeNameHelper
         {
             builder.Append(builtInName);
         }
-        else if (type.Namespace == nameof(System))
+        else if (type.Namespace == nameof(System) && !options.IncludeSystemNamespace)
         {
             builder.Append(type.Name);
         }
@@ -181,14 +182,17 @@ internal static class TypeNameHelper
 
     private struct DisplayNameOptions
     {
-        public DisplayNameOptions(bool fullName, bool includeGenericParameterNames)
+        public DisplayNameOptions(bool fullName, bool includeGenericParameterNames, bool includeSystemNamespace)
         {
             FullName = fullName;
             IncludeGenericParameterNames = includeGenericParameterNames;
+            IncludeSystemNamespace = includeSystemNamespace;
         }
 
         public bool FullName { get; }
 
         public bool IncludeGenericParameterNames { get; }
+
+        public bool IncludeSystemNamespace { get; }
     }
 }

--- a/src/Tests/Spectre.Console.Tests/Data/Exceptions.cs
+++ b/src/Tests/Spectre.Console.Tests/Data/Exceptions.cs
@@ -6,6 +6,8 @@ public static class TestExceptions
 
     public static bool GenericMethodThatThrows<T0, T1, TRet>(int? number) => throw new InvalidOperationException("Throwing!");
 
+    public static bool MethodThatThrowsGenericException<T>() => throw new GenericException<T>("Throwing!", default);
+
     public static void ThrowWithInnerException()
     {
         try
@@ -42,3 +44,6 @@ public static class TestExceptions
         return ("key", new List<T>());
     }
 }
+
+#pragma warning disable CS9113 // Parameter is unread.
+public class GenericException<T>(string message, T value) : Exception(message);

--- a/src/Tests/Spectre.Console.Tests/Expectations/Exception/GenericException.Output_exceptionFormats=Default.verified.txt
+++ b/src/Tests/Spectre.Console.Tests/Expectations/Exception/GenericException.Output_exceptionFormats=Default.verified.txt
@@ -1,0 +1,4 @@
+﻿[38;5;7mSpectre.Console.Tests.Data.[0m[38;5;15mGenericException<Spectre.Console.IAnsiConsole>[0m: [1;38;5;9mThrowing![0m
+  [38;5;8mat[0m [38;5;12mbool[0m [38;5;7mSpectre.Console.Tests.Data.TestExceptions.[0m[38;5;11mMethodThatThrowsGenericException<T>[0m[38;5;7m()[0m [38;5;8min[0m [38;5;7m{ProjectDirectory}Data/[0m[1;38;5;11mExceptions.cs[0m[38;5;8m:[0m[38;5;12m9[0m
+  [38;5;8mat[0m [38;5;12mvoid[0m [38;5;7mSpectre.Console.Tests.Unit.ExceptionTests.<>c.[0m[38;5;11m<Should_Write_GenericException>b__8_0[0m[38;5;7m()[0m [38;5;8min[0m [38;5;7m{ProjectDirectory}Unit/[0m[1;38;5;11mExceptionTests.cs[0m[38;5;8m:[0m[38;5;12m134[0m
+  [38;5;8mat[0m [38;5;12mException[0m [38;5;7mSpectre.Console.Tests.Unit.ExceptionTests.[0m[38;5;11mGetException[0m[38;5;7m([0m[38;5;12mAction[0m [38;5;7maction)[0m [38;5;8min[0m [38;5;7m{ProjectDirectory}Unit/[0m[1;38;5;11mExceptionTests.cs[0m[38;5;8m:[0m[38;5;12m147[0m

--- a/src/Tests/Spectre.Console.Tests/Expectations/Exception/GenericException.Output_exceptionFormats=ShortenTypes.verified.txt
+++ b/src/Tests/Spectre.Console.Tests/Expectations/Exception/GenericException.Output_exceptionFormats=ShortenTypes.verified.txt
@@ -1,0 +1,4 @@
+﻿[38;5;15mGenericException<IAnsiConsole>[0m: [1;38;5;9mThrowing![0m
+  [38;5;8mat[0m [38;5;12mbool[0m [38;5;7mSpectre.Console.Tests.Data.TestExceptions.[0m[38;5;11mMethodThatThrowsGenericException<T>[0m[38;5;7m()[0m [38;5;8min[0m [38;5;7m{ProjectDirectory}Data/[0m[1;38;5;11mExceptions.cs[0m[38;5;8m:[0m[38;5;12m9[0m
+  [38;5;8mat[0m [38;5;12mvoid[0m [38;5;7mSpectre.Console.Tests.Unit.ExceptionTests.<>c.[0m[38;5;11m<Should_Write_GenericException>b__8_0[0m[38;5;7m()[0m [38;5;8min[0m [38;5;7m{ProjectDirectory}Unit/[0m[1;38;5;11mExceptionTests.cs[0m[38;5;8m:[0m[38;5;12m134[0m
+  [38;5;8mat[0m [38;5;12mException[0m [38;5;7mSpectre.Console.Tests.Unit.ExceptionTests.[0m[38;5;11mGetException[0m[38;5;7m([0m[38;5;12mAction[0m [38;5;7maction)[0m [38;5;8min[0m [38;5;7m{ProjectDirectory}Unit/[0m[1;38;5;11mExceptionTests.cs[0m[38;5;8m:[0m[38;5;12m147[0m

--- a/src/Tests/Spectre.Console.Tests/Unit/ExceptionTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/ExceptionTests.cs
@@ -123,6 +123,23 @@ public sealed class ExceptionTests
         return Verifier.Verify(result);
     }
 
+    [Theory]
+    [InlineData(ExceptionFormats.Default)]
+    [InlineData(ExceptionFormats.ShortenTypes)]
+    [Expectation("GenericException")]
+    public Task Should_Write_GenericException(ExceptionFormats exceptionFormats)
+    {
+        // Given
+        var console = new TestConsole { EmitAnsiSequences = true }.Width(1024);
+        var dex = GetException(() => TestExceptions.MethodThatThrowsGenericException<IAnsiConsole>());
+
+        // When
+        var result = console.WriteNormalizedException(dex, exceptionFormats);
+
+        // Then
+        return Verifier.Verify(result).UseParameters(exceptionFormats);
+    }
+
     public static Exception GetException(Action action)
     {
         try


### PR DESCRIPTION
Fixes #1754

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] No documentation changes are required

## Changes

Before this pull request, generic exceptions would be mangled.

```
0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a]]: Dummy fault reason
  at void <Main>$(string[] args) in Program.cs:7
```

<img width="1383" alt="Screenshot of the mangled exception" src="https://github.com/user-attachments/assets/9967423f-f63e-483c-94d7-48eba488f5a2" />

After this pull request, generic exceptions are displayed properly.

```
FaultException<DriveInfo>: Dummy fault reason
  at void <Main>$(string[] args) in Program.cs:7
```

<img width="1383" alt="Screenshot of the proper exception" src="https://github.com/user-attachments/assets/dd28f6f1-d7c0-4eb4-a749-0769b96c54e9" />

---
Please upvote :+1: this pull request if you are interested in it.