### PR TITLE
Disable ANSI when stdout or stderr is redirected

### DIFF
--- a/src/Spectre.Console.Ansi/AnsiDetector.cs
+++ b/src/Spectre.Console.Ansi/AnsiDetector.cs
@@ -27,11 +27,34 @@ internal static class AnsiDetector
 
     public static (bool Ansi, bool Legacy) Detect(TextWriter buffer, AnsiSupport ansi)
     {
+        return Detect(
+            buffer,
+            ansi,
+            System.Console.IsOutputRedirected,
+            System.Console.IsErrorRedirected);
+    }
+
+    internal static (bool Ansi, bool Legacy) Detect(
+        TextWriter buffer,
+        AnsiSupport ansi,
+        bool isOutputRedirected,
+        bool isErrorRedirected)
+    {
         var supportsAnsi = ansi == AnsiSupport.Yes;
         var legacyConsole = false;
 
         if (ansi == AnsiSupport.Detect)
         {
+            if (buffer.IsStandardOut() && isOutputRedirected)
+            {
+                return (false, false);
+            }
+
+            if (buffer.IsStandardError() && isErrorRedirected)
+            {
+                return (false, false);
+            }
+
             (supportsAnsi, legacyConsole) = AnsiDetector.Detect(buffer.IsStandardError(), true);
             return (supportsAnsi, legacyConsole);
         }

--- a/src/Spectre.Console.Ansi/Spectre.Console.Ansi.csproj
+++ b/src/Spectre.Console.Ansi/Spectre.Console.Ansi.csproj
@@ -30,4 +30,8 @@
     <AdditionalFiles Include="Data\colors.json" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Spectre.Console.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Spectre.Console.Tests/Unit/AnsiDetectorTests.cs
+++ b/src/Spectre.Console.Tests/Unit/AnsiDetectorTests.cs
@@ -1,0 +1,42 @@
+namespace Spectre.Console.Tests.Unit;
+
+public sealed class AnsiDetectorTests
+{
+    [Fact]
+    public void Should_Not_Support_Ansi_When_Output_Is_Redirected()
+    {
+        var result = AnsiDetector.Detect(
+            global::System.Console.Out,
+            AnsiSupport.Detect,
+            isOutputRedirected: true,
+            isErrorRedirected: false);
+
+        result.Ansi.ShouldBeFalse();
+        result.Legacy.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_Not_Support_Ansi_When_Error_Is_Redirected()
+    {
+        var result = AnsiDetector.Detect(
+            global::System.Console.Error,
+            AnsiSupport.Detect,
+            isOutputRedirected: false,
+            isErrorRedirected: true);
+
+        result.Ansi.ShouldBeFalse();
+        result.Legacy.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_Support_Ansi_When_Explicitly_Enabled_Even_If_Output_Is_Redirected()
+    {
+        var result = AnsiDetector.Detect(
+            global::System.Console.Out,
+            AnsiSupport.Yes,
+            isOutputRedirected: true,
+            isErrorRedirected: false);
+
+        result.Ansi.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Fixes #1790

- [x] I have read the Contribution Guidelines
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

## Changes

Disable ANSI output when standard output or standard error is redirected while using "AnsiSupport.Detect".

Previously ANSI detection could still return `true` when output was redirected to a file, which caused escape sequences to be written to the file.

This change disables ANSI when:

- standard output is redirected
- standard error is redirected

Explicit "AnsiSupport.Yes" behaviour remains unchanged.

Unit tests were added to verify the behaviour.