### PR TITLE
Condition `PolySharp` for only `netstandard2.0`

### DIFF
--- a/src/Spectre.Console.Cli/Spectre.Console.Cli.csproj
+++ b/src/Spectre.Console.Cli/Spectre.Console.Cli.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup Label="Dependencies">
     <PackageReference Include="OpenCli.Sources" />
-    <PackageReference Include="PolySharp">
+    <PackageReference Include="PolySharp" Condition="'$(TargetFramework)' == 'netstandard2.0'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/Spectre.Console/Spectre.Console.csproj
+++ b/src/Spectre.Console/Spectre.Console.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Wcwidth.Sources">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="PolySharp">
+    <PackageReference Include="PolySharp" Condition="'$(TargetFramework)' == 'netstandard2.0'">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi, I did not file this on an issue, but the change is trivial, so I thought we could discuss here. Thanks!

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [ ] I have commented on the issue above and discussed the intended changes
- [ ] A maintainer has signed off on the changes and the issue was assigned to me
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

Context: https://github.com/dotnet/sdk/pull/51430
Context: https://github.com/dotnet/source-build-reference-packages/pull/1447

We would like to use Spectre.Console for the `dotnet` CLI, and .NET has to be able to be completely built from source.

It would help us to have `PolySharp` only included when building for `netstandard2.0`, as that is the only target framework that needs the polyfills.

.NET would probably only build the latest target framework.

Thanks!