### PR TITLE
#1718 TestConsole can now be configured and accessed in CommandAppTester

### DIFF
--- a/docs/input/cli/unit-testing.md
+++ b/docs/input/cli/unit-testing.md
@@ -1,13 +1,11 @@
 Title: Unit Testing
 Order: 14
 Description: Instructions for unit testing a Spectre.Console application.
-Reference: 
-    - T:Spectre.Console.Testing.CommandAppTester
-    - T:Spectre.Console.Testing.TestConsole
-    - T:Spectre.Console.Testing.TestConsoleInput
+Reference: - T:Spectre.Console.Testing.CommandAppTester - T:Spectre.Console.Testing.TestConsole - T:Spectre.Console.Testing.TestConsoleInput
+
 ---
 
-`Spectre.Console` has a separate project that contains test harnesses for unit testing your own console applications. 
+`Spectre.Console` has a separate project that contains test harnesses for unit testing your own console applications.
 
 The fastest way of getting started is to install the `Spectre.Console.Testing` NuGet package.
 
@@ -63,9 +61,93 @@ The following example validates the exit code and terminal output of a `Spectre.
     }
 ```
 
+The following example demonstrates how to mock user inputs for an interactive command.
+This test (InteractiveCommand_WithMockedUserInputs_ProducesExpectedOutput) simulates user interactions by pushing predefined inputs to the console, then verifies that the resulting output is as expected.
+
+```csharp
+public sealed class InteractiveCommandTests
+{
+    private sealed class InteractiveCommand : Command
+    {
+        private readonly IAnsiConsole _console;
+
+        public InteractiveCommand(IAnsiConsole console)
+        {
+            _console = console;
+        }
+
+        public override int Execute(CommandContext context)
+        {
+            var fruits = _console.Prompt(
+                new MultiSelectionPrompt<string>()
+                    .Title("What are your [green]favorite fruits[/]?")
+                    .NotRequired() // Not required to have a favorite fruit
+                    .PageSize(10)
+                    .MoreChoicesText("[grey](Move up and down to reveal more fruits)[/]")
+                    .InstructionsText(
+                        "[grey](Press [blue]<space>[/] to toggle a fruit, " +
+                        "[green]<enter>[/] to accept)[/]")
+                    .AddChoices(new[] {
+                        "Apple", "Apricot", "Avocado",
+                        "Banana", "Blackcurrant", "Blueberry",
+                        "Cherry", "Cloudberry", "Coconut",
+                    }));
+
+            var fruit = _console.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("What's your [green]favorite fruit[/]?")
+                    .PageSize(10)
+                    .MoreChoicesText("[grey](Move up and down to reveal more fruits)[/]")
+                    .AddChoices(new[] {
+                        "Apple", "Apricot", "Avocado",
+                        "Banana", "Blackcurrant", "Blueberry",
+                        "Cherry", "Cloudberry", "Cocunut",
+                    }));
+
+            var name = _console.Ask<string>("What's your name?");
+
+            _console.WriteLine($"[{string.Join(',', fruits)};{fruit};{name}]");
+
+            return 0;
+        }
+    }
+
+    [Fact]
+    public void InteractiveCommand_WithMockedUserInputs_ProducesExpectedOutput()
+    {
+        // Given
+        TestConsole console = new();
+        console.Interactive();
+
+        // Your mocked inputs must always end with "Enter" for each prompt!
+
+        // Multi selection prompt: Choose first option
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // Selection prompt: Choose second option
+        console.Input.PushKey(ConsoleKey.DownArrow);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // Ask text prompt: Enter name
+        console.Input.PushTextWithEnter("Spectre Console");
+
+        var app = new CommandAppTester(null, new CommandAppTesterSettings(), console);
+        app.SetDefaultCommand<InteractiveCommand>();
+
+        // When
+        var result = app.Run();
+
+        // Then
+        result.ExitCode.ShouldBe(0);
+        result.Output.EndsWith("[Apple;Apricot;Spectre Console]");
+    }
+}
+```
+
 ## Testing console behaviour
 
- `TestConsole` and `TestConsoleInput` are testable implementations of `IAnsiConsole` and `IAnsiConsoleInput`, allowing you fine-grain control over testing console output and interactivity.
+`TestConsole` and `TestConsoleInput` are testable implementations of `IAnsiConsole` and `IAnsiConsoleInput`, allowing you fine-grain control over testing console output and interactivity.
 
 The following example renders some widgets before then validating the console output:
 

--- a/docs/input/cli/unit-testing.md
+++ b/docs/input/cli/unit-testing.md
@@ -5,7 +5,6 @@ Reference:
     - T:Spectre.Console.Testing.CommandAppTester
     - T:Spectre.Console.Testing.TestConsole
     - T:Spectre.Console.Testing.TestConsoleInput
-
 ---
 
 `Spectre.Console` has a separate project that contains test harnesses for unit testing your own console applications. 
@@ -150,7 +149,7 @@ public sealed class InteractiveCommandTests
 
 ## Testing console behaviour
 
-- `TestConsole` and `TestConsoleInput` are testable implementations of `IAnsiConsole` and `IAnsiConsoleInput`, allowing you fine-grain control over testing console output and interactivity.
+`TestConsole` and `TestConsoleInput` are testable implementations of `IAnsiConsole` and `IAnsiConsoleInput`, allowing you fine-grain control over testing console output and interactivity.
 
 The following example renders some widgets before then validating the console output:
 
@@ -197,4 +196,4 @@ The following example prompts the user for input before then validating the expe
     }
 ```
 
-- `CommandAppTester` uses `TestConsole` internally, which in turn uses `TestConsoleInput`, offering a fully testable harness for `Spectre.Console` widgets, prompts and commands.
+`CommandAppTester` uses `TestConsole` internally, which in turn uses `TestConsoleInput`, offering a fully testable harness for `Spectre.Console` widgets, prompts and commands.

--- a/docs/input/cli/unit-testing.md
+++ b/docs/input/cli/unit-testing.md
@@ -1,11 +1,14 @@
 Title: Unit Testing
 Order: 14
 Description: Instructions for unit testing a Spectre.Console application.
-Reference: - T:Spectre.Console.Testing.CommandAppTester - T:Spectre.Console.Testing.TestConsole - T:Spectre.Console.Testing.TestConsoleInput
+Reference: 
+    - T:Spectre.Console.Testing.CommandAppTester
+    - T:Spectre.Console.Testing.TestConsole
+    - T:Spectre.Console.Testing.TestConsoleInput
 
 ---
 
-`Spectre.Console` has a separate project that contains test harnesses for unit testing your own console applications.
+`Spectre.Console` has a separate project that contains test harnesses for unit testing your own console applications. 
 
 The fastest way of getting started is to install the `Spectre.Console.Testing` NuGet package.
 
@@ -147,7 +150,7 @@ public sealed class InteractiveCommandTests
 
 ## Testing console behaviour
 
-`TestConsole` and `TestConsoleInput` are testable implementations of `IAnsiConsole` and `IAnsiConsoleInput`, allowing you fine-grain control over testing console output and interactivity.
+- `TestConsole` and `TestConsoleInput` are testable implementations of `IAnsiConsole` and `IAnsiConsoleInput`, allowing you fine-grain control over testing console output and interactivity.
 
 The following example renders some widgets before then validating the console output:
 
@@ -194,4 +197,4 @@ The following example prompts the user for input before then validating the expe
     }
 ```
 
-`CommandAppTester` uses `TestConsole` internally, which in turn uses `TestConsoleInput`, offering a fully testable harness for `Spectre.Console` widgets, prompts and commands.
+- `CommandAppTester` uses `TestConsole` internally, which in turn uses `TestConsoleInput`, offering a fully testable harness for `Spectre.Console` widgets, prompts and commands.

--- a/docs/input/cli/unit-testing.md
+++ b/docs/input/cli/unit-testing.md
@@ -149,7 +149,7 @@ public sealed class InteractiveCommandTests
 
 ## Testing console behaviour
 
-`TestConsole` and `TestConsoleInput` are testable implementations of `IAnsiConsole` and `IAnsiConsoleInput`, allowing you fine-grain control over testing console output and interactivity.
+ `TestConsole` and `TestConsoleInput` are testable implementations of `IAnsiConsole` and `IAnsiConsoleInput`, allowing you fine-grain control over testing console output and interactivity.
 
 The following example renders some widgets before then validating the console output:
 

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/Testing/CommandAppTesterTests.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/Testing/CommandAppTesterTests.cs
@@ -48,7 +48,7 @@ public sealed class CommandAppTesterTests
     [Fact]
     public void DefaultCtor_WithoutParameters_CreatesDefaultConsole()
     {
-        // When
+        // Given, When
         CommandAppTester app = new();
 
         // Then
@@ -73,7 +73,7 @@ public sealed class CommandAppTesterTests
     [Fact]
     public void Ctor_WithSettings_CreatesDefaultConsole()
     {
-        // When
+        // Given, When
         CommandAppTester app = new(new CommandAppTesterSettings());
 
         // Then

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/Testing/CommandAppTesterTests.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/Testing/CommandAppTesterTests.cs
@@ -44,4 +44,40 @@ public sealed class CommandAppTesterTests
         // Then
         result.Output.ShouldBe(expected);
     }
+
+    [Fact]
+    public void DefaultCtor_WithoutParameters_CreatesDefaultConsole()
+    {
+        // When
+        CommandAppTester app = new();
+
+        // Then
+        app.Console.ShouldNotBeNull();
+        app.Console.Profile.Width.ShouldBe(int.MaxValue);
+    }
+
+    [Fact]
+    public void DefaultCtor_WithCustomConsole_UsesProvidedInstance()
+    {
+        // Given
+        TestConsole console = new();
+
+        // When
+        CommandAppTester app = new(null, new CommandAppTesterSettings(), console);
+
+        // Then
+        app.Console.ShouldNotBeNull();
+        app.Console.ShouldBeSameAs(console);
+    }
+
+    [Fact]
+    public void Ctor_WithSettings_CreatesDefaultConsole()
+    {
+        // When
+        CommandAppTester app = new(new CommandAppTesterSettings());
+
+        // Then
+        app.Console.ShouldNotBeNull();
+        app.Console.Profile.Width.ShouldBe(int.MaxValue);
+    }
 }

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/Testing/InteractiveCommandTests.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/Testing/InteractiveCommandTests.cs
@@ -1,0 +1,80 @@
+namespace Spectre.Console.Cli.Tests.Unit.Testing;
+
+public sealed class InteractiveCommandTests
+{
+    private sealed class InteractiveCommand : Command
+    {
+        private readonly IAnsiConsole _console;
+
+        public InteractiveCommand(IAnsiConsole console)
+        {
+            _console = console;
+        }
+
+        public override int Execute(CommandContext context)
+        {
+            var fruits = _console.Prompt(
+                new MultiSelectionPrompt<string>()
+                    .Title("What are your [green]favorite fruits[/]?")
+                    .NotRequired() // Not required to have a favorite fruit
+                    .PageSize(10)
+                    .MoreChoicesText("[grey](Move up and down to reveal more fruits)[/]")
+                    .InstructionsText(
+                        "[grey](Press [blue]<space>[/] to toggle a fruit, " +
+                        "[green]<enter>[/] to accept)[/]")
+                    .AddChoices(new[] {
+                        "Apple", "Apricot", "Avocado",
+                        "Banana", "Blackcurrant", "Blueberry",
+                        "Cherry", "Cloudberry", "Coconut",
+                    }));
+
+            var fruit = _console.Prompt(
+                new SelectionPrompt<string>()
+                    .Title("What's your [green]favorite fruit[/]?")
+                    .PageSize(10)
+                    .MoreChoicesText("[grey](Move up and down to reveal more fruits)[/]")
+                    .AddChoices(new[] {
+                        "Apple", "Apricot", "Avocado",
+                        "Banana", "Blackcurrant", "Blueberry",
+                        "Cherry", "Cloudberry", "Cocunut",
+                    }));
+
+            var name = _console.Ask<string>("What's your name?");
+
+            _console.WriteLine($"[{string.Join(',', fruits)};{fruit};{name}]");
+
+            return 0;
+        }
+    }
+
+    [Fact]
+    public void InteractiveCommand_WithMockedUserInputs_ProducesExpectedOutput()
+    {
+        // Given
+        TestConsole console = new();
+        console.Interactive();
+
+        // Your mocked inputs must always end with "Enter" for each prompt!
+
+        // Multi selection prompt: Choose first option
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // Selection prompt: Choose second option
+        console.Input.PushKey(ConsoleKey.DownArrow);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // Ask text prompt: Enter name
+        console.Input.PushTextWithEnter("Spectre Console");
+
+        var app = new CommandAppTester(null, new CommandAppTesterSettings(), console);
+        app.SetDefaultCommand<InteractiveCommand>();
+
+        // When
+        var result = app.Run();
+
+        // Then
+        result.ExitCode.ShouldBe(0);
+        result.Output.EndsWith("[Apple;Apricot;Spectre Console]");
+    }
+}


### PR DESCRIPTION
Feature #1718

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes
I added a new optional parameter to `CommandAppTester` to override the default `TestConsole`.
The `TestConsole` can now be accessed through a public property of the `CommandAppTester` instance.
The new parameter is placed last to avoid introducing a breaking change.

Added tests and documentation on how to mock user inputs in interactive commands using CommandAppTester.

Please squash the commits when merging.

---
Please upvote :+1: this pull request if you are interested in it.