### PR TITLE
Fix Align measure to respect explicitly set width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ src/.idea/**/uiDesigner.xml
 [Dd]ebug/
 [Rr]elease/
 x64/
+*.lscache
 *_i.c
 *_p.c
 *.ilk

--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -7,6 +7,7 @@
         public Spectre.Console.HorizontalAlignment Horizontal { get; set; }
         public Spectre.Console.VerticalAlignment? Vertical { get; set; }
         public int? Width { get; set; }
+        protected override Spectre.Console.Rendering.Measurement Measure(Spectre.Console.Rendering.RenderOptions options, int maxWidth) { }
         protected override System.Collections.Generic.IEnumerable<Spectre.Console.Rendering.Segment> Render(Spectre.Console.Rendering.RenderOptions options, int maxWidth) { }
         public static Spectre.Console.Align Center(Spectre.Console.Rendering.IRenderable renderable, Spectre.Console.VerticalAlignment? vertical = default) { }
         public static Spectre.Console.Align Left(Spectre.Console.Rendering.IRenderable renderable, Spectre.Console.VerticalAlignment? vertical = default) { }

--- a/src/Spectre.Console.Tests/Unit/Widgets/AlignTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Widgets/AlignTests.cs
@@ -146,4 +146,21 @@ public sealed class AlignTests
             return Verifier.Verify(console.Output);
         }
     }
+    public sealed class Measure
+    {
+        [Fact]
+        public void Should_Return_Explicit_Width_When_Set()
+        {
+            // Given
+            var console = new TestConsole().Size(new Size(40, 15));
+            var align = Align.Left(new Panel("Hello World!")).Width(20);
+
+            // When
+            var measurement = ((IRenderable)align)
+                .Measure(RenderOptions.Create(console), 40);
+
+            // Then
+            Assert.Equal(20, measurement.Max);
+        }
+    }
 }

--- a/src/Spectre.Console/Widgets/Align.cs
+++ b/src/Spectre.Console/Widgets/Align.cs
@@ -75,6 +75,14 @@ public sealed class Align : Renderable
     }
 
     /// <inheritdoc/>
+    protected override Measurement Measure(RenderOptions options, int maxWidth)
+    {
+        var width = Math.Min(Width ?? maxWidth, maxWidth);
+        var measurement = _renderable.Measure(options with { Height = null }, width);
+        return new Measurement(Math.Min(measurement.Min, width), width);
+    }
+
+    /// <inheritdoc/>
     protected override IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
     {
         var rendered = _renderable.Render(options with { Height = null }, maxWidth);


### PR DESCRIPTION
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
Fixes #1910

<!-- Formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

<!-- 
If you have used generative AI to create this pull request, you will need to disclose this here,
i.e. What AI agent you used and to what extent.
-->

## Changes

<!-- Describe the changes you made. -->
`Align` did not override the `Measure` method, causing it to always return `maxWidth` regardless of any explicitly set `Width`.

Added a `Measure` override that respects the explicitly set width, consistent with how `Render` already handles it.

Added regression test to ensure explicit width is enforced.

---
Please upvote :+1: this pull request if you are interested in it.