### PR TITLE
Option to exclude vertical padding for live progress renderer

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -2581,8 +2581,9 @@
         public static Spectre.Console.Progress AutoClear(this Spectre.Console.Progress progress, bool enabled) { }
         public static Spectre.Console.Progress AutoRefresh(this Spectre.Console.Progress progress, bool enabled) { }
         public static Spectre.Console.Progress Columns(this Spectre.Console.Progress progress, params Spectre.Console.ProgressColumn[] columns) { }
-        public static Spectre.Console.Progress ExcludeVerticalPadding(this Spectre.Console.Progress progress, bool enabled) { }
+        public static Spectre.Console.Progress ExcludeVerticalPadding(this Spectre.Console.Progress progress) { }
         public static Spectre.Console.Progress HideCompleted(this Spectre.Console.Progress progress, bool enabled) { }
+        public static Spectre.Console.Progress IncludeVerticalPadding(this Spectre.Console.Progress progress) { }
         public static Spectre.Console.Progress UseRenderHook(this Spectre.Console.Progress progress, System.Func<Spectre.Console.Rendering.IRenderable, System.Collections.Generic.IReadOnlyList<Spectre.Console.ProgressTask>, Spectre.Console.Rendering.IRenderable> renderHook) { }
     }
     public sealed class ProgressTask : System.IProgress<double>

--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -2530,6 +2530,7 @@
         public Progress(Spectre.Console.IAnsiConsole console, System.TimeProvider? timeProvider = null) { }
         public bool AutoClear { get; set; }
         public bool AutoRefresh { get; set; }
+        public bool ExcludeVerticalPadding { get; set; }
         public bool HideCompleted { get; set; }
         public System.TimeSpan RefreshRate { get; set; }
         public System.Func<Spectre.Console.Rendering.IRenderable, System.Collections.Generic.IReadOnlyList<Spectre.Console.ProgressTask>, Spectre.Console.Rendering.IRenderable> RenderHook { get; set; }
@@ -2580,6 +2581,7 @@
         public static Spectre.Console.Progress AutoClear(this Spectre.Console.Progress progress, bool enabled) { }
         public static Spectre.Console.Progress AutoRefresh(this Spectre.Console.Progress progress, bool enabled) { }
         public static Spectre.Console.Progress Columns(this Spectre.Console.Progress progress, params Spectre.Console.ProgressColumn[] columns) { }
+        public static Spectre.Console.Progress ExcludeVerticalPadding(this Spectre.Console.Progress progress, bool enabled) { }
         public static Spectre.Console.Progress HideCompleted(this Spectre.Console.Progress progress, bool enabled) { }
         public static Spectre.Console.Progress UseRenderHook(this Spectre.Console.Progress progress, System.Func<Spectre.Console.Rendering.IRenderable, System.Collections.Generic.IReadOnlyList<Spectre.Console.ProgressTask>, Spectre.Console.Rendering.IRenderable> renderHook) { }
     }

--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -2582,6 +2582,7 @@
         public static Spectre.Console.Progress AutoRefresh(this Spectre.Console.Progress progress, bool enabled) { }
         public static Spectre.Console.Progress Columns(this Spectre.Console.Progress progress, params Spectre.Console.ProgressColumn[] columns) { }
         public static Spectre.Console.Progress ExcludeVerticalPadding(this Spectre.Console.Progress progress) { }
+        public static Spectre.Console.Progress ExcludeVerticalPadding(this Spectre.Console.Progress progress, bool enabled) { }
         public static Spectre.Console.Progress HideCompleted(this Spectre.Console.Progress progress, bool enabled) { }
         public static Spectre.Console.Progress IncludeVerticalPadding(this Spectre.Console.Progress progress) { }
         public static Spectre.Console.Progress UseRenderHook(this Spectre.Console.Progress progress, System.Func<Spectre.Console.Rendering.IRenderable, System.Collections.Generic.IReadOnlyList<Spectre.Console.ProgressTask>, Spectre.Console.Rendering.IRenderable> renderHook) { }

--- a/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
@@ -671,4 +671,31 @@ public sealed class ProgressTests
             .ShouldNotBeNull()
             .ShouldBeGreaterThan(0);
     }
+
+    [Fact]
+    public void Should_Exclude_Vertical_Padding()
+    {
+        // Given
+        var console = new TestConsole()
+            .Width(10)
+            .Interactive()
+            .EmitAnsiSequences();
+
+        var progress = new Progress(console)
+            .Columns(new ProgressBarColumn())
+            .AutoRefresh(false)
+            .AutoClear(false)
+            .ExcludeVerticalPadding(true);
+
+        // When
+        progress.Start(ctx => ctx.AddTask("foo"));
+
+        // Then
+        console.Output
+            .NormalizeLineEndings()
+            .ShouldBe(
+                "\e[?25l" + // Hide cursor
+                "\e[38;5;8m━━━━━━━━━━\e[0m\n" + // Task
+                "\e[?25h"); // show cursor
+    }
 }

--- a/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
@@ -685,7 +685,7 @@ public sealed class ProgressTests
             .Columns(new ProgressBarColumn())
             .AutoRefresh(false)
             .AutoClear(false)
-            .ExcludeVerticalPadding(true);
+            .ExcludeVerticalPadding();
 
         // When
         progress.Start(ctx => ctx.AddTask("foo"));
@@ -696,6 +696,35 @@ public sealed class ProgressTests
             .ShouldBe(
                 "\e[?25l" + // Hide cursor
                 "\e[38;5;8m━━━━━━━━━━\e[0m\n" + // Task
+                "\e[?25h"); // show cursor
+    }
+
+    [Fact]
+    public void Should_Include_Vertical_Padding()
+    {
+        // Given
+        var console = new TestConsole()
+            .Width(10)
+            .Interactive()
+            .EmitAnsiSequences();
+
+        var progress = new Progress(console)
+            .Columns(new ProgressBarColumn())
+            .AutoRefresh(false)
+            .AutoClear(false)
+            .IncludeVerticalPadding();
+
+        // When
+        progress.Start(ctx => ctx.AddTask("foo"));
+
+        // Then
+        console.Output
+            .NormalizeLineEndings()
+            .ShouldBe(
+                "\e[?25l" + // Hide cursor
+                "          \n" + // Top padding
+                "\e[38;5;8m━━━━━━━━━━\e[0m\n" + // Task
+                "          \n" + // Bottom padding
                 "\e[?25h"); // show cursor
     }
 }

--- a/src/Spectre.Console/Live/LiveRenderable.cs
+++ b/src/Spectre.Console/Live/LiveRenderable.cs
@@ -63,7 +63,10 @@ internal sealed class LiveRenderable : Renderable
             return ControlCode.Create(options.Capabilities, w =>
             {
                 w.Write("\r"); // More efficient than CHA (CSI 1 G)?
-                w.CursorUp(linesToMoveUp);
+                if (linesToMoveUp > 0)
+                {
+                    w.CursorUp(linesToMoveUp);
+                }
             });
         }
     }

--- a/src/Spectre.Console/Live/Progress/Progress.cs
+++ b/src/Spectre.Console/Live/Progress/Progress.cs
@@ -268,17 +268,29 @@ public static class ProgressExtensions
     }
 
     /// <summary>
+    /// Sets whether or not to exclude the vertical padding in the display.
+    /// If enabled, the progress display will not include vertical padding.
+    /// </summary>
+    /// <param name="progress">The <see cref="Progress"/> instance.</param>
+    /// <param name="enabled">Whether or not to exclude the vertical padding.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Progress ExcludeVerticalPadding(this Progress progress, bool enabled)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+
+        progress.ExcludeVerticalPadding = enabled;
+
+        return progress;
+    }
+
+    /// <summary>
     /// Excludes the vertical padding in the display.
     /// </summary>
     /// <param name="progress">The <see cref="Progress"/> instance.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public static Progress ExcludeVerticalPadding(this Progress progress)
     {
-        ArgumentNullException.ThrowIfNull(progress);
-
-        progress.ExcludeVerticalPadding = true;
-
-        return progress;
+        return progress.ExcludeVerticalPadding(true);
     }
 
     /// <summary>
@@ -288,10 +300,6 @@ public static class ProgressExtensions
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public static Progress IncludeVerticalPadding(this Progress progress)
     {
-        ArgumentNullException.ThrowIfNull(progress);
-
-        progress.ExcludeVerticalPadding = false;
-
-        return progress;
+        return progress.ExcludeVerticalPadding(false);
     }
 }

--- a/src/Spectre.Console/Live/Progress/Progress.cs
+++ b/src/Spectre.Console/Live/Progress/Progress.cs
@@ -34,6 +34,13 @@ public sealed class Progress
     public bool HideCompleted { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether or not to exclude the
+    /// vertical padding in the display.
+    /// Defaults to <c>false</c>.
+    /// </summary>
+    public bool ExcludeVerticalPadding { get; set; }
+
+    /// <summary>
     /// Gets or sets the refresh rate if <c>AutoRefresh</c> is enabled.
     /// Defaults to 10 times/second.
     /// </summary>
@@ -160,7 +167,7 @@ public sealed class Progress
         if (interactive)
         {
             var columns = new List<ProgressColumn>(Columns);
-            return new DefaultProgressRenderer(_console, columns, RefreshRate, HideCompleted, RenderHook);
+            return new DefaultProgressRenderer(_console, columns, RefreshRate, HideCompleted, ExcludeVerticalPadding, RenderHook);
         }
         else
         {
@@ -256,6 +263,22 @@ public static class ProgressExtensions
         ArgumentNullException.ThrowIfNull(progress);
 
         progress.HideCompleted = enabled;
+
+        return progress;
+    }
+
+    /// <summary>
+    /// Sets whether or not to exclude the vertical padding in the display.
+    /// If enabled, the progress display will not include vertical padding.
+    /// </summary>
+    /// <param name="progress">The <see cref="Progress"/> instance.</param>
+    /// <param name="enabled">Whether or not to exclude the vertical padding.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Progress ExcludeVerticalPadding(this Progress progress, bool enabled)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+
+        progress.ExcludeVerticalPadding = enabled;
 
         return progress;
     }

--- a/src/Spectre.Console/Live/Progress/Progress.cs
+++ b/src/Spectre.Console/Live/Progress/Progress.cs
@@ -268,17 +268,29 @@ public static class ProgressExtensions
     }
 
     /// <summary>
-    /// Sets whether or not to exclude the vertical padding in the display.
-    /// If enabled, the progress display will not include vertical padding.
+    /// Excludes the vertical padding in the display.
     /// </summary>
     /// <param name="progress">The <see cref="Progress"/> instance.</param>
-    /// <param name="enabled">Whether or not to exclude the vertical padding.</param>
     /// <returns>The same instance so that multiple calls can be chained.</returns>
-    public static Progress ExcludeVerticalPadding(this Progress progress, bool enabled)
+    public static Progress ExcludeVerticalPadding(this Progress progress)
     {
         ArgumentNullException.ThrowIfNull(progress);
 
-        progress.ExcludeVerticalPadding = enabled;
+        progress.ExcludeVerticalPadding = true;
+
+        return progress;
+    }
+
+    /// <summary>
+    /// Includes the vertical padding in the display.
+    /// </summary>
+    /// <param name="progress">The <see cref="Progress"/> instance.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Progress IncludeVerticalPadding(this Progress progress)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+
+        progress.ExcludeVerticalPadding = false;
 
         return progress;
     }

--- a/src/Spectre.Console/Live/Progress/Renderers/DefaultProgressRenderer.cs
+++ b/src/Spectre.Console/Live/Progress/Renderers/DefaultProgressRenderer.cs
@@ -8,12 +8,13 @@ internal sealed class DefaultProgressRenderer : ProgressRenderer
     private readonly object _lock;
     private readonly Stopwatch _stopwatch;
     private readonly bool _hideCompleted;
+    private readonly bool _excludeVerticalPadding;
     private readonly Func<IRenderable, IReadOnlyList<ProgressTask>, IRenderable> _renderHook;
     private TimeSpan _lastUpdate;
 
     public override TimeSpan RefreshRate { get; }
 
-    public DefaultProgressRenderer(IAnsiConsole console, List<ProgressColumn> columns, TimeSpan refreshRate, bool hideCompleted, Func<IRenderable, IReadOnlyList<ProgressTask>, IRenderable> renderHook)
+    public DefaultProgressRenderer(IAnsiConsole console, List<ProgressColumn> columns, TimeSpan refreshRate, bool hideCompleted, bool excludeVerticalPadding, Func<IRenderable, IReadOnlyList<ProgressTask>, IRenderable> renderHook)
     {
         _console = console ?? throw new ArgumentNullException(nameof(console));
         _columns = columns ?? throw new ArgumentNullException(nameof(columns));
@@ -22,6 +23,7 @@ internal sealed class DefaultProgressRenderer : ProgressRenderer
         _stopwatch = new Stopwatch();
         _lastUpdate = TimeSpan.Zero;
         _hideCompleted = hideCompleted;
+        _excludeVerticalPadding = excludeVerticalPadding;
         _renderHook = renderHook;
 
         RefreshRate = refreshRate;
@@ -110,7 +112,7 @@ internal sealed class DefaultProgressRenderer : ProgressRenderer
 
             layout.AddRow(grid);
 
-            _live.SetRenderable(new Padder(_renderHook(layout, tasks), new Padding(0, 1)));
+            _live.SetRenderable(_excludeVerticalPadding ? _renderHook(layout, tasks) : new Padder(_renderHook(layout, tasks), new Padding(0, 1)));
         }
     }
 


### PR DESCRIPTION
Fixes: https://github.com/spectreconsole/spectre.console/issues/1726

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

No AI was used in commit

## Changes

Currently, a live progress widget forces you to have a 1-top, 1-bottom vertical padding and there is no option to change this.  This commit adds a new option to `Progress.cs` called `ExcludeVerticalPadding` that when set excludes the Padder added in `DefaultProgressRenderer.cs` (default false to keep existing behavior).
