### PR TITLE
Make the JSON indent width configurable

### DIFF
--- a/src/Extensions/Spectre.Console.Json/JsonBuilder.cs
+++ b/src/Extensions/Spectre.Console.Json/JsonBuilder.cs
@@ -5,16 +5,22 @@ internal sealed class JsonBuilderContext
     public Paragraph Paragraph { get; }
     public int Indentation { get; set; }
     public JsonTextStyles Styling { get; }
+    public int IndentWidth { get; }
 
-    public JsonBuilderContext(JsonTextStyles styling)
+    public JsonBuilderContext(JsonTextStyles styling, int indentWidth)
     {
+        if (indentWidth < 2 || indentWidth > 4)
+        {
+            throw new ArgumentOutOfRangeException(nameof(indentWidth), indentWidth, "The value must be between 2 and 4 spaces (inclusive).");
+        }
+
         Paragraph = new Paragraph();
         Styling = styling;
     }
 
     public void InsertIndentation()
     {
-        Paragraph.Append(new string(' ', Indentation * 3));
+        Paragraph.Append(new string(' ', Indentation * IndentWidth));
     }
 }
 

--- a/src/Extensions/Spectre.Console.Json/JsonBuilder.cs
+++ b/src/Extensions/Spectre.Console.Json/JsonBuilder.cs
@@ -16,6 +16,7 @@ internal sealed class JsonBuilderContext
 
         Paragraph = new Paragraph();
         Styling = styling;
+        IndentWidth = indentWidth;
     }
 
     public void InsertIndentation()

--- a/src/Extensions/Spectre.Console.Json/JsonText.cs
+++ b/src/Extensions/Spectre.Console.Json/JsonText.cs
@@ -98,7 +98,7 @@ public sealed class JsonText : JustInTimeRenderable
     public JsonText(string json)
     {
         _json = json ?? throw new ArgumentNullException(nameof(json));
-        _indentWidth = 3;
+        _indentWidth = 3; // Use 3 spaces for indent by default.
     }
 
     /// <inheritdoc/>

--- a/src/Extensions/Spectre.Console.Json/JsonText.cs
+++ b/src/Extensions/Spectre.Console.Json/JsonText.cs
@@ -8,6 +8,7 @@ public sealed class JsonText : JustInTimeRenderable
     private readonly string _json;
     private JsonSyntax? _syntax;
     private IJsonParser? _parser;
+    private int _indentWidth;
 
     /// <summary>
     /// Gets or sets the style used for braces.
@@ -55,6 +56,26 @@ public sealed class JsonText : JustInTimeRenderable
     public Style? NullStyle { get; set; }
 
     /// <summary>
+    /// Gets or sets the width of indent used for rendering the JSON text.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The value must be between 2 and 4 spaces (inclusive).
+    /// </exception>
+    public int IndentWidth
+    {
+        get => _indentWidth;
+        set
+        {
+            if (value < 2 || value > 4)
+            {
+                throw new ArgumentOutOfRangeException(nameof(IndentWidth), value, "The value must be between 2 and 4 spaces (inclusive).");
+            }
+
+            _indentWidth = value;
+        }
+    }
+
+    /// <summary>
     /// Gets or sets the JSON parser.
     /// </summary>
     public IJsonParser? Parser
@@ -77,6 +98,7 @@ public sealed class JsonText : JustInTimeRenderable
     public JsonText(string json)
     {
         _json = json ?? throw new ArgumentNullException(nameof(json));
+        _indentWidth = 3;
     }
 
     /// <inheritdoc/>
@@ -87,7 +109,7 @@ public sealed class JsonText : JustInTimeRenderable
             _syntax = (Parser ?? JsonParser.Shared).Parse(_json);
         }
 
-        var context = new JsonBuilderContext(new JsonTextStyles
+        var jsonStyles = new JsonTextStyles
         {
             BracesStyle = BracesStyle ?? Color.Grey,
             BracketsStyle = BracketsStyle ?? Color.Grey,
@@ -98,7 +120,8 @@ public sealed class JsonText : JustInTimeRenderable
             NumberStyle = NumberStyle ?? Color.Green,
             BooleanStyle = BooleanStyle ?? Color.Green,
             NullStyle = NullStyle ?? Color.Grey,
-        });
+        };
+        var context = new JsonBuilderContext(jsonStyles, IndentWidth);
 
         _syntax.Accept(JsonBuilder.Shared, context);
         return context.Paragraph;

--- a/src/Extensions/Spectre.Console.Json/JsonTextExtensions.cs
+++ b/src/Extensions/Spectre.Console.Json/JsonTextExtensions.cs
@@ -318,7 +318,7 @@ public static class JsonTextExtensions
     /// <param name="indentWidth">The indent width.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     /// <exception cref="ArgumentOutOfRangeException">The value must be between 2 and 4 spaces (inclusive).</exception>
-    public static JsonText NullColor(this JsonText text, int indentWidth)
+    public static JsonText IndentWidth(this JsonText text, int indentWidth)
     {
         if (text == null)
         {

--- a/src/Extensions/Spectre.Console.Json/JsonTextExtensions.cs
+++ b/src/Extensions/Spectre.Console.Json/JsonTextExtensions.cs
@@ -310,4 +310,22 @@ public static class JsonTextExtensions
         text.NullStyle = new Style(color);
         return text;
     }
+
+    /// <summary>
+    /// Sets the width of indent used for rendering the JSON text.
+    /// </summary>
+    /// <param name="text">The JSON text instance.</param>
+    /// <param name="indentWidth">The indent width.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The value must be between 2 and 4 spaces (inclusive).</exception>
+    public static JsonText NullColor(this JsonText text, int indentWidth)
+    {
+        if (text == null)
+        {
+            throw new ArgumentNullException(nameof(text));
+        }
+
+        text.IndentWidth = indentWidth;
+        return text;
+    }
 }


### PR DESCRIPTION
This PR is for the discussion https://github.com/spectreconsole/spectre.console/discussions/1841

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [ ] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [ ] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

Today, the indent size for rendering a `JsonText` instance is [hard coded to be 3 spaces](https://github.com/spectreconsole/spectre.console/blob/main/src/Extensions/Spectre.Console.Json/JsonBuilder.cs#L17). For a deep JSON object, it'd nice if I can set the indent size to be 2 to have more rendered within the same console space. So, I propose to make the indent size configurable for an `JsonText` instance.

The changes are simple:
1. Update `JsonBuilderContext` 
    - Add a read-only property `int IndentWidth`
    - Update the constructor take another parameter `int indentWidth`, and assign its value to the read-only property `IndentWidth`
    - Update the `InsertIndentation` method to have `Indentation * IndentWidth` instead.
1. Add a new read-write property `IndentWidth` to `JsonText` to allow user set value
    - Use 3 as the default value so the default behavior is unchanged.
    - Pass it in when creating the `JsonBuilderContext` instance in the `Build()` method.

I think it may be reasonable to make sure the value assigned to `IndentWidth` is between 2 and 4 inclusively, to make user only choose from 2, 3, or 4 spaces.

---
Please upvote :+1: this pull request if you are interested in it.