### PR TITLE
Escape markup in case passed argument is class

### DIFF
--- a/src/Spectre.Console/Widgets/Markup.cs
+++ b/src/Spectre.Console/Widgets/Markup.cs
@@ -109,7 +109,22 @@ public sealed class Markup : Renderable, IHasJustification, IOverflowable
 
     internal static string EscapeInterpolated(IFormatProvider provider, FormattableString value)
     {
-        object?[] args = value.GetArguments().Select(arg => arg is string s ? s.EscapeMarkup() : arg).ToArray();
+        object?[] args = value.GetArguments().Select(arg =>
+        {
+            if (arg is string s)
+            {
+                return s.EscapeMarkup();
+            }
+            else if (arg != null && arg.GetType().IsClass)
+            {
+                return arg?.ToString()?.EscapeMarkup();
+            }
+            else
+            {
+                return arg;
+            }
+        }).ToArray();
+
         return string.Format(provider, value.Format, args);
     }
 }

--- a/src/Tests/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Widgets/MarkupTests.cs
@@ -174,4 +174,22 @@ public sealed class MarkupTests
 └─────────────────┘
 ".NormalizeLineEndings());
     }
+
+    [Fact]
+    public void Should_Escape_Object_With_Square_Brackets()
+    {
+        // Given
+        var console = new TestConsole();
+        SomeCLass obj = new SomeCLass();
+
+        // When
+        console.Write($"Text {obj}");
+
+        // Then
+        console.Output.ShouldBe("Text with [square brackets]");
+    }
+    class SomeCLass
+    {
+        public override string ToString() => "with [square brackets]";
+    }
 }


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #1763

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [ ] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes
- Modified `Markup.EscapeInterpolated` to escape markup in case passed argument is class, otherwise, return argument.
- Added unit test to verify the fix.
<!-- describe the changes you made. -->

---
Please upvote :+1: this pull request if you are interested in it.