### PR TITLE
Fix space triggering selection when items in selection list have a space.

### DIFF
--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -109,7 +109,9 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     /// <inheritdoc/>
     ListPromptInputResult IListPromptStrategy<T>.HandleInput(ConsoleKeyInfo key, ListPromptState<T> state)
     {
-        if (key.Key == ConsoleKey.Enter || key.Key == ConsoleKey.Spacebar || key.Key == ConsoleKey.Packet)
+        if (key.Key == ConsoleKey.Enter
+         || key.Key == ConsoleKey.Packet
+         || (!state.SearchEnabled && key.Key == ConsoleKey.Spacebar))
         {
             // Selecting a non leaf in "leaf mode" is not allowed
             if (state.Current.IsGroup && Mode == SelectionMode.Leaf)

--- a/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -142,6 +142,8 @@ file sealed class CustomSelectionItem
     {
         Value = value;
         Name = name ?? throw new ArgumentNullException(nameof(name));
+    }
+    
     public void Should_Append_Space_To_Search_If_Search_Is_Enabled()
     {
         /// Given

--- a/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -131,22 +131,11 @@ public sealed class SelectionPromptTests
         var exception = action.ShouldThrow<InvalidOperationException>();
         exception.Message.ShouldBe("Cannot show an empty selection prompt. Please call the AddChoice() method to configure the prompt.");
     }
-}
 
-file sealed class CustomSelectionItem
-{
-    public int Value { get; }
-    public string Name { get; }
-
-    public CustomSelectionItem(int value, string name)
-    {
-        Value = value;
-        Name = name ?? throw new ArgumentNullException(nameof(name));
-    }
-    
+    [Fact]
     public void Should_Append_Space_To_Search_If_Search_Is_Enabled()
     {
-        /// Given
+        // Given
         var console = new TestConsole();
         console.Profile.Capabilities.Interactive = true;
         console.EmitAnsiSequences();
@@ -165,5 +154,17 @@ file sealed class CustomSelectionItem
         // Then
         result.ShouldBe("Item 2");
         console.Output.ShouldContain($"{ESC}[38;5;12m> {ESC}[0m{ESC}[1;38;5;12;48;5;11mItem {ESC}[0m{ESC}[38;5;12m2{ESC}[0m ");
+    }
+}
+
+file sealed class CustomSelectionItem
+{
+    public int Value { get; }
+    public string Name { get; }
+
+    public CustomSelectionItem(int value, string name)
+    {
+        Value = value;
+        Name = name ?? throw new ArgumentNullException(nameof(name));
     }
 }

--- a/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -87,7 +87,6 @@ public sealed class SelectionPromptTests
     }
 
     [Fact]
-<<<<<<< HEAD:src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
     public void Should_Search_In_Remapped_Result()
     {
         // Given
@@ -116,7 +115,8 @@ public sealed class SelectionPromptTests
         selection.ShouldBe(choices[1]);
     }
 
-    [Fact] public void Should_Throw_Meaningful_Exception_For_Empty_Prompt()
+    [Fact]
+    public void Should_Throw_Meaningful_Exception_For_Empty_Prompt()
     {
         // Given
         var console = new TestConsole();
@@ -142,7 +142,6 @@ file sealed class CustomSelectionItem
     {
         Value = value;
         Name = name ?? throw new ArgumentNullException(nameof(name));
-=======
     public void Should_Append_Space_To_Search_If_Search_Is_Enabled()
     {
         /// Given
@@ -164,6 +163,5 @@ file sealed class CustomSelectionItem
         // Then
         result.ShouldBe("Item 2");
         console.Output.ShouldContain($"{ESC}[38;5;12m> {ESC}[0m{ESC}[1;38;5;12;48;5;11mItem {ESC}[0m{ESC}[38;5;12m2{ESC}[0m ");
->>>>>>> b402054 (changes Search in SelectionPrompt to accept Space Key as text):test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
     }
 }

--- a/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -87,6 +87,7 @@ public sealed class SelectionPromptTests
     }
 
     [Fact]
+<<<<<<< HEAD:src/Tests/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
     public void Should_Search_In_Remapped_Result()
     {
         // Given
@@ -141,5 +142,28 @@ file sealed class CustomSelectionItem
     {
         Value = value;
         Name = name ?? throw new ArgumentNullException(nameof(name));
+=======
+    public void Should_Append_Space_To_Search_If_Search_Is_Enabled()
+    {
+        /// Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.EmitAnsiSequences();
+        console.Input.PushText("Item");
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+            .Title("Search for something with space")
+            .EnableSearch()
+            .AddChoices("Item1")
+            .AddChoices("Item 2");
+        string result = prompt.Show(console);
+
+        // Then
+        result.ShouldBe("Item 2");
+        console.Output.ShouldContain($"{ESC}[38;5;12m> {ESC}[0m{ESC}[1;38;5;12;48;5;11mItem {ESC}[0m{ESC}[38;5;12m2{ESC}[0m ");
+>>>>>>> b402054 (changes Search in SelectionPrompt to accept Space Key as text):test/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
     }
 }


### PR DESCRIPTION
fixes #1536 .. same as #1601 with merge conflicts resolved.

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

This is the same as #1601 to fix #1536 but I've resolved the merge conflicts. I've no made no other changes to the PR. We are hitting this space behavior issue in the selection prompt in [Aspire](https://github.com/dotnet/aspire).

---
Please upvote :+1: this pull request if you are interested in it.