### PR TITLE
Changed IConfigurator to return IConfigurator instead of void

### DIFF
--- a/src/Spectre.Console.Cli/IConfigurator.cs
+++ b/src/Spectre.Console.Cli/IConfigurator.cs
@@ -9,13 +9,15 @@ public interface IConfigurator
     /// Sets the help provider for the application.
     /// </summary>
     /// <param name="helpProvider">The help provider to use.</param>
-    public void SetHelpProvider(IHelpProvider helpProvider);
+    /// <returns>A configurator that can be used for further configuration.</returns>
+    public IConfigurator SetHelpProvider(IHelpProvider helpProvider);
 
     /// <summary>
     /// Sets the help provider for the application.
     /// </summary>
     /// <typeparam name="T">The type of the help provider to instantiate at runtime and use.</typeparam>
-    public void SetHelpProvider<T>()
+    /// <returns>A configurator that can be used for further configuration.</returns>
+    public IConfigurator SetHelpProvider<T>()
         where T : IHelpProvider;
 
     /// <summary>
@@ -27,7 +29,8 @@ public interface IConfigurator
     /// Adds an example of how to use the application.
     /// </summary>
     /// <param name="args">The example arguments.</param>
-    void AddExample(params string[] args);
+    /// <returns>A configurator that can be used for further configuration.</returns>
+    IConfigurator AddExample(params string[] args);
 
     /// <summary>
     /// Adds a command.

--- a/src/Spectre.Console.Cli/Internal/Configuration/Configurator.cs
+++ b/src/Spectre.Console.Cli/Internal/Configuration/Configurator.cs
@@ -20,22 +20,25 @@ internal sealed class Configurator : IUnsafeConfigurator, IConfigurator, IConfig
         Examples = new List<string[]>();
     }
 
-    public void SetHelpProvider(IHelpProvider helpProvider)
+    public IConfigurator SetHelpProvider(IHelpProvider helpProvider)
     {
         // Register the help provider
         _registrar.RegisterInstance(typeof(IHelpProvider), helpProvider);
+        return this;
     }
 
-    public void SetHelpProvider<T>()
+    public IConfigurator SetHelpProvider<T>()
         where T : IHelpProvider
     {
         // Register the help provider
         _registrar.Register(typeof(IHelpProvider), typeof(T));
+        return this;
     }
 
-    public void AddExample(params string[] args)
+    public IConfigurator AddExample(params string[] args)
     {
         Examples.Add(args);
+        return this;
     }
 
     public ConfiguredCommand SetDefaultCommand<TDefaultCommand>()

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.Help.cs
@@ -348,10 +348,10 @@ public sealed partial class CommandAppTests
             fixture.SetDefaultCommand<LionCommand>();
             fixture.Configure(configurator =>
             {
-                configurator.SetApplicationName("myapp");
-                configurator.AddExample("20", "--alive");
-                configurator.AddCommand<GiraffeCommand>("giraffe");
-                configurator.SetHelpProvider(new RenderMarkupHelpProvider(configurator.Settings));
+                configurator.SetApplicationName("myapp")
+                   .SetHelpProvider(new RenderMarkupHelpProvider(configurator.Settings))
+                   .AddExample("20", "--alive")
+                   .AddCommand<GiraffeCommand>("giraffe");
             });
 
             // When
@@ -539,10 +539,9 @@ public sealed partial class CommandAppTests
             fixture.Configure(configurator =>
             {
                 // Configure the custom help provider type
-                configurator.SetHelpProvider<RedirectHelpProvider>();
-
-                configurator.SetApplicationName("myapp");
-                configurator.AddCommand<DogCommand>("dog");
+                configurator.SetHelpProvider<RedirectHelpProvider>()
+                    .SetApplicationName("myapp")
+                    .AddCommand<DogCommand>("dog");
             });
 
             // When
@@ -952,12 +951,12 @@ public sealed partial class CommandAppTests
                 configurator.SetApplicationName("myapp");
 
                 // All root examples should be shown
-                configurator.AddExample("--name", "Rufus", "--age", "12", "--good-boy");
-                configurator.AddExample("--name", "Luna");
-                configurator.AddExample("--name", "Charlie");
-                configurator.AddExample("--name", "Bella");
-                configurator.AddExample("--name", "Daisy");
-                configurator.AddExample("--name", "Milo");
+                configurator.AddExample("--name", "Rufus", "--age", "12", "--good-boy")
+                    .AddExample("--name", "Luna")
+                    .AddExample("--name", "Charlie")
+                    .AddExample("--name", "Bella")
+                    .AddExample("--name", "Daisy")
+                    .AddExample("--name", "Milo");
             });
 
             // When


### PR DESCRIPTION
Fixes #1219

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
  - the discussion was on an issue and was discussed with @FrankRay78 https://github.com/spectreconsole/spectre.console/discussions/1713#discussioncomment-12242915
- [x] A maintainer has signed off on the changes and the issue was assigned to me
  - see above link to discussion.
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

Changed IConfigurator to return IConfigurator instead of void for the following interface methods:
- SetHelpProvider
- SetHelpProvider<T>
- AddExample

However, other methods like AddCommand narrow the configurator so the order of chaining methods does matter.  Just to point that out.  Chaining is optional obviously.

I saw the ICofiguratorOfT also returns void for SetDescription, and AddExample. However, it becomes a bigger challenge to change that because Configurator<TSettings> implements both `IUnsafeBranchConfigurator` and `IConfiguratorOfT` and both share the SetDescription and AddExample but one does not take in the generic type.  Probably would need "unsafe configurator of T" or something?

---
Please upvote :+1: this pull request if you are interested in it.