### PR TITLE
Fix Segment.SplitLines ignoring multiple line breaks

### DIFF
--- a/src/Spectre.Console.Tests/Unit/Rendering/SegmentTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Rendering/SegmentTests.cs
@@ -197,6 +197,41 @@ public sealed class SegmentTests
             lines[0][0].Text.ShouldBe("测试测"); // 6 cells
             lines[1][0].Text.ShouldBe("试"); // 2 cells
         }
+
+        [Fact]
+        [GitHubIssue("https://github.com/spectreconsole/spectre.console/issues/1785")]
+        public void Should_Respect_Multiple_Linebreaks_In_A_Segment()
+        {
+            // Given
+            var segments = new[]
+            {
+                new Segment("Foo\nBar"),
+                new Segment("Baz"),
+                new Segment("Qux\nTra\nLate"),
+                new Segment("Corgi"),
+            };
+
+            // When
+            var lines = Segment.SplitLines(segments, maxWidth: 80);
+
+            // Then
+            lines.Count.ShouldBe(4);
+
+            lines[0].Count.ShouldBe(1);
+            lines[0][0].Text.ShouldBe("Foo");
+
+            lines[1].Count.ShouldBe(3);
+            lines[1][0].Text.ShouldBe("Bar");
+            lines[1][1].Text.ShouldBe("Baz");
+            lines[1][2].Text.ShouldBe("Qux");
+
+            lines[2].Count.ShouldBe(1);
+            lines[2][0].Text.ShouldBe("Tra");
+
+            lines[3].Count.ShouldBe(2);
+            lines[3][0].Text.ShouldBe("Late");
+            lines[3][1].Text.ShouldBe("Corgi");
+        }
     }
 
     public sealed class TheSplitOverflowMethod

--- a/src/Spectre.Console/Rendering/Segment.cs
+++ b/src/Spectre.Console/Rendering/Segment.cs
@@ -273,7 +273,7 @@ public class Segment
                             line = [];
                         }
 
-                        text = string.Concat(parts.Skip(1).Take(parts.Length - 1));
+                        text = string.Join('\n', parts.Skip(1).Take(parts.Length - 1));
                     }
                     else
                     {


### PR DESCRIPTION
Fixes #1785

- [x] I have read the Contribution Guidelines
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

## Changes

Fix an issue in "Segment.SplitLines" where multiple line breaks inside a segment were not handled correctly.

Previously the implementation used: string.Concat(parts.Skip(1).Take(parts.Length - 1))
which removed the remaining line breaks and caused multiple lines to be merged into one.

This change replaces it with: string.Join('\n', parts.Skip(1).Take(parts.Length - 1))
so that remaining line breaks are preserved.

A unit test was added to reproduce and verify the behaviour described in the issue.