### PR TITLE
Add ShowRowSeparators in Table Widget docs

### DIFF
--- a/docs/input/widgets/table.md
+++ b/docs/input/widgets/table.md
@@ -138,3 +138,10 @@ table.Columns[0].NoWrap();
 // Set the column width
 table.Columns[0].Width(15);
 ```
+
+### Show row separators
+
+```csharp
+// Shows separator between each row
+table.ShowRowSeparators();
+```


### PR DESCRIPTION
Add ShowRowSeparators in Table Widget docs. 
fixes #1806 

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes 

## Changes

Added a use-case of ShowRowSeparators in Table Docs. Discussed in #1806 
---
Please upvote :+1: this pull request if you are interested in it.