### PR TITLE
add default value to selection prompt and multiselection prompt

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -2324,6 +2324,8 @@
             where T :  notnull { }
         public static Spectre.Console.MultiSelectionPrompt<T> AddChoices<T>(this Spectre.Console.MultiSelectionPrompt<T> obj, T choice, System.Action<Spectre.Console.IMultiSelectionItem<T>> configurator)
             where T :  notnull { }
+        public static Spectre.Console.MultiSelectionPrompt<T> DefaultValue<T>(this Spectre.Console.MultiSelectionPrompt<T> obj, T? defaultValue)
+            where T :  notnull { }
         public static Spectre.Console.MultiSelectionPrompt<T> HighlightStyle<T>(this Spectre.Console.MultiSelectionPrompt<T> obj, Spectre.Console.Style highlightStyle)
             where T :  notnull { }
         public static Spectre.Console.MultiSelectionPrompt<T> InstructionsText<T>(this Spectre.Console.MultiSelectionPrompt<T> obj, string? text)
@@ -2355,6 +2357,7 @@
         public MultiSelectionPrompt(System.Collections.Generic.IEqualityComparer<T>? comparer = null) { }
         public System.Func<System.Collections.Generic.List<T>>? CancelResult { get; set; }
         public System.Func<T, string>? Converter { get; set; }
+        public T DefaultValue { get; set; }
         public Spectre.Console.Style? HighlightStyle { get; set; }
         public string? InstructionsText { get; set; }
         public Spectre.Console.SelectionMode Mode { get; set; }
@@ -2698,6 +2701,8 @@
             where T :  notnull { }
         public static Spectre.Console.SelectionPrompt<T> AddChoices<T>(this Spectre.Console.SelectionPrompt<T> obj, params T[] choices)
             where T :  notnull { }
+        public static Spectre.Console.SelectionPrompt<T> DefaultValue<T>(this Spectre.Console.SelectionPrompt<T> obj, T? defaultValue)
+            where T :  notnull { }
         public static Spectre.Console.SelectionPrompt<T> DisableSearch<T>(this Spectre.Console.SelectionPrompt<T> obj)
             where T :  notnull { }
         public static Spectre.Console.SelectionPrompt<T> EnableSearch<T>(this Spectre.Console.SelectionPrompt<T> obj)
@@ -2722,9 +2727,10 @@
     public sealed class SelectionPrompt<T> : Spectre.Console.IPrompt<T>
         where T :  notnull
     {
-        public SelectionPrompt() { }
+        public SelectionPrompt(System.Collections.Generic.IEqualityComparer<T>? comparer = null) { }
         public System.Func<T>? CancelResult { get; set; }
         public System.Func<T, string>? Converter { get; set; }
+        public T DefaultValue { get; set; }
         public Spectre.Console.Style? DisabledStyle { get; set; }
         public Spectre.Console.Style? HighlightStyle { get; set; }
         public Spectre.Console.SelectionMode Mode { get; set; }

--- a/src/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/ListPromptStateTests.cs
@@ -2,23 +2,25 @@ namespace Spectre.Console.Tests.Unit;
 
 public sealed class ListPromptStateTests
 {
-    private ListPromptState<string> CreateListPromptState(int count, int pageSize, bool shouldWrap, bool searchEnabled)
+    private ListPromptState<string> CreateListPromptState(int count, int pageSize, bool shouldWrap, bool searchEnabled, int initialIndex = 0)
         => new(
             Enumerable.Range(0, count).Select(i => new ListPromptItem<string>(i.ToString())).ToList(),
             text => text,
-            pageSize, shouldWrap, SelectionMode.Independent, true, searchEnabled);
+            pageSize, shouldWrap, SelectionMode.Independent, true, searchEnabled, initialIndex);
 
-    [Fact]
-    public void Should_Have_Start_Index_Zero()
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void Should_Have_Specified_Start_Index(int index)
     {
         // Given
-        var state = CreateListPromptState(100, 10, false, false);
+        var state = CreateListPromptState(100, 10, false, false, initialIndex: index);
 
         // When
         /* noop */
 
         // Then
-        state.Index.ShouldBe(0);
+        state.Index.ShouldBe(index);
     }
 
     [Theory]

--- a/src/Spectre.Console.Tests/Unit/Prompts/MultiSelectionPromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/MultiSelectionPromptTests.cs
@@ -250,6 +250,260 @@ public sealed class MultiSelectionPromptTests
         // Then
         selection.ShouldBe([]);
     }
+
+    [Fact]
+    public void Should_Initially_Select_The_First_Item_When_No_Default_Is_Specified()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new MultiSelectionPrompt<string>()
+                .AddChoices("First", "Second", "Third");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "> [ ] First                                 ",
+            "  [ ] Second                                ",
+            "  [ ] Third                                 ",
+            "                                            ",
+            "(Press <space> to select, <enter> to accept)> [X] First                                 ",
+            "  [ ] Second                                ",
+            "  [ ] Third                                 ",
+            "                                            ",
+            "(Press <space> to select, <enter> to accept)",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Item_When_It_Exists_In_The_Choices()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new MultiSelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third")
+                .DefaultValue("Second");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one                                  ",
+            "                                            ",
+            "  [ ] First                                 ",
+            "> [ ] Second                                ",
+            "  [ ] Third                                 ",
+            "                                            ",
+            "(Press <space> to select, <enter> to accept)Select one                                  ",
+            "                                            ",
+            "  [ ] First                                 ",
+            "> [X] Second                                ",
+            "  [ ] Third                                 ",
+            "                                            ",
+            "(Press <space> to select, <enter> to accept)",]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_First_Item_When_Default_Does_Not_Exist_In_The_Choices()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new MultiSelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third")
+                .DefaultValue("Fourth");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one                                  ",
+            "                                            ",
+            "> [ ] First                                 ",
+            "  [ ] Second                                ",
+            "  [ ] Third                                 ",
+            "                                            ",
+            "(Press <space> to select, <enter> to accept)Select one                                  ",
+            "                                            ",
+            "> [X] First                                 ",
+            "  [ ] Second                                ",
+            "  [ ] Third                                 ",
+            "                                            ",
+            "(Press <space> to select, <enter> to accept)",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Item_When_Scrolling_Is_Required_And_Item_Is_Not_Last()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new MultiSelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third", "Fourth", "Fifth", "Sixth")
+                .DefaultValue("Third")
+                .PageSize(3);
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one                                  ",
+            "                                            ",
+            "  [ ] Second                                ",
+            "> [ ] Third                                 ",
+            "  [ ] Fourth                                ",
+            "                                            ",
+            "(Move up and down to reveal more choices)   ",
+            "(Press <space> to select, <enter> to accept)Select one                                  ", "                                            ", "  [ ] Second                                ", "> [X] Third                                 ", "  [ ] Fourth                                ", "                                            ", "(Move up and down to reveal more choices)   ",
+            "(Press <space> to select, <enter> to accept)",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Item_When_Scrolling_Is_Required_And_Item_Is_Last()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new MultiSelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third", "Fourth", "Fifth", "Sixth")
+                .DefaultValue("Sixth")
+                .PageSize(3);
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one                                  ",
+            "                                            ",
+            "  [ ] Fourth                                ",
+            "  [ ] Fifth                                 ",
+            "> [ ] Sixth                                 ",
+            "                                            ",
+            "(Move up and down to reveal more choices)   ",
+            "(Press <space> to select, <enter> to accept)Select one                                  ",
+            "                                            ",
+            "  [ ] Fourth                                ",
+            "  [ ] Fifth                                 ",
+            "> [X] Sixth                                 ",
+            "                                            ",
+            "(Move up and down to reveal more choices)   ",
+            "(Press <space> to select, <enter> to accept)",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Value_When_Skipping_Unselectable_Items_And_Default_Value_Is_Leaf()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new MultiSelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoiceGroup("Group one", "First", "Second")
+                .AddChoiceGroup("Group two", "Third", "Fourth")
+                .Mode(SelectionMode.Leaf)
+                .DefaultValue("Third");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one                                  ",
+            "                                            ",
+            "  [ ] Group one                             ",
+            "    [ ] First                               ",
+            "    [ ] Second                              ",
+            "  [ ] Group two                             ",
+            "  > [ ] Third                               ",
+            "    [ ] Fourth                              ",
+            "                                            ",
+            "(Press <space> to select, <enter> to accept)Select one                                  ",
+            "                                            ",
+            "  [ ] Group one                             ",
+            "    [ ] First                               ",
+            "    [ ] Second                              ",
+            "  [ ] Group two                             ",
+            "  > [X] Third                               ",
+            "    [ ] Fourth                              ",
+            "                                            ",
+            "(Press <space> to select, <enter> to accept)",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_First_Leaf_When_Skipping_Unselectable_Items_And_Default_Value_Is_Not_Leaf()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Spacebar);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new MultiSelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoiceGroup("Group one", "First", "Second")
+                .AddChoiceGroup("Group two", "Third", "Fourth")
+                .Mode(SelectionMode.Leaf)
+                .DefaultValue("Group two");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one                                  ",
+            "                                            ",
+            "  [ ] Group one                             ",
+            "    [ ] First                               ",
+            "    [ ] Second                              ",
+            "> [ ] Group two                             ",
+            "    [ ] Third                               ",
+            "    [ ] Fourth                              ",
+            "                                            ",
+            "(Press <space> to select, <enter> to accept)Select one                                  ",
+            "                                            ",
+            "  [ ] Group one                             ",
+            "    [ ] First                               ",
+            "    [ ] Second                              ",
+            "> [X] Group two                             ",
+            "    [X] Third                               ",
+            "    [X] Fourth                              ",
+            "                                            ",
+            "(Press <space> to select, <enter> to accept)",
+        ]);
+    }
 }
 
 file sealed class CustomItem

--- a/src/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -265,6 +265,196 @@ public sealed class SelectionPromptTests
         // Then
         result.ShouldBe("[Dev] Development");
     }
+
+    [Fact]
+    public void Should_Initially_Select_The_First_Item_When_No_Default_Is_Specified() {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one",
+            "          ",
+            "> First   ",
+            "  Second  ",
+            "  Third   ",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Item_When_It_Exists_In_The_Choices() {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third")
+                .DefaultValue("Second");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one",
+            "          ",
+            "  First   ",
+            "> Second  ",
+            "  Third   ",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_First_Item_When_Default_Does_Not_Exist_In_The_Choices() {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third")
+                .DefaultValue("Fourth");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one",
+            "          ",
+            "> First   ",
+            "  Second  ",
+            "  Third   ",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Item_When_Scrolling_Is_Required_And_Item_Is_Not_Last() {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third", "Fourth", "Fifth", "Sixth")
+                .DefaultValue("Third")
+                .PageSize(3);
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one                               ",
+            "                                         ",
+            "  Second                                 ",
+            "> Third                                  ",
+            "  Fourth                                 ",
+            "                                         ",
+            "(Move up and down to reveal more choices)",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Item_When_Scrolling_Is_Required_And_Item_Is_Last() {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoices("First", "Second", "Third", "Fourth", "Fifth", "Sixth")
+                .DefaultValue("Sixth")
+                .PageSize(3);
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one                               ",
+            "                                         ",
+            "  Fourth                                 ",
+            "  Fifth                                  ",
+            "> Sixth                                  ",
+            "                                         ",
+            "(Move up and down to reveal more choices)",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_Default_Value_When_Skipping_Unselectable_Items_And_Default_Value_Is_Leaf() {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoiceGroup("Group one", "First", "Second")
+                .AddChoiceGroup("Group two", "Third", "Fourth")
+                .Mode(SelectionMode.Leaf)
+                .DefaultValue("Third");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one  ",
+            "            ",
+            "  Group one ",
+            "    First   ",
+            "    Second  ",
+            "  Group two ",
+            "  > Third   ",
+            "    Fourth  ",
+        ]);
+    }
+
+    [Fact]
+    public void Should_Initially_Select_The_First_Leaf_When_Skipping_Unselectable_Items_And_Default_Value_Is_Not_Leaf() {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new SelectionPrompt<string>()
+                .Title("Select one")
+                .AddChoiceGroup("Group one", "First", "Second")
+                .AddChoiceGroup("Group two", "Third", "Fourth")
+                .Mode(SelectionMode.Leaf)
+                .DefaultValue("Group two");
+
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one  ",
+            "            ",
+            "  Group one ",
+            "  > First   ",
+            "    Second  ",
+            "  Group two ",
+            "    Third   ",
+            "    Fourth  ",
+        ]);
+    }
 }
 
 file sealed class CustomSelectionItem

--- a/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
+++ b/src/Spectre.Console/Prompts/List/IListPromptStrategy.cs
@@ -36,4 +36,11 @@ internal interface IListPromptStrategy<T>
     /// <returns>A <see cref="IRenderable"/> representing the items.</returns>
     public IRenderable Render(IAnsiConsole console, bool scrollable, int cursorIndex,
         IEnumerable<(int Index, ListPromptItem<T> Node)> items, bool skipUnselectableItems, string searchText);
+
+    /// <summary>
+    /// Calculates the state's initial index.
+    /// </summary>
+    /// <param name="nodes">The nodes that will be shown in the list.</param>
+    /// <returns>The initial index that should be used.</returns>
+    public int CalculateInitialIndex(IReadOnlyList<ListPromptItem<T>> nodes);
 }

--- a/src/Spectre.Console/Prompts/List/ListPrompt.cs
+++ b/src/Spectre.Console/Prompts/List/ListPrompt.cs
@@ -44,7 +44,15 @@ internal sealed class ListPrompt<T>
             throw new InvalidOperationException("Cannot show an empty selection prompt. Please call the AddChoice() method to configure the prompt.");
         }
 
-        var state = new ListPromptState<T>(nodes, converter, _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize), wrapAround, selectionMode, skipUnselectableItems, searchEnabled);
+        var state = new ListPromptState<T>(
+            nodes,
+            converter,
+            _strategy.CalculatePageSize(_console, nodes.Count, requestedPageSize),
+            wrapAround,
+            selectionMode,
+            skipUnselectableItems,
+            searchEnabled,
+            _strategy.CalculateInitialIndex(nodes));
         var hook = new ListPromptRenderHook<T>(_console, () => BuildRenderable(state));
 
         using (new RenderHookScope(_console, hook))

--- a/src/Spectre.Console/Prompts/List/ListPromptState.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptState.cs
@@ -25,7 +25,8 @@ internal sealed class ListPromptState<T>
         int pageSize, bool wrapAround,
         SelectionMode mode,
         bool skipUnselectableItems,
-        bool searchEnabled)
+        bool searchEnabled,
+        int initialIndex)
     {
         _converter = converter ?? throw new ArgumentNullException(nameof(converter));
         Items = items;
@@ -46,11 +47,11 @@ internal sealed class ListPromptState<T>
                     .ToList()
                     .AsReadOnly();
 
-            Index = _leafIndexes.FirstOrDefault();
+            Index = _leafIndexes.Contains(initialIndex) ? initialIndex : _leafIndexes.FirstOrDefault();
         }
         else
         {
-            Index = 0;
+            Index = initialIndex;
         }
     }
 

--- a/src/Spectre.Console/Prompts/List/ListPromptTree.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptTree.cs
@@ -29,6 +29,22 @@ internal sealed class ListPromptTree<T>
         return null;
     }
 
+    public int? IndexOf(T item)
+    {
+        var index = 0;
+        foreach (var node in Traverse())
+        {
+            if (_comparer.Equals(item, node.Data))
+            {
+                return index;
+            }
+
+            index++;
+        }
+
+        return null;
+    }
+
     public void Add(ListPromptItem<T> node)
     {
         _roots.Add(node);

--- a/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPrompt.cs
@@ -60,6 +60,12 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
     internal ListPromptTree<T> Tree { get; }
 
     /// <summary>
+    /// Gets or sets the choice to show as selected when the prompt is first displayed.
+    /// By default the first choice is selected.
+    /// </summary>
+    public T? DefaultValue { get; set; }
+
+    /// <summary>
     /// Gets or sets a Func that will be triggered if Cancel is triggered by the 'ESC' key.
     /// </summary>
     public Func<List<T>>? CancelResult { get; set; }
@@ -292,5 +298,16 @@ public sealed class MultiSelectionPrompt<T> : IPrompt<List<T>>, IListPromptStrat
 
         // Combine all items
         return new Rows(list);
+    }
+
+    /// <inheritdoc/>
+    int IListPromptStrategy<T>.CalculateInitialIndex(IReadOnlyList<ListPromptItem<T>> nodes)
+    {
+        if (DefaultValue is not null)
+        {
+            return Tree.IndexOf(DefaultValue) ?? 0;
+        }
+
+        return 0;
     }
 }

--- a/src/Spectre.Console/Prompts/MultiSelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/MultiSelectionPromptExtensions.cs
@@ -363,4 +363,20 @@ public static class MultiSelectionPromptExtensions
 
         return obj.AddCancelResult([]);
     }
+
+    /// <summary>
+    /// Sets the choice that will be selected when the prompt is first displayed.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="defaultValue">The choice to show as selected when the prompt is first displayed.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static MultiSelectionPrompt<T> DefaultValue<T>(this MultiSelectionPrompt<T> obj, T? defaultValue)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+
+        obj.DefaultValue = defaultValue;
+        return obj;
+    }
 }

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -69,6 +69,12 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     public bool SearchEnabled { get; set; }
 
     /// <summary>
+    /// Gets or sets the choice to show as selected when the prompt is first displayed.
+    /// By default the first choice is selected.
+    /// </summary>
+    public T? DefaultValue { get; set; }
+
+    /// <summary>
     /// Gets or sets a Func that will be triggered if Cancel is triggered by the 'ESC' key.
     /// </summary>
     public Func<T>? CancelResult { get; set; }
@@ -76,9 +82,13 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
     /// <summary>
     /// Initializes a new instance of the <see cref="SelectionPrompt{T}"/> class.
     /// </summary>
-    public SelectionPrompt()
+    /// <param name="comparer">
+    /// The <see cref="IEqualityComparer{T}"/> implementation to use when comparing items,
+    /// or <c>null</c> to use the default <see cref="IEqualityComparer{T}"/> for the type of the item.
+    /// </param>
+    public SelectionPrompt(IEqualityComparer<T>? comparer = null)
     {
-        _tree = new ListPromptTree<T>(EqualityComparer<T>.Default);
+        _tree = new ListPromptTree<T>(comparer ?? EqualityComparer<T>.Default);
     }
 
     /// <summary>
@@ -242,5 +252,16 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
         }
 
         return new Rows(list);
+    }
+
+    /// <inheritdoc/>
+    int IListPromptStrategy<T>.CalculateInitialIndex(IReadOnlyList<ListPromptItem<T>> nodes)
+    {
+        if (DefaultValue is not null)
+        {
+            return _tree.IndexOf(DefaultValue) ?? 0;
+        }
+
+        return 0;
     }
 }

--- a/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionPromptExtensions.cs
@@ -282,4 +282,20 @@ public static class SelectionPromptExtensions
         obj.Converter = displaySelector;
         return obj;
     }
+
+    /// <summary>
+    /// Sets the choice that will be selected when the prompt is first displayed.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="defaultValue">The choice to show as selected when the prompt is first displayed.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static SelectionPrompt<T> DefaultValue<T>(this SelectionPrompt<T> obj, T? defaultValue)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+
+        obj.DefaultValue = defaultValue;
+        return obj;
+    }
 }


### PR DESCRIPTION
Fixes #508 

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have checked that there isn't already another pull request that solves the above issue
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors

## Changes

This change was previously proposed in https://github.com/spectreconsole/spectre.console/pull/1541 but became outdated.
This PR reintroduces the same fix on top of the current codebase.
I also extended outdated PR with similar implementation of DefaultValue for MultiSelectionPrompt