### PR TITLE
Fixes problems with extension blocks and `params` keyword

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,12 +17,6 @@
     <PolyArgumentExceptions>true</PolyArgumentExceptions>
   </PropertyGroup>
 
-  <!-- Due to a bug in the .NET SDK (10.0.101), a false positive CS8620 warning is emitted -->
-  <!-- when "params" are used together with extension blocks -->
-  <PropertyGroup>
-    <NoWarn>$(NoWarn);CS8620</NoWarn>
-  </PropertyGroup>
-
   <!-- Earlier (<10.0.100) SDK throws on extension blocks -->
   <PropertyGroup Condition="'$(TargetFramework)' != 'net10.0'">
     <NoWarn>$(NoWarn);AD0001</NoWarn>

--- a/src/Spectre.Console/AnsiConsole.cs
+++ b/src/Spectre.Console/AnsiConsole.cs
@@ -66,3 +66,98 @@ public static partial class AnsiConsole
         return _factory.Create(settings);
     }
 }
+
+// TODO: This is here temporary due to a bug in the .NET SDK
+// See issue: https://github.com/dotnet/roslyn/issues/80024
+public static partial class AnsiConsole
+{
+    /// <summary>
+    /// Writes the text representation of the specified array of objects,
+    /// to the console using the specified format information.
+    /// </summary>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void Write(string format, params object[] args)
+    {
+        Write(CultureInfo.CurrentCulture, format, args);
+    }
+
+    /// <summary>
+    /// Writes the text representation of the specified array of objects,
+    /// to the console using the specified format information.
+    /// </summary>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void Write(IFormatProvider provider, string format, params object[] args)
+    {
+        Console.Write(string.Format(provider, format, args), CurrentStyle);
+    }
+
+    /// <summary>
+    /// Writes the text representation of the specified array of objects,
+    /// followed by the current line terminator, to the console
+    /// using the specified format information.
+    /// </summary>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void WriteLine(string format, params object[] args)
+    {
+        WriteLine(CultureInfo.CurrentCulture, format, args);
+    }
+
+    /// <summary>
+    /// Writes the text representation of the specified array of objects,
+    /// followed by the current line terminator, to the console
+    /// using the specified format information.
+    /// </summary>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void WriteLine(IFormatProvider provider, string format, params object[] args)
+    {
+        Console.WriteLine(string.Format(provider, format, args), CurrentStyle);
+    }
+
+    /// <summary>
+    /// Writes the specified markup to the console.
+    /// </summary>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void Markup(string format, params object[] args)
+    {
+        Console.Markup(format, args);
+    }
+
+    /// <summary>
+    /// Writes the specified markup to the console.
+    /// </summary>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void Markup(IFormatProvider provider, string format, params object[] args)
+    {
+        Console.Markup(provider, format, args);
+    }
+
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// </summary>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void MarkupLine(string format, params object[] args)
+    {
+        Console.MarkupLine(format, args);
+    }
+
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// </summary>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void MarkupLine(IFormatProvider provider, string format, params object[] args)
+    {
+        Console.MarkupLine(provider, format, args);
+    }
+}

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Markup.cs
@@ -2,6 +2,64 @@ namespace Spectre.Console;
 
 public static partial class AnsiConsoleExtensions
 {
+    /// <summary>
+    /// Writes the specified markup to the console.
+    /// </summary>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void Markup(this IAnsiConsole console, string format, params object[] args)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        Markup(console, CultureInfo.CurrentCulture, format, args);
+    }
+
+    /// <summary>
+    /// Writes the specified markup to the console.
+    /// </summary>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void Markup(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        Markup(console, string.Format(provider, format, args));
+    }
+
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// </summary>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void MarkupLine(this IAnsiConsole console, string format, params object[] args)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        MarkupLine(console, CultureInfo.CurrentCulture, format, args);
+    }
+
+    /// <summary>
+    /// Writes the specified markup, followed by the current line terminator, to the console.
+    /// </summary>
+    /// <param name="console">The console to write to.</param>
+    /// <param name="provider">An object that supplies culture-specific formatting information.</param>
+    /// <param name="format">A composite format string.</param>
+    /// <param name="args">An array of objects to write.</param>
+    public static void MarkupLine(this IAnsiConsole console, IFormatProvider provider, string format, params object[] args)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        Markup(console, provider, format + Environment.NewLine, args);
+    }
+
     extension(AnsiConsole)
     {
         /// <summary>
@@ -11,16 +69,6 @@ public static partial class AnsiConsoleExtensions
         public static void Markup(string value)
         {
             AnsiConsole.Console.Markup(value);
-        }
-
-        /// <summary>
-        /// Writes the specified markup to the console.
-        /// </summary>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void Markup(string format, params object[] args)
-        {
-            AnsiConsole.Console.Markup(format, args);
         }
 
         /// <summary>
@@ -39,17 +87,6 @@ public static partial class AnsiConsoleExtensions
         public static void MarkupInterpolated(FormattableString value)
         {
             AnsiConsole.Console.MarkupInterpolated(value);
-        }
-
-        /// <summary>
-        /// Writes the specified markup to the console.
-        /// </summary>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void Markup(IFormatProvider provider, string format, params object[] args)
-        {
-            AnsiConsole.Console.Markup(provider, format, args);
         }
 
         /// <summary>
@@ -82,16 +119,6 @@ public static partial class AnsiConsoleExtensions
 
         /// <summary>
         /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// </summary>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void MarkupLine(string format, params object[] args)
-        {
-            AnsiConsole.Console.MarkupLine(format, args);
-        }
-
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
         /// <para/>
         /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
         /// </summary>
@@ -106,17 +133,6 @@ public static partial class AnsiConsoleExtensions
         public static void MarkupLineInterpolated(FormattableString value)
         {
             AnsiConsole.Console.MarkupLineInterpolated(value);
-        }
-
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// </summary>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void MarkupLine(IFormatProvider provider, string format, params object[] args)
-        {
-            AnsiConsole.Console.MarkupLine(provider, format, args);
         }
 
         /// <summary>
@@ -144,16 +160,6 @@ public static partial class AnsiConsoleExtensions
     {
         /// <summary>
         /// Writes the specified markup to the console.
-        /// </summary>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public void Markup(string format, params object[] args)
-        {
-            Markup(console, CultureInfo.CurrentCulture, format, args);
-        }
-
-        /// <summary>
-        /// Writes the specified markup to the console.
         /// <para/>
         /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
         /// </summary>
@@ -168,17 +174,6 @@ public static partial class AnsiConsoleExtensions
         public void MarkupInterpolated(FormattableString value)
         {
             MarkupInterpolated(console, CultureInfo.CurrentCulture, value);
-        }
-
-        /// <summary>
-        /// Writes the specified markup to the console.
-        /// </summary>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public void Markup(IFormatProvider provider, string format, params object[] args)
-        {
-            Markup(console, string.Format(provider, format, args));
         }
 
         /// <summary>
@@ -211,16 +206,6 @@ public static partial class AnsiConsoleExtensions
 
         /// <summary>
         /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// </summary>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public void MarkupLine(string format, params object[] args)
-        {
-            MarkupLine(console, CultureInfo.CurrentCulture, format, args);
-        }
-
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
         /// <para/>
         /// All interpolation holes which contain a string are automatically escaped so you must not call <see cref="StringExtensions.EscapeMarkup"/>.
         /// </summary>
@@ -244,17 +229,6 @@ public static partial class AnsiConsoleExtensions
         public void MarkupLine(string value)
         {
             Markup(console, value + Environment.NewLine);
-        }
-
-        /// <summary>
-        /// Writes the specified markup, followed by the current line terminator, to the console.
-        /// </summary>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public void MarkupLine(IFormatProvider provider, string format, params object[] args)
-        {
-            Markup(console, provider, format + Environment.NewLine, args);
         }
 
         /// <summary>

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Write.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Write.cs
@@ -10,7 +10,7 @@ public static partial class AnsiConsoleExtensions
         /// <param name="value">The value to write.</param>
         public static void Write(string value)
         {
-            Write(value, AnsiConsole.CurrentStyle);
+            AnsiConsole.Write(value, AnsiConsole.CurrentStyle);
         }
 
         /// <summary>
@@ -218,29 +218,6 @@ public static partial class AnsiConsoleExtensions
             {
                 AnsiConsole.Console.Write(value[index].ToString(provider), AnsiConsole.CurrentStyle);
             }
-        }
-
-        /// <summary>
-        /// Writes the text representation of the specified array of objects,
-        /// to the console using the specified format information.
-        /// </summary>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void Write(string format, params object[] args)
-        {
-            Write(CultureInfo.CurrentCulture, format, args);
-        }
-
-        /// <summary>
-        /// Writes the text representation of the specified array of objects,
-        /// to the console using the specified format information.
-        /// </summary>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void Write(IFormatProvider provider, string format, params object[] args)
-        {
-            AnsiConsole.Console.Write(string.Format(provider, format, args), AnsiConsole.CurrentStyle);
         }
     }
 

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.WriteLine.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.WriteLine.cs
@@ -237,31 +237,6 @@ public static partial class AnsiConsoleExtensions
 
             AnsiConsole.Console.WriteLine();
         }
-
-        /// <summary>
-        /// Writes the text representation of the specified array of objects,
-        /// followed by the current line terminator, to the console
-        /// using the specified format information.
-        /// </summary>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void WriteLine(string format, params object[] args)
-        {
-            WriteLine(CultureInfo.CurrentCulture, format, args);
-        }
-
-        /// <summary>
-        /// Writes the text representation of the specified array of objects,
-        /// followed by the current line terminator, to the console
-        /// using the specified format information.
-        /// </summary>
-        /// <param name="provider">An object that supplies culture-specific formatting information.</param>
-        /// <param name="format">A composite format string.</param>
-        /// <param name="args">An array of objects to write.</param>
-        public static void WriteLine(IFormatProvider provider, string format, params object[] args)
-        {
-            AnsiConsole.Console.WriteLine(string.Format(provider, format, args), AnsiConsole.CurrentStyle);
-        }
     }
 
     extension(IAnsiConsole console)

--- a/src/Spectre.Console/IHasTreeNodes.cs
+++ b/src/Spectre.Console/IHasTreeNodes.cs
@@ -16,6 +16,54 @@ public interface IHasTreeNodes
 /// </summary>
 public static class HasTreeNodeExtensions
 {
+    /// <summary>
+    /// Add multiple tree nodes.
+    /// </summary>
+    /// <param name="obj">The object to add the tree node to.</param>
+    /// <param name="nodes">The tree nodes to add.</param>
+    public static void AddNodes(this IHasTreeNodes obj, params string[] nodes)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(obj);
+        ArgumentNullException.ThrowIfNull(nodes);
+
+        obj.Nodes.AddRange(nodes.Select(node => new TreeNode(new Markup(node))));
+    }
+
+    /// <summary>
+    /// Add multiple tree nodes.
+    /// </summary>
+    /// <param name="obj">The object to add the tree node to.</param>
+    /// <param name="nodes">The tree nodes to add.</param>
+    public static void AddNodes(this IHasTreeNodes obj, params IRenderable[] nodes)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(obj);
+        ArgumentNullException.ThrowIfNull(nodes);
+
+        obj.Nodes.AddRange(nodes.Select(node => new TreeNode(node)));
+    }
+
+    /// <summary>
+    /// Add multiple tree nodes.
+    /// </summary>
+    /// <param name="obj">The object to add the tree node to.</param>
+    /// <param name="nodes">The tree nodes to add.</param>
+    public static void AddNodes(this IHasTreeNodes obj, params TreeNode[] nodes)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(obj);
+        ArgumentNullException.ThrowIfNull(nodes);
+
+        obj.Nodes.AddRange(nodes);
+    }
+
     /// <param name="obj">The object to add the tree node to.</param>
     /// <typeparam name="T">An object with tree nodes.</typeparam>
     extension<T>(T obj) where T : IHasTreeNodes
@@ -27,11 +75,7 @@ public static class HasTreeNodeExtensions
         /// <returns>The added tree node.</returns>
         public TreeNode AddNode(string markup)
         {
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
+            ArgumentNullException.ThrowIfNull(obj);
             ArgumentNullException.ThrowIfNull(markup);
 
             return AddNode(obj, new Markup(markup));
@@ -44,11 +88,7 @@ public static class HasTreeNodeExtensions
         /// <returns>The added tree node.</returns>
         public TreeNode AddNode(IRenderable renderable)
         {
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
+            ArgumentNullException.ThrowIfNull(obj);
             ArgumentNullException.ThrowIfNull(renderable);
 
             var node = new TreeNode(renderable);
@@ -63,11 +103,7 @@ public static class HasTreeNodeExtensions
         /// <returns>The added tree node.</returns>
         public TreeNode AddNode(TreeNode node)
         {
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
+            ArgumentNullException.ThrowIfNull(obj);
             ArgumentNullException.ThrowIfNull(node);
 
             obj.Nodes.Add(node);
@@ -78,48 +114,12 @@ public static class HasTreeNodeExtensions
         /// Add multiple tree nodes.
         /// </summary>
         /// <param name="nodes">The tree nodes to add.</param>
-        public void AddNodes(params string[] nodes)
-        {
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
-            ArgumentNullException.ThrowIfNull(nodes);
-
-            obj.Nodes.AddRange(nodes.Select(node => new TreeNode(new Markup(node))));
-        }
-
-        /// <summary>
-        /// Add multiple tree nodes.
-        /// </summary>
-        /// <param name="nodes">The tree nodes to add.</param>
         public void AddNodes(IEnumerable<string> nodes)
         {
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
+            ArgumentNullException.ThrowIfNull(obj);
             ArgumentNullException.ThrowIfNull(nodes);
 
             obj.Nodes.AddRange(nodes.Select(node => new TreeNode(new Markup(node))));
-        }
-
-        /// <summary>
-        /// Add multiple tree nodes.
-        /// </summary>
-        /// <param name="nodes">The tree nodes to add.</param>
-        public void AddNodes(params IRenderable[] nodes)
-        {
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
-            ArgumentNullException.ThrowIfNull(nodes);
-
-            obj.Nodes.AddRange(nodes.Select(node => new TreeNode(node)));
         }
 
         /// <summary>
@@ -128,11 +128,7 @@ public static class HasTreeNodeExtensions
         /// <param name="nodes">The tree nodes to add.</param>
         public void AddNodes(IEnumerable<IRenderable> nodes)
         {
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
+            ArgumentNullException.ThrowIfNull(obj);
             ArgumentNullException.ThrowIfNull(nodes);
 
             obj.Nodes.AddRange(nodes.Select(node => new TreeNode(node)));
@@ -142,29 +138,9 @@ public static class HasTreeNodeExtensions
         /// Add multiple tree nodes.
         /// </summary>
         /// <param name="nodes">The tree nodes to add.</param>
-        public void AddNodes(params TreeNode[] nodes)
-        {
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
-            ArgumentNullException.ThrowIfNull(nodes);
-
-            obj.Nodes.AddRange(nodes);
-        }
-
-        /// <summary>
-        /// Add multiple tree nodes.
-        /// </summary>
-        /// <param name="nodes">The tree nodes to add.</param>
         public void AddNodes(IEnumerable<TreeNode> nodes)
         {
-            if (obj is null)
-            {
-                throw new ArgumentNullException(nameof(obj));
-            }
-
+            ArgumentNullException.ThrowIfNull(obj);
             ArgumentNullException.ThrowIfNull(nodes);
 
             obj.Nodes.AddRange(nodes);

--- a/src/Spectre.Console/Live/Progress/Progress.cs
+++ b/src/Spectre.Console/Live/Progress/Progress.cs
@@ -171,31 +171,34 @@ public sealed class Progress
 /// </summary>
 public static class ProgressExtensions
 {
+    /// <summary>
+    /// Sets the columns to be used for an <see cref="Progress"/> instance.
+    /// </summary>
+    /// <param name="progress">The <see cref="Progress"/> instance.</param>
+    /// <param name="columns">The columns to use.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Progress Columns(this Progress progress, params ProgressColumn[] columns)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(progress);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        if (!columns.Any())
+        {
+            throw new InvalidOperationException("At least one column must be specified.");
+        }
+
+        progress.Columns.Clear();
+        progress.Columns.AddRange(columns);
+
+        return progress;
+    }
+
     /// <param name="progress">The <see cref="Progress"/> instance.</param>
     extension(Progress progress)
     {
-        /// <summary>
-        /// Sets the columns to be used for an <see cref="Progress"/> instance.
-        /// </summary>
-        /// <param name="columns">The columns to use.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public Progress Columns(params ProgressColumn[] columns)
-        {
-            ArgumentNullException.ThrowIfNull(progress);
-
-            ArgumentNullException.ThrowIfNull(columns);
-
-            if (!columns.Any())
-            {
-                throw new InvalidOperationException("At least one column must be specified.");
-            }
-
-            progress.Columns.Clear();
-            progress.Columns.AddRange(columns);
-
-            return progress;
-        }
-
         /// <summary>
         /// Sets an optional hook to intercept rendering.
         /// </summary>
@@ -204,7 +207,6 @@ public static class ProgressExtensions
         public Progress UseRenderHook(Func<IRenderable, IReadOnlyList<ProgressTask>, IRenderable> renderHook)
         {
             progress.RenderHook = renderHook;
-
             return progress;
         }
 
@@ -217,9 +219,7 @@ public static class ProgressExtensions
         public Progress AutoRefresh(bool enabled)
         {
             ArgumentNullException.ThrowIfNull(progress);
-
             progress.AutoRefresh = enabled;
-
             return progress;
         }
 
@@ -233,9 +233,7 @@ public static class ProgressExtensions
         public Progress AutoClear(bool enabled)
         {
             ArgumentNullException.ThrowIfNull(progress);
-
             progress.AutoClear = enabled;
-
             return progress;
         }
 
@@ -249,9 +247,7 @@ public static class ProgressExtensions
         public Progress HideCompleted(bool enabled)
         {
             ArgumentNullException.ThrowIfNull(progress);
-
             progress.HideCompleted = enabled;
-
             return progress;
         }
     }

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -95,7 +95,8 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
         // Create the list prompt
         var prompt = new ListPrompt<T>(console, this);
         var converter = Converter ?? TypeConverterHelper.ConvertToString;
-        var result = await prompt.Show(Tree, converter, Mode, false, false, PageSize, WrapAround, cancellationToken).ConfigureAwait(false);
+        var result = await prompt.Show(Tree, converter, Mode, false, false, PageSize, WrapAround, cancellationToken)
+            .ConfigureAwait(false);
 
         if (Mode == SelectionMode.Leaf)
         {
@@ -248,9 +249,12 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
             var style = current ? highlightStyle : Style.Plain;
 
             var indent = new string(' ', item.Node.Depth * 2);
-            var prompt = item.Index == cursorIndex ? ListPromptConstants.Arrow : new string(' ', ListPromptConstants.Arrow.Length);
+            var prompt = item.Index == cursorIndex
+                ? ListPromptConstants.Arrow
+                : new string(' ', ListPromptConstants.Arrow.Length);
 
-            var text = (Converter ?? TypeConverterHelper.ConvertToString)?.Invoke(item.Node.Data) ?? item.Node.Data.ToString() ?? "?";
+            var text = (Converter ?? TypeConverterHelper.ConvertToString)?.Invoke(item.Node.Data) ??
+                       item.Node.Data.ToString() ?? "?";
             if (current)
             {
                 text = text.RemoveMarkup().EscapeMarkup();
@@ -285,6 +289,56 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
 /// </summary>
 public static class MultiSelectionPromptExtensions
 {
+    /// <summary>
+    /// Adds multiple choices.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="choices">The choices to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static MultiSelectionPrompt<T> AddChoices<T>(
+        this MultiSelectionPrompt<T> obj,
+        params T[] choices) where T : notnull
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(obj);
+
+        foreach (var choice in choices)
+        {
+            obj.AddChoice(choice);
+        }
+
+        return obj;
+    }
+
+    /// <summary>
+    /// Adds multiple grouped choices.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="group">The group.</param>
+    /// <param name="choices">The choices to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static MultiSelectionPrompt<T> AddChoiceGroup<T>(
+        this MultiSelectionPrompt<T> obj,
+        T group, params T[] choices) where T : notnull
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(obj);
+
+        var root = obj.AddChoice(group);
+        foreach (var choice in choices)
+        {
+            root.AddChild(choice);
+        }
+
+        return obj;
+    }
+
     /// <param name="obj">The prompt.</param>
     /// <typeparam name="T">The prompt result type.</typeparam>
     extension<T>(MultiSelectionPrompt<T> obj) where T : notnull
@@ -325,23 +379,6 @@ public static class MultiSelectionPromptExtensions
         /// </summary>
         /// <param name="choices">The choices to add.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public MultiSelectionPrompt<T> AddChoices(params T[] choices)
-        {
-            ArgumentNullException.ThrowIfNull(obj);
-
-            foreach (var choice in choices)
-            {
-                obj.AddChoice(choice);
-            }
-
-            return obj;
-        }
-
-        /// <summary>
-        /// Adds multiple choices.
-        /// </summary>
-        /// <param name="choices">The choices to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
         public MultiSelectionPrompt<T> AddChoices(IEnumerable<T> choices)
         {
             ArgumentNullException.ThrowIfNull(obj);
@@ -361,25 +398,6 @@ public static class MultiSelectionPromptExtensions
         /// <param name="choices">The choices to add.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
         public MultiSelectionPrompt<T> AddChoiceGroup(T group, IEnumerable<T> choices)
-        {
-            ArgumentNullException.ThrowIfNull(obj);
-
-            var root = obj.AddChoice(group);
-            foreach (var choice in choices)
-            {
-                root.AddChild(choice);
-            }
-
-            return obj;
-        }
-
-        /// <summary>
-        /// Adds multiple grouped choices.
-        /// </summary>
-        /// <param name="group">The group.</param>
-        /// <param name="choices">The choices to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public MultiSelectionPrompt<T> AddChoiceGroup(T group, params T[] choices)
         {
             ArgumentNullException.ThrowIfNull(obj);
 

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -235,6 +235,55 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
 /// </summary>
 public static class SelectionPromptExtensions
 {
+    /// <summary>
+    /// Adds multiple choices.
+    /// </summary>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="choices">The choices to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static SelectionPrompt<T> AddChoices<T>(
+        this SelectionPrompt<T> obj,
+        params T[] choices) where T : notnull
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(obj);
+
+        foreach (var choice in choices)
+        {
+            obj.AddChoice(choice);
+        }
+
+        return obj;
+    }
+
+    /// <summary>
+    /// Adds multiple grouped choices.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="group">The group.</param>
+    /// <param name="choices">The choices to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static SelectionPrompt<T> AddChoiceGroup<T>(
+        this SelectionPrompt<T> obj,
+        T group, params T[] choices) where T : notnull
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(obj);
+
+        var root = obj.AddChoice(group);
+        foreach (var choice in choices)
+        {
+            root.AddChild(choice);
+        }
+
+        return obj;
+    }
+
     /// <param name="obj">The prompt.</param>
     /// <typeparam name="T">The prompt result type.</typeparam>
     extension<T>(SelectionPrompt<T> obj) where T : notnull
@@ -249,23 +298,6 @@ public static class SelectionPromptExtensions
             ArgumentNullException.ThrowIfNull(obj);
 
             obj.Mode = mode;
-            return obj;
-        }
-
-        /// <summary>
-        /// Adds multiple choices.
-        /// </summary>
-        /// <param name="choices">The choices to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public SelectionPrompt<T> AddChoices(params T[] choices)
-        {
-            ArgumentNullException.ThrowIfNull(obj);
-
-            foreach (var choice in choices)
-            {
-                obj.AddChoice(choice);
-            }
-
             return obj;
         }
 
@@ -293,25 +325,6 @@ public static class SelectionPromptExtensions
         /// <param name="choices">The choices to add.</param>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
         public SelectionPrompt<T> AddChoiceGroup(T group, IEnumerable<T> choices)
-        {
-            ArgumentNullException.ThrowIfNull(obj);
-
-            var root = obj.AddChoice(group);
-            foreach (var choice in choices)
-            {
-                root.AddChild(choice);
-            }
-
-            return obj;
-        }
-
-        /// <summary>
-        /// Adds multiple grouped choices.
-        /// </summary>
-        /// <param name="group">The group.</param>
-        /// <param name="choices">The choices to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public SelectionPrompt<T> AddChoiceGroup(T group, params T[] choices)
         {
             ArgumentNullException.ThrowIfNull(obj);
 

--- a/src/Spectre.Console/Widgets/Grid.cs
+++ b/src/Spectre.Console/Widgets/Grid.cs
@@ -146,6 +146,46 @@ public sealed class Grid : JustInTimeRenderable, IExpandable, IAlignable
 /// </summary>
 public static class GridExtensions
 {
+    /// <summary>
+    /// Adds a new row to the grid.
+    /// </summary>
+    /// <param name="grid">The grid to add the column to.</param>
+    /// <param name="columns">The columns to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Grid AddRow(this Grid grid, params string[] columns)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(grid);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        grid.AddRow(columns.Select(column => new Markup(column)).ToArray<IRenderable>());
+        return grid;
+    }
+
+    /// <summary>
+    /// Adds a column to the grid.
+    /// </summary>
+    /// <param name="grid">The grid to add the column to.</param>
+    /// <param name="columns">The columns to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Grid AddColumns(this Grid grid, params GridColumn[] columns)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(grid);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        foreach (var column in columns)
+        {
+            grid.AddColumn(column);
+        }
+
+        return grid;
+    }
+
     /// <param name="grid">The grid to add the column to.</param>
     extension(Grid grid)
     {
@@ -167,25 +207,6 @@ public static class GridExtensions
         }
 
         /// <summary>
-        /// Adds a column to the grid.
-        /// </summary>
-        /// <param name="columns">The columns to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public Grid AddColumns(params GridColumn[] columns)
-        {
-            ArgumentNullException.ThrowIfNull(grid);
-
-            ArgumentNullException.ThrowIfNull(columns);
-
-            foreach (var column in columns)
-            {
-                grid.AddColumn(column);
-            }
-
-            return grid;
-        }
-
-        /// <summary>
         /// Adds an empty row to the grid.
         /// </summary>
         /// <returns>The same instance so that multiple calls can be chained.</returns>
@@ -197,21 +218,6 @@ public static class GridExtensions
             Enumerable.Range(0, grid.Columns.Count).ForEach(index => columns[index] = Text.Empty);
             grid.AddRow(columns);
 
-            return grid;
-        }
-
-        /// <summary>
-        /// Adds a new row to the grid.
-        /// </summary>
-        /// <param name="columns">The columns to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public Grid AddRow(params string[] columns)
-        {
-            ArgumentNullException.ThrowIfNull(grid);
-
-            ArgumentNullException.ThrowIfNull(columns);
-
-            grid.AddRow(columns.Select(column => new Markup(column)).ToArray());
             return grid;
         }
 

--- a/src/Spectre.Console/Widgets/Table/Table.cs
+++ b/src/Spectre.Console/Widgets/Table/Table.cs
@@ -168,28 +168,121 @@ public sealed class Table : Renderable, IHasTableBorder, IExpandable, IAlignable
 /// </summary>
 public static class TableExtensions
 {
+    /// <summary>
+    /// Adds multiple columns to the table.
+    /// </summary>
+    /// <param name="table">The table to add the column to.</param>
+    /// <param name="columns">The columns to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Table AddColumns(this Table table, params TableColumn[] columns)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        foreach (var column in columns)
+        {
+            table.AddColumn(column);
+        }
+
+        return table;
+    }
+
+    /// <summary>
+    /// Adds a row to the table.
+    /// </summary>
+    /// <param name="table">The table to add the column to.</param>
+    /// <param name="columns">The row columns to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Table AddRow(this Table table, params IRenderable[] columns)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(table);
+
+        return table.AddRow((IEnumerable<IRenderable>)columns);
+    }
+
+    /// <summary>
+    /// Adds multiple columns to the table.
+    /// </summary>
+    /// <param name="table">The table to add the column to.</param>
+    /// <param name="columns">The columns to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Table AddColumns(this Table table, params string[] columns)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        foreach (var column in columns)
+        {
+            AddColumn(table, column);
+        }
+
+        return table;
+    }
+
+    /// <summary>
+    /// Adds a row to the table.
+    /// </summary>
+    /// <param name="table">The table to add the column to.</param>
+    /// <param name="columns">The row columns to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Table AddRow(this Table table, params string[] columns)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(table);
+        ArgumentNullException.ThrowIfNull(columns);
+
+        table.AddRow(columns.Select(column => new Markup(column)).ToArray());
+        return table;
+    }
+
+    /// <summary>
+    /// Inserts a row in the table at the specified index.
+    /// </summary>
+    /// <param name="table">The table to add the column to.</param>
+    /// <param name="index">The index to insert the row at.</param>
+    /// <param name="columns">The row columns to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Table InsertRow(this Table table, int index, params IRenderable[] columns)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(table);
+
+        return InsertRow(table, index, (IEnumerable<IRenderable>)columns);
+    }
+
+    /// <summary>
+    /// Inserts a row in the table at the specified index.
+    /// </summary>
+    /// <param name="table">The table to add the column to.</param>
+    /// <param name="index">The index to insert the row at.</param>
+    /// <param name="columns">The row columns to add.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Table InsertRow(this Table table, int index, params string[] columns)
+    {
+        // TODO: This is here temporary due to a bug in the .NET SDK
+        // See issue: https://github.com/dotnet/roslyn/issues/80024
+
+        ArgumentNullException.ThrowIfNull(table);
+
+        return InsertRow(table, index, columns.Select(column => new Markup(column)));
+    }
+
     /// <param name="table">The table to add the column to.</param>
     extension(Table table)
     {
-        /// <summary>
-        /// Adds multiple columns to the table.
-        /// </summary>
-        /// <param name="columns">The columns to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public Table AddColumns(params TableColumn[] columns)
-        {
-            ArgumentNullException.ThrowIfNull(table);
-
-            ArgumentNullException.ThrowIfNull(columns);
-
-            foreach (var column in columns)
-            {
-                table.AddColumn(column);
-            }
-
-            return table;
-        }
-
         /// <summary>
         /// Adds a row to the table.
         /// </summary>
@@ -203,18 +296,6 @@ public static class TableExtensions
 
             table.Rows.Add(new TableRow(columns));
             return table;
-        }
-
-        /// <summary>
-        /// Adds a row to the table.
-        /// </summary>
-        /// <param name="columns">The row columns to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public Table AddRow(params IRenderable[] columns)
-        {
-            ArgumentNullException.ThrowIfNull(table);
-
-            return table.AddRow((IEnumerable<IRenderable>)columns);
         }
 
         /// <summary>
@@ -247,40 +328,6 @@ public static class TableExtensions
             configure?.Invoke(tableColumn);
 
             table.AddColumn(tableColumn);
-            return table;
-        }
-
-        /// <summary>
-        /// Adds multiple columns to the table.
-        /// </summary>
-        /// <param name="columns">The columns to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public Table AddColumns(params string[] columns)
-        {
-            ArgumentNullException.ThrowIfNull(table);
-
-            ArgumentNullException.ThrowIfNull(columns);
-
-            foreach (var column in columns)
-            {
-                AddColumn(table, column);
-            }
-
-            return table;
-        }
-
-        /// <summary>
-        /// Adds a row to the table.
-        /// </summary>
-        /// <param name="columns">The row columns to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public Table AddRow(params string[] columns)
-        {
-            ArgumentNullException.ThrowIfNull(table);
-
-            ArgumentNullException.ThrowIfNull(columns);
-
-            table.AddRow(columns.Select(column => new Markup(column)).ToArray());
             return table;
         }
 
@@ -334,32 +381,6 @@ public static class TableExtensions
             table.Rows.Update(rowIndex, columnIndex, new Markup(cellData));
 
             return table;
-        }
-
-        /// <summary>
-        /// Inserts a row in the table at the specified index.
-        /// </summary>
-        /// <param name="index">The index to insert the row at.</param>
-        /// <param name="columns">The row columns to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public Table InsertRow(int index, params IRenderable[] columns)
-        {
-            ArgumentNullException.ThrowIfNull(table);
-
-            return InsertRow(table, index, (IEnumerable<IRenderable>)columns);
-        }
-
-        /// <summary>
-        /// Inserts a row in the table at the specified index.
-        /// </summary>
-        /// <param name="index">The index to insert the row at.</param>
-        /// <param name="columns">The row columns to add.</param>
-        /// <returns>The same instance so that multiple calls can be chained.</returns>
-        public Table InsertRow(int index, params string[] columns)
-        {
-            ArgumentNullException.ThrowIfNull(table);
-
-            return InsertRow(table, index, columns.Select(column => new Markup(column)));
         }
 
         /// <summary>


### PR DESCRIPTION
There is currently a bug in the .NET SDK that will emit false CS8620
warnings for extension block members using the `params` keyword.

This commit fixes the warning by converting these methods to
old-fashioned extension methods.

For more information see: https://github.com/dotnet/roslyn/issues/80024