### PR TITLE
docs: add XML documentation to TableRendererContext.

### DIFF
--- a/src/Spectre.Console/Widgets/Table/TableRendererContext.cs
+++ b/src/Spectre.Console/Widgets/Table/TableRendererContext.cs
@@ -7,11 +7,34 @@ internal sealed class TableRendererContext : TableAccessor
 
     public override IReadOnlyList<TableRow> Rows => _rows;
 
+    /// <summary>
+    /// Gets the table border.
+    /// </summary>
     public TableBorder Border { get; }
+
+    /// <summary>
+    /// Gets the style of the table border.
+    /// </summary>
     public Style BorderStyle { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the border should be shown.
+    /// </summary>
     public bool ShowBorder { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether row separators should be shown.
+    /// </summary>
     public bool ShowRowSeparators { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the table has any rows.
+    /// </summary>
     public bool HasRows { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the table has any footers.
+    /// </summary>
     public bool HasFooters { get; }
 
     /// <summary>


### PR DESCRIPTION
## Description
Added missing XML documentation summaries for the `TableRendererContext` class properties. 
This update improves code readability and IntelliSense support for internal development, with no changes to the logic.

## Checklist
- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] All existing tests are still running without errors
- [x] The documentation was modified to reflect the changes