### PR TITLE
Fix IndexOutOfRangeException in ExceptionFormatter

### DIFF
--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionFormatter.cs
@@ -65,7 +65,7 @@ internal static class ExceptionFormatter
 
         var stackTrace = new StackTrace(ex, fNeedFileInfo: true);
         var allFrames = stackTrace.GetFrames();
-        if (allFrames[0]?.GetMethod() == null)
+        if (allFrames.Length > 0 && allFrames[0]?.GetMethod() == null)
         {
             // if we can't easily get the method for the frame, then we are in AOT
             // fallback to using ToString method of each frame.

--- a/src/Tests/Spectre.Console.Tests/Unit/AnsiConsoleTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/AnsiConsoleTests.cs
@@ -142,4 +142,21 @@ public partial class AnsiConsoleTests
                 .ShouldBe("[101mHello[0m\n[101mWorld[0m\n");
         }
     }
+
+    public sealed class WriteException
+    {
+        [Fact]
+        public void Should_Not_Throw_If_Exception_Has_No_StackTrace()
+        {
+            // Given
+            var console = new TestConsole();
+            var exception = new InvalidOperationException("An exception.");
+
+            // When
+            void When() => console.WriteException(exception);
+
+            // Then
+            Should.NotThrow(When);
+        }
+    }
 }


### PR DESCRIPTION
fixes #1798

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [ ] No documentation changes are required.

## Changes

Fix `IndexOutOfRangeException` if an exception does not have an associated stack trace.
