### PR TITLE
Fix IndexOutOfRangeException in ExceptionFormatter

### DIFF
--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
@@ -64,8 +64,7 @@ internal static class ExceptionFormatter
         }
 
         var stackTrace = new StackTrace(ex, fNeedFileInfo: true);
-        var allFrames = stackTrace.GetFrames();
-        if (allFrames[0]?.GetMethod() == null)
+        if (stackTrace.GetFrame(0)?.GetMethod() == null)
         {
             // if we can't easily get the method for the frame, then we are in AOT
             // fallback to using ToString method of each frame.
@@ -73,7 +72,8 @@ internal static class ExceptionFormatter
             return grid;
         }
 
-        var frames = allFrames
+        var frames = stackTrace
+            .GetFrames()
             .FilterStackFrames()
             .ToList();
 


### PR DESCRIPTION
Commit b2689be introduced a regression when stacktrace don't have frame.

Here is the crash in my app.
![image](https://github.com/user-attachments/assets/3205fff2-f3b3-4b5e-af1b-542220e60730)

The change that caused this issue is that stackTrace.GetFrame(0) has been replaced by stackTrace.GetFrames()[0].
Method GetFrame does index bound check whereas stackTrace.GetFrames()[0] is a simple array access and don't.
I put back the previous method to fix the issue.

I tried to make a test to cover this case but I failed to create an exception with no frame.
