### PR TITLE
Resolved CLI: Add negation flags like clang or gcc

### DIFF
--- a/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs
+++ b/src/Spectre.Console.Cli/Internal/Parsing/CommandTreeParser.cs
@@ -256,7 +256,13 @@ internal class CommandTreeParser
         if (context.State == State.Normal)
         {
             // Find the option.
-            var option = node.FindOption(token.Value, isLongOption, CaseSensitivity);
+            var rawName = token.Value;
+            if (isLongOption && rawName.StartsWith("no-", StringComparison.OrdinalIgnoreCase))
+            {
+                rawName = rawName.Substring(3);
+            }
+
+            var option = node.FindOption(rawName, isLongOption, CaseSensitivity);
             if (option != null)
             {
                 ParseOptionValue(context, stream, token, node, option);
@@ -264,6 +270,7 @@ internal class CommandTreeParser
             }
 
             // Help?
+
             if (_help?.IsMatch(token.Value) == true)
             {
                 node.ShowHelp = true;
@@ -378,7 +385,6 @@ internal class CommandTreeParser
                 context.AddRemainingArgument(token.Representation, null);
             }
         }
-
         // No value?
         if (context.State == State.Normal)
         {
@@ -386,7 +392,14 @@ internal class CommandTreeParser
             {
                 if (parameter.ParameterKind == ParameterKind.Flag)
                 {
-                    value = "true";
+                    if (token.Representation.StartsWith("--no-", StringComparison.Ordinal))
+                    {
+                        value = "false";
+                    }
+                    else
+                    {
+                        value = "true";
+                    }
                 }
                 else
                 {

--- a/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.FlagValues.cs
+++ b/src/Tests/Spectre.Console.Cli.Tests/Unit/CommandAppTests.FlagValues.cs
@@ -210,5 +210,31 @@ public sealed partial class CommandAppTests
             // Then
             result.ShouldBe(expected);
         }
+
+        [Fact]
+        public void Should_Negate_Boolean_Flag_With_No_Prefix()
+        {
+            var app = new CommandAppTester();
+            app.Configure(config =>
+            {
+                config.PropagateExceptions();
+                config.AddCommand<GenericCommand<BoolSettings>>("foo");
+            });
+
+            var result = app.Run(new[] { "foo", "--no-verbose" });
+
+            result.ExitCode.ShouldBe(0);
+            result.Settings.ShouldBeOfType<BoolSettings>().And(s =>
+            {
+                s.Verbose.ShouldBeFalse();
+            });
+        }
+
+        [SuppressMessage("Performance", "CA1812", Justification = "It's OK")]
+        private sealed class BoolSettings : CommandSettings
+        {
+            [CommandOption("--verbose")]
+            public bool Verbose { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1701 

## Changes

This pull request implements support for **negation flags** using the `--no-` prefix, similar to the behavior found in compilers like Clang and GCC.

- Added support to set the flag value to `"false"` when prefixed with `--no-`
- Adjusted `CommandTreeParser.cs` logic to strip the `no-` prefix before looking up matching options
 - If a boolean flag such as `--verbose` is defined, the parser will now also accept `--no-verbose` to automatically assign the value `false`
- Added a unit test in `CommandAppTests.FlagValues.cs` to verify the behavior with a `BoolSettings` class.

Please upvote :+1: this pull request if you are interested in it.