### PR TITLE
Support CancelResult for TextPrompt

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -1,4 +1,4 @@
-﻿namespace Spectre.Console
+namespace Spectre.Console
 {
     public sealed class Align : Spectre.Console.Rendering.Renderable
     {
@@ -3106,6 +3106,10 @@
     }
     public static class TextPromptExtensions
     {
+        public static Spectre.Console.TextPrompt<T> AddCancelResult<T>(this Spectre.Console.TextPrompt<T> obj, System.Func<T> cancelResultFunc)
+            where T :  notnull { }
+        public static Spectre.Console.TextPrompt<T> AddCancelResult<T>(this Spectre.Console.TextPrompt<T> obj, T cancelResult)
+            where T :  notnull { }
         public static Spectre.Console.TextPrompt<T> AddChoice<T>(this Spectre.Console.TextPrompt<T> obj, T choice) { }
         public static Spectre.Console.TextPrompt<T> AddChoices<T>(this Spectre.Console.TextPrompt<T> obj, System.Collections.Generic.IEnumerable<T> choices) { }
         public static Spectre.Console.TextPrompt<T> AllowEmpty<T>(this Spectre.Console.TextPrompt<T> obj) { }
@@ -3133,6 +3137,7 @@
     {
         public TextPrompt(string prompt, System.StringComparer? comparer = null) { }
         public bool AllowEmpty { get; set; }
+        public System.Func<T>? CancelResult { get; set; }
         public System.Collections.Generic.List<T> Choices { get; }
         public Spectre.Console.Style? ChoicesStyle { get; set; }
         public bool ClearOnFinish { get; set; }

--- a/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -473,4 +473,78 @@ public sealed class TextPromptTests
         // Then
         result.ShouldBe("Yes");
     }
+
+    [Fact]
+    public void Should_Return_CancelResult_On_Cancel_DirectFuncVersion()
+    {
+        // Given
+        const string Expected = "Cancelled";
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Escape);
+
+        // When
+        var prompt = new TextPrompt<string>("Title");
+
+        prompt.CancelResult = () => Expected;
+
+        var selection = prompt.Show(console);
+
+        // Then
+        selection.ShouldBe(Expected);
+    }
+
+    [Fact]
+    public void Should_Return_CancelResult_On_Cancel_FuncVersion()
+    {
+        // Given
+        const string Expected = "Cancelled";
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Escape);
+
+        // When
+        var prompt = new TextPrompt<string>("Title")
+                .AddCancelResult(() => Expected);
+        var selection = prompt.Show(console);
+
+        // Then
+        selection.ShouldBe(Expected);
+    }
+
+    [Fact]
+    public void Should_Return_CancelResult_On_Cancel_ValueVersion()
+    {
+        // Given
+        const string Expected = "Cancelled";
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Escape);
+
+        // When
+        var prompt = new TextPrompt<string>("Title")
+                .AddCancelResult(Expected);
+
+        var result = prompt.Show(console);
+
+        // Then
+        result.ShouldBe(Expected);
+    }
+
+    [Fact]
+    public void Should_Ignore_Escape_If_CancelResult_Not_Set()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Escape);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var prompt = new TextPrompt<string>("Title").AllowEmpty();
+        var selection = prompt.Show(console);
+
+        // Then
+        selection.ShouldBe(string.Empty);
+    }
 }

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
@@ -5,7 +5,7 @@ namespace Spectre.Console;
 /// </summary>
 public static partial class AnsiConsoleExtensions
 {
-    internal static async Task<string> ReadLine(this IAnsiConsole console, Style? style, bool secret, char? mask, IEnumerable<string>? items = null, CancellationToken cancellationToken = default, string? initialInput = null)
+    internal static async Task<string?> ReadLine(this IAnsiConsole console, Style? style, bool secret, char? mask, IEnumerable<string>? items = null, CancellationToken cancellationToken = default, string? initialInput = null)
     {
         ArgumentNullException.ThrowIfNull(console);
 
@@ -45,6 +45,11 @@ public static partial class AnsiConsoleExtensions
             }
 
             var key = rawKey.Value;
+            if (key.Key == ConsoleKey.Escape)
+            {
+                return null;
+            }
+
             if (key.Key == ConsoleKey.Enter)
             {
                 return text;

--- a/src/Spectre.Console/Prompts/TextPrompt.cs
+++ b/src/Spectre.Console/Prompts/TextPrompt.cs
@@ -102,6 +102,11 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
     internal DefaultPromptValue<T>? DefaultValue { get; set; }
 
     /// <summary>
+    /// Gets or sets a Func that will be triggered if Cancel is triggered by the 'ESC' key.
+    /// </summary>
+    public Func<T>? CancelResult { get; set; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="TextPrompt{T}"/> class.
     /// </summary>
     /// <param name="prompt">The prompt markup text.</param>
@@ -139,7 +144,7 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
 
             while (true)
             {
-                string input;
+                string? input;
                 if (EditableDefaultValue && DefaultValue != null)
                 {
                     input = await console.ReadLine(promptStyle, IsSecret, Mask, choices, cancellationToken, converter(DefaultValue.Value)).ConfigureAwait(false);
@@ -149,7 +154,15 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
                     input = await console.ReadLine(promptStyle, IsSecret, Mask, choices, cancellationToken).ConfigureAwait(false);
                 }
 
-
+                // input == null => 'Esc' pressed
+                if (input is null)
+                {
+                    if (CancelResult is not null)
+                    {
+                        return CancelResult();
+                    }
+                    continue;
+                }
 
                 // Nothing entered?
                 if (string.IsNullOrWhiteSpace(input))

--- a/src/Spectre.Console/Prompts/TextPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/TextPromptExtensions.cs
@@ -333,4 +333,35 @@ public static class TextPromptExtensions
         obj.ClearOnFinish = clear;
         return obj;
     }
+
+    /// <summary>
+    /// Sets the value that will be returned if the prompt is cancelled with 'ESC'.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="cancelResultFunc">A Func that is returning a value on cancel.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static TextPrompt<T> AddCancelResult<T>(this TextPrompt<T> obj, Func<T> cancelResultFunc)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+
+        obj.CancelResult = cancelResultFunc;
+        return obj;
+    }
+
+    /// <summary>
+    /// Sets a Func that will be triggered if the prompt is cancelled with 'ESC'.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="cancelResult">The value to be returned on cancel.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static TextPrompt<T> AddCancelResult<T>(this TextPrompt<T> obj, T cancelResult)
+        where T : notnull
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+
+        return obj.AddCancelResult(() => cancelResult);
+    }
 }


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
Fixes #1392 (although it is closed, my last PR #2028 did not cover `TextPrompt<T>`)

<!-- Formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

<!-- 
If you have used generative AI to create this pull request, you will need to disclose this here,
i.e. What AI agent you used and to what extent.
-->

## Changes

For `TextPrompt<T>`:
- Allow setting a `Func<T>` property to be triggered on Cancel
- Extension methods to set the property, either with a Func or with a Value (for easier use)
- Capture 'ESC' key and cancel the prompt
- Return the specified result if the prompt is cancelled
- Unit tests to cover both extension methods.

If property not set, the prompts works as before.

Note that this is the same type of functionality that was added by #2028 for `SelectionPrompt<T>` and `MultiSelectionPrompt<T>`.

---
Please upvote :+1: this pull request if you are interested in it.