### PR TITLE
docs: improve Grid/Padder/Rows widget docs

### DIFF
--- a/docs/input/widgets/grid.md
+++ b/docs/input/widgets/grid.md
@@ -33,6 +33,22 @@ grid.AddRow(new string[]{"Row 1", "Row 2", "Row 3"});
 AnsiConsole.Write(grid);
 ```
 
+### Configure columns
+
+```csharp
+var grid = new Grid();
+
+// Add columns with specific configuration
+grid.AddColumns(
+    new GridColumn { Alignment = Justify.Left },
+    new GridColumn { Alignment = Justify.Center },
+    new GridColumn { Alignment = Justify.Right, Width = 12, NoWrap = true });
+
+grid.AddRow("Left", "Center", "Right");
+
+AnsiConsole.Write(grid);
+```
+
 ### Align and style items within cells
 
 ```csharp

--- a/docs/input/widgets/padder.md
+++ b/docs/input/widgets/padder.md
@@ -37,8 +37,22 @@ grid.AddColumn();
 
 grid.AddRow(pad_I, pad_II, pad_III);
 
-// Write grid and it's padded contents to the Console
+// Write grid and its padded contents to the Console
 AnsiConsole.Write(grid);
+```
+
+### Set padding and expand
+
+```csharp
+var panel = new Panel("Padded panel");
+
+var paddedPanel = new Padder(panel)
+{
+    Padding = new Padding(2, 1, 2, 1),
+    Expand = true,
+};
+
+AnsiConsole.Write(paddedPanel);
 ```
 
 ### Padding element within a padded element
@@ -61,7 +75,7 @@ grid.AddColumn();
 grid.AddRow(pad_I, pad_II);
 
 // Apply horizontal and vertical padding on the grid
-var paddedGrid = new Padder(grid).Padding(4,1);
+var paddedGrid = new Padder(grid).Padding(4, 1);
 
 // Write the padded grid to the Console
 AnsiConsole.Write(paddedGrid);

--- a/docs/input/widgets/rows.md
+++ b/docs/input/widgets/rows.md
@@ -1,6 +1,6 @@
 Title: Rows
 Order: 20
-Description: "Use **Rows** to render widgets in horiztonal rows to the console."
+Description: "Use **Rows** to render widgets in horizontal rows to the console."
 Highlights:
     - Custom colors
     - Labels
@@ -22,6 +22,17 @@ Use `Rows` to render widgets in horizontal rows to the console.
 AnsiConsole.Write(new Rows(
             new Text("Item 1"),
             new Text("Item 2")
+        ));
+```
+
+### Mix widgets
+
+```csharp
+// Rows can contain any IRenderable widgets
+AnsiConsole.Write(new Rows(
+            new Markup("[bold]Title[/]"),
+            new Rule(),
+            new Panel("Content")
         ));
 ```
 


### PR DESCRIPTION
This adds a few missing/handy examples to the widget docs and fixes a couple of small typos.

- `Grid`: add a column configuration example (`GridColumn` alignment/width/nowrap).
- `Padder`: add an example showing explicit `Padding` + `Expand`, and fix “its” wording.
- `Rows`: add an example showing mixing different widgets, and fix “horizontal” typo.

Tested:
- `dotnet build docs/Docs.csproj -c Release`

Fixes #752
Fixes #753
Fixes #754