### PR TITLE
Updates to xUnit v3 and enables Microsoft.Testing.Platform

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,9 +12,9 @@
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="Spectre.Verify.Extensions" Version="22.3.2-preview.0.1" />
-    <PackageVersion Include="Verify.Xunit" Version="28.2.1" />
-    <PackageVersion Include="xunit" Version="2.9.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="Verify.XunitV3" Version="28.10.1" />
+    <PackageVersion Include="xunit.v3" Version="1.1.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" />
     <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="SixLabors.ImageSharp" Version="3.1.5" />
     <PackageVersion Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" />

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -5,6 +5,9 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\..\..\resources\spectre.snk</AssemblyOriginatorKeyFile>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tests/Spectre.Console.Cli.Tests/Spectre.Console.Cli.Tests.csproj
+++ b/src/Tests/Spectre.Console.Cli.Tests/Spectre.Console.Cli.Tests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
     <PackageReference Include="Shouldly"/>
     <PackageReference Include="Spectre.Verify.Extensions"/>
-    <PackageReference Include="Verify.Xunit"/>
-    <PackageReference Include="xunit"/>
+    <PackageReference Include="Verify.XunitV3"/>
+    <PackageReference Include="xunit.v3"/>
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/Spectre.Console.Tests/Spectre.Console.Tests.csproj
+++ b/src/Tests/Spectre.Console.Tests/Spectre.Console.Tests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="Spectre.Verify.Extensions" />
-    <PackageReference Include="Verify.Xunit" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="Verify.XunitV3" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Tests/Spectre.Console.Tests/Unit/AnsiConsoleTests.Prompt.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/AnsiConsoleTests.Prompt.cs
@@ -19,7 +19,7 @@ public partial class AnsiConsoleTests
             bool result;
             if (async)
             {
-                result = await console.ConfirmAsync("Want some prompt?", defaultValue);
+                result = await console.ConfirmAsync("Want some prompt?", defaultValue, cancellationToken: TestContext.Current.CancellationToken);
             }
             else
             {
@@ -46,7 +46,7 @@ public partial class AnsiConsoleTests
             DateTime dateTime;
             if (async)
             {
-                dateTime = await console.AskAsync<DateTime>(string.Empty, CultureInfo.GetCultureInfo("pl-PL"));
+                dateTime = await console.AskAsync<DateTime>(string.Empty, CultureInfo.GetCultureInfo("pl-PL"), cancellationToken: TestContext.Current.CancellationToken);
             }
             else
             {
@@ -70,7 +70,7 @@ public partial class AnsiConsoleTests
             DateTime dateTime;
             if (async)
             {
-                dateTime = await console.AskAsync<DateTime>(string.Empty, CultureInfo.GetCultureInfo("en-US"));
+                dateTime = await console.AskAsync<DateTime>(string.Empty, CultureInfo.GetCultureInfo("en-US"), cancellationToken: TestContext.Current.CancellationToken);
             }
             else
             {


### PR DESCRIPTION
Verify and Cake worked without a hitch. Very smooth upgrade process. Tests run too quick on my machine to see the fancy ANSI output for the runner, but it's there! 

One neat thing about a change like this is that if the AOT route is tackled, theoretically it makes it much easier to test as we can run the tests in a PublishAOT scenario with a bit of leg work...hopefully.

There was a code change was responding to warnings regarding using `TestContext.Current.CancellationToken` . See this for the reason - https://xunit.net/xunit.analyzers/rules/xUnit1051