### PR TITLE
Update the Spectre.Console.Cli documentation with CancellationToken

### DIFF
--- a/docs/input/cli/commands.md
+++ b/docs/input/cli/commands.md
@@ -18,7 +18,7 @@ public class HelloCommand : Command<HelloCommand.Settings>
     }
 
 
-    public override int Execute(CommandContext context, Settings settings)
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         AnsiConsole.MarkupLine($"Hello, [blue]{settings.Name}[/]");
         return 0;

--- a/docs/input/cli/composing.md
+++ b/docs/input/cli/composing.md
@@ -55,7 +55,7 @@ in the previous step.
 ```csharp
 public class AddPackageCommand : Command<AddPackageSettings>
 {
-    public override int Execute(CommandContext context, AddPackageSettings settings)
+    public override int Execute(CommandContext context, AddPackageSettings settings, CancellationToken cancellationToken)
     {
         // Omitted
         return 0;
@@ -64,7 +64,7 @@ public class AddPackageCommand : Command<AddPackageSettings>
 
 public class AddReferenceCommand : Command<AddReferenceSettings>
 {
-    public override int Execute(CommandContext context, AddReferenceSettings settings)
+    public override int Execute(CommandContext context, AddReferenceSettings settings, CancellationToken cancellationToken)
     {
         // Omitted
         return 0;

--- a/docs/input/cli/getting-started.md
+++ b/docs/input/cli/getting-started.md
@@ -33,7 +33,7 @@ internal sealed class FileSizeCommand : Command<FileSizeCommand.Settings>
         public bool IncludeHidden { get; init; }
     }
 
-    public override int Execute([NotNull] CommandContext context, [NotNull] Settings settings)
+    public override int Execute(CommandContext context, Settings settings, CancellationToken cancellationToken)
     {
         var searchOptions = new EnumerationOptions
         {

--- a/docs/input/cli/introduction.md
+++ b/docs/input/cli/introduction.md
@@ -61,7 +61,7 @@ in the previous step.
 ```csharp
 public class AddPackageCommand : Command<AddPackageSettings>
 {
-    public override int Execute(CommandContext context, AddPackageSettings settings)
+    public override int Execute(CommandContext context, AddPackageSettings settings, CancellationToken cancellationToken)
     {
         // Omitted
         return 0;
@@ -70,7 +70,7 @@ public class AddPackageCommand : Command<AddPackageSettings>
 
 public class AddReferenceCommand : Command<AddReferenceSettings>
 {
-    public override int Execute(CommandContext context, AddReferenceSettings settings)
+    public override int Execute(CommandContext context, AddReferenceSettings settings, CancellationToken cancellationToken)
     {
         // Omitted
         return 0;

--- a/docs/input/cli/unit-testing.md
+++ b/docs/input/cli/unit-testing.md
@@ -40,7 +40,7 @@ The following example validates the exit code and terminal output of a `Spectre.
             _console = console;
         }
 
-        public override int Execute(CommandContext context)
+        public override int Execute(CommandContext context, CancellationToken cancellationToken)
         {
             _console.WriteLine("Hello world.");
             return 0;
@@ -78,7 +78,7 @@ public sealed class InteractiveCommandTests
             _console = console;
         }
 
-        public override int Execute(CommandContext context)
+        public override int Execute(CommandContext context, CancellationToken cancellationToken)
         {
             var fruits = _console.Prompt(
                 new MultiSelectionPrompt<string>()


### PR DESCRIPTION
- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [x] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

Now that #1911 is merged, all `Execute` methods of commands have a new CancellationToken parameter. Update the documentation to reflect that.

New documentation shall still be written with an example on how to pass the top-level CancellationToken to the app.Run(Async) method.

Also, I'm still experimenting with MarkdownSnippets on a branch. But with this pull request, the documentation is at least in line with the current state of the code.

---
Please upvote :+1: this pull request if you are interested in it.