### PR TITLE
Fix interactive console detection when output is redirected (#1810)

### DIFF
--- a/src/Spectre.Console.Tests/Unit/InteractionDetectorTests.cs
+++ b/src/Spectre.Console.Tests/Unit/InteractionDetectorTests.cs
@@ -1,0 +1,40 @@
+namespace Spectre.Console.Tests.Unit;
+
+public sealed class InteractionDetectorTests
+{
+    [Fact]
+    public void Should_Not_Be_Interactive_When_Output_Is_Redirected()
+    {
+        var result = InteractionDetector.IsInteractive(
+            InteractionSupport.Detect,
+            isInputRedirected: false,
+            isOutputRedirected: true,
+            isErrorRedirected: false);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_Not_Be_Interactive_When_Error_Is_Redirected()
+    {
+        var result = InteractionDetector.IsInteractive(
+            InteractionSupport.Detect,
+            isInputRedirected: false,
+            isOutputRedirected: false,
+            isErrorRedirected: true);
+
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_Be_Interactive_When_Nothing_Is_Redirected()
+    {
+        var result = InteractionDetector.IsInteractive(
+            InteractionSupport.Detect,
+            isInputRedirected: false,
+            isOutputRedirected: false,
+            isErrorRedirected: false);
+
+        result.ShouldBeTrue();
+    }
+}

--- a/src/Spectre.Console/InteractionDetector.cs
+++ b/src/Spectre.Console/InteractionDetector.cs
@@ -4,11 +4,28 @@ internal static class InteractionDetector
 {
     public static bool IsInteractive(InteractionSupport interaction)
     {
+        return IsInteractive(
+            interaction,
+            System.Console.IsInputRedirected,
+            System.Console.IsOutputRedirected,
+            System.Console.IsErrorRedirected);
+    }
+
+    internal static bool IsInteractive(
+        InteractionSupport interaction,
+        bool isInputRedirected,
+        bool isOutputRedirected,
+        bool isErrorRedirected)
+    {
         var interactive = interaction == InteractionSupport.Yes;
+
         if (interaction == InteractionSupport.Detect)
         {
-            // TODO: We need a better way of checking this
-            interactive = !System.Console.IsInputRedirected;
+            // Consider the console interactive only when input, output and error are not redirected.
+            interactive =
+                !isInputRedirected &&
+                !isOutputRedirected &&
+                !isErrorRedirected;
         }
 
         return interactive;


### PR DESCRIPTION
Fixes #1810

- [x] I have read the Contribution Guidelines
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

## Changes

Improve interactive console detection when output is redirected.

Previously "InteractionDetector" only checked "Console.IsInputRedirected"
when determining if the console was interactive.

This caused "Status" and "Progress" renderers to treat redirected output
(e.g. "command > file.log") as interactive, resulting in ANSI escape
sequences being written to files.

This change updates the detection logic to also consider:

- "Console.IsOutputRedirected"
- "Console.IsErrorRedirected"

Additionally, unit tests were added to verify the behavior.