### PR TITLE
Resolved: Esc Key to exit selection

### DIFF
--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -71,6 +71,12 @@ internal sealed class ListPrompt<T>
                     break;
                 }
 
+                if (result == ListPromptInputResult.Abort)
+                {
+                    state.Aborted = true;
+                    break;
+                }
+
                 if (state.Update(key) || result == ListPromptInputResult.Refresh)
                 {
                     hook.Refresh();

--- a/src/Spectre.Console/Prompts/List/ListPromptState.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptState.cs
@@ -3,6 +3,7 @@ namespace Spectre.Console;
 internal sealed class ListPromptState<T>
     where T : notnull
 {
+    public bool Aborted { get; set; }
     private readonly Func<T, string> _converter;
 
     public int Index { get; private set; }

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -101,6 +101,10 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
         var prompt = new ListPrompt<T>(console, this);
         var converter = Converter ?? TypeConverterHelper.ConvertToString;
         var result = await prompt.Show(_tree, converter, Mode, true, SearchEnabled, PageSize, WrapAround, cancellationToken).ConfigureAwait(false);
+        if (result.Aborted)
+        {
+            throw new OperationCanceledException("Prompt Aborted.");
+        }
 
         // Return the selected item
         return result.Items[result.Index].Data;
@@ -109,6 +113,10 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     /// <inheritdoc/>
     ListPromptInputResult IListPromptStrategy<T>.HandleInput(ConsoleKeyInfo key, ListPromptState<T> state)
     {
+        if (key.Key == ConsoleKey.Escape)
+        {
+            return ListPromptInputResult.Abort;
+        }
         if (key.Key == ConsoleKey.Enter || key.Key == ConsoleKey.Spacebar || key.Key == ConsoleKey.Packet)
         {
             // Selecting a non leaf in "leaf mode" is not allowed

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -117,6 +117,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
         {
             return ListPromptInputResult.Abort;
         }
+
         if (key.Key == ConsoleKey.Enter || key.Key == ConsoleKey.Spacebar || key.Key == ConsoleKey.Packet)
         {
             // Selecting a non leaf in "leaf mode" is not allowed

--- a/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -130,6 +130,21 @@ public sealed class SelectionPromptTests
         var exception = action.ShouldThrow<InvalidOperationException>();
         exception.Message.ShouldBe("Cannot show an empty selection prompt. Please call the AddChoice() method to configure the prompt.");
     }
+
+    [Fact]
+    public void Should_Abort_When_Escaped_Is_Pressed()
+    {
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Escape);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        var prompt = new SelectionPrompt<string>()
+            .Title("Select one")
+            .AddChoices("A", "B");
+
+        Should.Throw<OperationCanceledException>(() => prompt.Show(console));
+    }
 }
 
 file sealed class CustomSelectionItem


### PR DESCRIPTION
Fixes #851 

Changes
+ Added logic in Selection Prompt to detect when the Escape key is pressed and return the default value, effectively exiting the prompt early.
+ Included unit test by simulating an Escape key input and asserting the result is null


Please upvote 👍 this pull request if you are interested in it.