### PR TITLE
Filter selection prompt items with search

### DIFF
--- a/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
+++ b/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
@@ -35,5 +35,5 @@ internal interface IListPromptStrategy<T>
     /// <param name="searchText">The search text.</param>
     /// <returns>A <see cref="IRenderable"/> representing the items.</returns>
     public IRenderable Render(IAnsiConsole console, bool scrollable, int cursorIndex,
-        IEnumerable<(int Index, ListPromptItem<T> Node)> items, bool skipUnselectableItems, string searchText);
+        IEnumerable<(int Index, ListPromptItem<T> Node)> items, string searchText);
 }

--- a/src/Spectre.Console/Prompts/List/ListPromptState.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptState.cs
@@ -182,10 +182,10 @@ internal sealed class ListPromptState<T>
             .ToList();
     }
 
-    private bool MatchesSearch(ListPromptItem<T>? item) =>
+    private bool MatchesSearch(ListPromptItem<T> item) =>
         _converter.Invoke(item.Data).Contains(SearchText, StringComparison.OrdinalIgnoreCase);
 
-    private class SelectableItem(ListPromptItem<T>? item, int index)
+    private class SelectableItem(ListPromptItem<T> item, int index)
     {
         public ListPromptItem<T> Item { get; } = item;
         public int Index { get; } = index;

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -95,7 +95,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
         // Create the list prompt
         var prompt = new ListPrompt<T>(console, this);
         var converter = Converter ?? TypeConverterHelper.ConvertToString;
-        var result = await prompt.Show(Tree, converter, Mode, false, false, PageSize, WrapAround, cancellationToken).ConfigureAwait(false);
+        var result = await prompt.Show(Tree, converter, Mode, false, false, false, PageSize, WrapAround, cancellationToken).ConfigureAwait(false);
 
         if (Mode == SelectionMode.Leaf)
         {
@@ -163,7 +163,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
 
         if (key.Key == ConsoleKey.Spacebar || key.Key == ConsoleKey.Packet)
         {
-            var current = state.Items[state.Index];
+            var current = state.Current;
             var select = !current.IsSelected;
 
             if (Mode == SelectionMode.Leaf)
@@ -224,7 +224,7 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
 
     /// <inheritdoc/>
     IRenderable IListPromptStrategy<T>.Render(IAnsiConsole console, bool scrollable, int cursorIndex,
-        IEnumerable<(int Index, ListPromptItem<T> Node)> items, bool skipUnselectableItems, string searchText)
+        IEnumerable<(int Index, ListPromptItem<T> Node)> items, string searchText)
     {
         var list = new List<IRenderable>();
         var highlightStyle = HighlightStyle ?? Color.Blue;

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -114,7 +114,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     /// <inheritdoc/>
     ListPromptInputResult IListPromptStrategy<T>.HandleInput(ConsoleKeyInfo key, ListPromptState<T> state)
     {
-        if (key.Key == ConsoleKey.Enter || key.Key == ConsoleKey.Spacebar || key.Key == ConsoleKey.Packet)
+        if (key.Key == ConsoleKey.Enter || key.Key == ConsoleKey.Packet)
         {
             if (state.Current == null)
             {

--- a/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
@@ -187,8 +187,9 @@ public static class SelectionPromptExtensions
     /// </summary>
     /// <typeparam name="T">The prompt result type.</typeparam>
     /// <param name="obj">The prompt.</param>
+    /// <param name="filterOnSearch">A boolean which indicates whether items should be filtered on searching.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static SelectionPrompt<T> EnableSearch<T>(this SelectionPrompt<T> obj, bool filterOptionsOnSearch = false)
+    public static SelectionPrompt<T> EnableSearch<T>(this SelectionPrompt<T> obj, bool filterOnSearch = false)
         where T : notnull
     {
         if (obj is null)
@@ -197,7 +198,7 @@ public static class SelectionPromptExtensions
         }
 
         obj.SearchEnabled = true;
-        obj.FilterOnSearch = filterOptionsOnSearch;
+        obj.FilterOnSearch = filterOnSearch;
         return obj;
     }
 

--- a/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
@@ -188,7 +188,7 @@ public static class SelectionPromptExtensions
     /// <typeparam name="T">The prompt result type.</typeparam>
     /// <param name="obj">The prompt.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static SelectionPrompt<T> EnableSearch<T>(this SelectionPrompt<T> obj)
+    public static SelectionPrompt<T> EnableSearch<T>(this SelectionPrompt<T> obj, bool filterOptionsOnSearch = false)
         where T : notnull
     {
         if (obj is null)
@@ -197,6 +197,7 @@ public static class SelectionPromptExtensions
         }
 
         obj.SearchEnabled = true;
+        obj.FilterOnSearch = filterOptionsOnSearch;
         return obj;
     }
 

--- a/src/Tests/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
@@ -2,17 +2,17 @@ namespace Spectre.Console.Tests.Unit;
 
 public sealed class ListPromptStateTests
 {
-    private ListPromptState<string> CreateListPromptState(int count, int pageSize, bool shouldWrap, bool searchEnabled)
+    private ListPromptState<string> CreateListPromptState(int count, int pageSize, bool shouldWrap, bool searchEnabled, bool filterOnSearch)
         => new(
             Enumerable.Range(0, count).Select(i => new ListPromptItem<string>(i.ToString())).ToList(),
             text => text,
-            pageSize, shouldWrap, SelectionMode.Independent, true, searchEnabled);
+            pageSize, shouldWrap, SelectionMode.Independent, true, searchEnabled, filterOnSearch);
 
     [Fact]
     public void Should_Have_Start_Index_Zero()
     {
         // Given
-        var state = CreateListPromptState(100, 10, false, false);
+        var state = CreateListPromptState(100, 10, false, false, false);
 
         // When
         /* noop */
@@ -27,7 +27,7 @@ public sealed class ListPromptStateTests
     public void Should_Increase_Index(bool wrap)
     {
         // Given
-        var state = CreateListPromptState(100, 10, wrap, false);
+        var state = CreateListPromptState(100, 10, wrap, false, false);
         var index = state.Index;
 
         // When
@@ -43,7 +43,7 @@ public sealed class ListPromptStateTests
     public void Should_Go_To_End(bool wrap)
     {
         // Given
-        var state = CreateListPromptState(100, 10, wrap, false);
+        var state = CreateListPromptState(100, 10, wrap, false, false);
 
         // When
         state.Update(ConsoleKey.End.ToConsoleKeyInfo());
@@ -56,7 +56,7 @@ public sealed class ListPromptStateTests
     public void Should_Clamp_Index_If_No_Wrap()
     {
         // Given
-        var state = CreateListPromptState(100, 10, false, false);
+        var state = CreateListPromptState(100, 10, false, false, false);
         state.Update(ConsoleKey.End.ToConsoleKeyInfo());
 
         // When
@@ -70,7 +70,7 @@ public sealed class ListPromptStateTests
     public void Should_Wrap_Index_If_Wrap()
     {
         // Given
-        var state = CreateListPromptState(100, 10, true, false);
+        var state = CreateListPromptState(100, 10, true, false, false);
         state.Update(ConsoleKey.End.ToConsoleKeyInfo());
 
         // When
@@ -84,7 +84,7 @@ public sealed class ListPromptStateTests
     public void Should_Wrap_Index_If_Wrap_And_Down()
     {
         // Given
-        var state = CreateListPromptState(100, 10, true, false);
+        var state = CreateListPromptState(100, 10, true, false, false);
 
         // When
         state.Update(ConsoleKey.UpArrow.ToConsoleKeyInfo());
@@ -97,7 +97,7 @@ public sealed class ListPromptStateTests
     public void Should_Wrap_Index_If_Wrap_And_Page_Up()
     {
         // Given
-        var state = CreateListPromptState(10, 100, true, false);
+        var state = CreateListPromptState(10, 100, true, false, false);
 
         // When
         state.Update(ConsoleKey.PageUp.ToConsoleKeyInfo());
@@ -110,7 +110,7 @@ public sealed class ListPromptStateTests
     public void Should_Wrap_Index_If_Wrap_And_Offset_And_Page_Down()
     {
         // Given
-        var state = CreateListPromptState(10, 100, true, false);
+        var state = CreateListPromptState(10, 100, true, false, false);
         state.Update(ConsoleKey.End.ToConsoleKeyInfo());
         state.Update(ConsoleKey.UpArrow.ToConsoleKeyInfo());
 
@@ -125,7 +125,7 @@ public sealed class ListPromptStateTests
     public void Should_Jump_To_First_Matching_Item_When_Searching()
     {
         // Given
-        var state = CreateListPromptState(10, 100, true, true);
+        var state = CreateListPromptState(10, 100, true, true, false);
 
         // When
         state.Update(ConsoleKey.D3.ToConsoleKeyInfo());
@@ -135,10 +135,23 @@ public sealed class ListPromptStateTests
     }
 
     [Fact]
+    public void Should_Filter_Items_On_Search()
+    {
+        // Given
+        var state = CreateListPromptState(14, 100, true, true, true);
+
+        // When
+        state.Update(ConsoleKey.D3.ToConsoleKeyInfo());
+
+        // Then
+        state.VisibleItems.Select(x => x.Data).ShouldBe(["3", "13"]);
+    }
+
+    [Fact]
     public void Should_Jump_Back_To_First_Item_When_Clearing_Search_Term()
     {
         // Given
-        var state = CreateListPromptState(10, 100, true, true);
+        var state = CreateListPromptState(10, 100, true, true, false);
 
         // When
         state.Update(ConsoleKey.D3.ToConsoleKeyInfo());


### PR DESCRIPTION
fixes #1702

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes
I changed the code so that now when a user searches, the list is filtered down to only those items which match the search term

### `ListPromptState.cs`
There are now 3 lists which hold the current state of the prompt:
- `Items` This existed before and contains all the items
- `VisibleItems` This list contains only items which match the search term, or any groups which contain a child which matches the search term
- `_selectableItems` This list contains only the subset of `VisibleItems` which are selectable (ie. not a group if in leaf mode, following the same logic as before with `_leafIndexes`). it is a list of `SelectableItem` which contains the `ListPromptItem` and also the index of the item in `VisibleItems`.

`VisibleItems` and `_selectableItems` are updated every time the search term changes, when the user is navigates the list the only the index of the item in `_selectableItems` is updated (which is stored in `_selectableIndex`).

### `ListPrompt.cs`
- BuildRenderable now uses `VisibleItems` 
- added argument for `filterOnSearch`

### `SelectionPrompt.cs`
- added `FilterOnSearch` property
- Removed the spacebar as a key which submits, to allow the search to contain spaces
- Added null check for when `state.Current == null`. This happens when the `VisibleItems` is filtered to the point it contains no items
- removed skipUnselectableItems argument as it wasn't being used

### `SelectionPromptExtensions.cs`
- Added optional bool to the `EnableSearch` method to set `FilterOnSearch`

### `MultiSelectionPrompt.cs`
- added argument for `filterOnSearch`
- removed skipUnselectableItems argument as it wasn't being used

### `IListPromptStrategy`
- removed skipUnselectableItems argument as it wasn't being used

---
Please upvote :+1: this pull request if you are interested in it.