### PR TITLE
Add mentioning about Textual

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 _[![Spectre.Console NuGet Version](https://img.shields.io/nuget/v/spectre.console.svg?style=flat&label=NuGet%3A%20Spectre.Console)](https://www.nuget.org/packages/spectre.console)_ _[![Spectre.Console CLI NuGet Version](https://img.shields.io/nuget/v/spectre.console.cli.svg?style=flat&label=NuGet%3A%20Spectre.Console.Cli)](https://www.nuget.org/packages/spectre.console.cli)_ [![Netlify Status](https://api.netlify.com/api/v1/badges/1eaf215a-eb9c-45e4-8c64-c90b62963149/deploy-status)](https://app.netlify.com/sites/spectreconsole/deploys)
 
 A .NET library that makes it easier to create beautiful, cross platform, console applications.  
-It is heavily inspired by the excellent Python library, [Rich](https://github.com/willmcgugan/rich). Detailed instructions for using `Spectre.Console` are located on the project website, https://spectreconsole.net
+It is heavily inspired by the excellent Python libraries, [Rich](https://github.com/willmcgugan/rich) and [Textual](https://github.com/Textualize/textual?tab=readme-ov-file#widgets) 
+Detailed instructions for using `Spectre.Console` are located on the project website, https://spectreconsole.net
 
 ## Table of Contents
 


### PR DESCRIPTION
I spend the last ~ 4 years thinking Spectre is only a replacement for `rich` since this is what it references in the README. 👀

Now I heard yesterday, that it also has elements from the library of the same author, that builds up on `rich`: Textual.

This commit adds a mention to it.

I hope its ok that I opened this without discussing it in an issue.

Lovely day 🩷

<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
fixes #

<!-- formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have commented on the issue above and discussed the intended changes
- [] A maintainer has signed off on the changes and the issue was assigned to me
- [ ] All newly added code is adequately covered by tests
- [ ] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes _OR_ no documentation changes are required.

## Changes

<!-- describe the changes you made. -->

---
Please upvote :+1: this pull request if you are interested in it.