### PR TITLE
Fix resizing of Live views with reduced size.

### DIFF
--- a/src/Spectre.Console/Live/LiveDisplayRenderer.cs
+++ b/src/Spectre.Console/Live/LiveDisplayRenderer.cs
@@ -4,7 +4,7 @@ internal sealed class LiveDisplayRenderer : IRenderHook
 {
     private readonly IAnsiConsole _console;
     private readonly LiveDisplayContext _context;
-
+    private Size _size;
     public LiveDisplayRenderer(IAnsiConsole console, LiveDisplayContext context)
     {
         _console = console;
@@ -45,7 +45,26 @@ internal sealed class LiveDisplayRenderer : IRenderHook
     {
         lock (_context.Lock)
         {
-            yield return _context.Live.PositionCursor();
+            // check if the size of the renderable decreased
+            var size = options.ConsoleSize;
+            if (size.Width >= _size.Width && size.Height >= _size.Height)
+            {
+                yield return _context.Live.PositionCursor();
+            }
+            else
+            {
+                // clear shape to ensure new size calculations
+                _context.Live.ClearShape();
+
+                // render a clear screen
+                yield return new ControlCode(AnsiSequences.ED(2));
+                yield return new ControlCode(AnsiSequences.ED(3));
+                yield return new ControlCode(AnsiSequences.CUP(1, 1));
+            }
+
+            // store new size
+            _size = size;
+
 
             foreach (var renderable in renderables)
             {

--- a/src/Spectre.Console/Live/LiveDisplayRenderer.cs
+++ b/src/Spectre.Console/Live/LiveDisplayRenderer.cs
@@ -4,7 +4,6 @@ internal sealed class LiveDisplayRenderer : IRenderHook
 {
     private readonly IAnsiConsole _console;
     private readonly LiveDisplayContext _context;
-    private Size _size;
     public LiveDisplayRenderer(IAnsiConsole console, LiveDisplayContext context)
     {
         _console = console;
@@ -45,26 +44,7 @@ internal sealed class LiveDisplayRenderer : IRenderHook
     {
         lock (_context.Lock)
         {
-            // check if the size of the renderable decreased
-            var size = options.ConsoleSize;
-            if (size.Width >= _size.Width && size.Height >= _size.Height)
-            {
-                yield return _context.Live.PositionCursor();
-            }
-            else
-            {
-                // clear shape to ensure new size calculations
-                _context.Live.ClearShape();
-
-                // render a clear screen
-                yield return new ControlCode(AnsiSequences.ED(2));
-                yield return new ControlCode(AnsiSequences.ED(3));
-                yield return new ControlCode(AnsiSequences.CUP(1, 1));
-            }
-
-            // store new size
-            _size = size;
-
+            yield return _context.Live.PositionCursor(options);
 
             foreach (var renderable in renderables)
             {

--- a/src/Spectre.Console/Live/LiveRenderable.cs
+++ b/src/Spectre.Console/Live/LiveRenderable.cs
@@ -51,7 +51,7 @@ internal sealed class LiveRenderable : Renderable
             // check if the size reduced see bug #703
             if (_shape.Value.Height > options.ConsoleSize.Height || _shape.Value.Width > options.ConsoleSize.Width)
             {
-                // important reset shape, so the size can shrink
+                // Important reset shape, so the size can shrink
                 _shape = null;
                 return new ControlCode(ED(2) + ED(3) + CUP(1, 1));
             }

--- a/src/Spectre.Console/Live/LiveRenderable.cs
+++ b/src/Spectre.Console/Live/LiveRenderable.cs
@@ -67,6 +67,14 @@ internal sealed class LiveRenderable : Renderable
         }
     }
 
+    public void ClearShape()
+    {
+        lock (_lock)
+        {
+            _shape = null;
+        }
+    }
+
     protected override IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
     {
         lock (_lock)

--- a/src/Spectre.Console/Live/LiveRenderable.cs
+++ b/src/Spectre.Console/Live/LiveRenderable.cs
@@ -48,7 +48,7 @@ internal sealed class LiveRenderable : Renderable
                 return new ControlCode(string.Empty);
             }
 
-            // check if the size reduced see bug #703
+            // Check if the size have been reduced
             if (_shape.Value.Height > options.ConsoleSize.Height || _shape.Value.Width > options.ConsoleSize.Width)
             {
                 // Important reset shape, so the size can shrink

--- a/src/Spectre.Console/Live/LiveRenderable.cs
+++ b/src/Spectre.Console/Live/LiveRenderable.cs
@@ -53,8 +53,6 @@ internal sealed class LiveRenderable : Renderable
             {
                 // important reset shape, so the size can shrink
                 _shape = null;
-
-                // send clear screen sequence + home - I'm not sure here what is best - I have lack of experience here!
                 return new ControlCode(ED(2) + ED(3) + CUP(1, 1));
             }
 

--- a/src/Spectre.Console/Live/Progress/Renderers/DefaultProgressRenderer.cs
+++ b/src/Spectre.Console/Live/Progress/Renderers/DefaultProgressRenderer.cs
@@ -10,7 +10,6 @@ internal sealed class DefaultProgressRenderer : ProgressRenderer
     private readonly bool _hideCompleted;
     private readonly Func<IRenderable, IReadOnlyList<ProgressTask>, IRenderable> _renderHook;
     private TimeSpan _lastUpdate;
-    private Size _size;
 
     public override TimeSpan RefreshRate { get; }
 
@@ -119,25 +118,7 @@ internal sealed class DefaultProgressRenderer : ProgressRenderer
     {
         lock (_lock)
         {
-            // check if the size of the renderable decreased
-            var size = options.ConsoleSize;
-            if (size.Width >= _size.Width && size.Height >= _size.Height)
-            {
-                yield return _live.PositionCursor();
-            }
-            else
-            {
-                // clear shape to ensure new size calculations
-                _live.ClearShape();
-
-                // render a clear screen
-                yield return new ControlCode(AnsiSequences.ED(2));
-                yield return new ControlCode(AnsiSequences.ED(3));
-                yield return new ControlCode(AnsiSequences.CUP(1, 1));
-            }
-
-            // store new size
-            _size = size;
+            yield return _live.PositionCursor(options);
 
             foreach (var renderable in renderables)
             {

--- a/src/Spectre.Console/Prompts/List/ListPromptRenderHook.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptRenderHook.cs
@@ -8,6 +8,7 @@ internal sealed class ListPromptRenderHook<T> : IRenderHook
     private readonly LiveRenderable _live;
     private readonly object _lock;
     private bool _dirty;
+    private Size _size;
 
     public ListPromptRenderHook(
         IAnsiConsole console,
@@ -42,7 +43,25 @@ internal sealed class ListPromptRenderHook<T> : IRenderHook
                 _dirty = false;
             }
 
-            yield return _live.PositionCursor();
+            // check if the size of the renderable decreased
+            var size = options.ConsoleSize;
+            if (size.Width >= _size.Width && size.Height >= _size.Height)
+            {
+                yield return _live.PositionCursor();
+            }
+            else
+            {
+                // clear shape to ensure new size calculations
+                _live.ClearShape();
+
+                // render a clear screen
+                yield return new ControlCode(AnsiSequences.ED(2));
+                yield return new ControlCode(AnsiSequences.ED(3));
+                yield return new ControlCode(AnsiSequences.CUP(1, 1));
+            }
+
+            // store new size
+            _size = size;
 
             foreach (var renderable in renderables)
             {

--- a/src/Spectre.Console/Prompts/List/ListPromptRenderHook.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptRenderHook.cs
@@ -8,7 +8,6 @@ internal sealed class ListPromptRenderHook<T> : IRenderHook
     private readonly LiveRenderable _live;
     private readonly object _lock;
     private bool _dirty;
-    private Size _size;
 
     public ListPromptRenderHook(
         IAnsiConsole console,
@@ -43,25 +42,7 @@ internal sealed class ListPromptRenderHook<T> : IRenderHook
                 _dirty = false;
             }
 
-            // check if the size of the renderable decreased
-            var size = options.ConsoleSize;
-            if (size.Width >= _size.Width && size.Height >= _size.Height)
-            {
-                yield return _live.PositionCursor();
-            }
-            else
-            {
-                // clear shape to ensure new size calculations
-                _live.ClearShape();
-
-                // render a clear screen
-                yield return new ControlCode(AnsiSequences.ED(2));
-                yield return new ControlCode(AnsiSequences.ED(3));
-                yield return new ControlCode(AnsiSequences.CUP(1, 1));
-            }
-
-            // store new size
-            _size = size;
+            yield return _live.PositionCursor(options);
 
             foreach (var renderable in renderables)
             {


### PR DESCRIPTION
https://github.com/spectreconsole/spectre.console/issues/703

When resizing Live views e.g. tables this was working only when the size increased. This patch fixes that by detecting size decreases and forcing the IRenderable to forget it's old shape.

fixes #703 


- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [ ] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

---
Please upvote :+1: this pull request if you are interested in it.