### PR TITLE
Fix #1638: Add missing text prompt suffix

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Prompts/Text/ClearOnFinish.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Prompts/Text/ClearOnFinish.Output.verified.txt
@@ -1,3 +1,3 @@
-﻿Enter a value ************
+﻿Enter a value: ************
 
 [2K

--- a/src/Spectre.Console.Tests/Expectations/Prompts/Text/Issue_1638.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Prompts/Text/Issue_1638.Output.verified.txt
@@ -1,0 +1,2 @@
+no default, with suffix: input
+

--- a/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -320,6 +320,22 @@ public sealed class TextPromptTests
     }
 
     [Fact]
+    [Expectation("Issue_1638")]
+    public Task Should_Append_Colon_When_No_Default_Value_Is_Set()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Input.PushTextWithEnter("input");
+
+        // When
+        console.Prompt(
+            new TextPrompt<string>("no default, with suffix"));
+
+        // Then
+        return Verifier.Verify(console.Output);
+    }
+
+    [Fact]
     [Expectation("DefaultValueStyleNotSet")]
     public Task Uses_default_style_for_default_value_if_no_style_is_set()
     {

--- a/src/Spectre.Console/Prompts/TextPrompt.cs
+++ b/src/Spectre.Console/Prompts/TextPrompt.cs
@@ -219,10 +219,10 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
         var builder = new StringBuilder();
         builder.Append(_prompt.TrimEnd());
 
-        var appendSuffix = false;
+        var hasPromptDetails = false;
         if (ShowChoices && Choices.Count > 0)
         {
-            appendSuffix = true;
+            hasPromptDetails = true;
             var converter = Converter ?? TypeConverterHelper.ConvertToString;
             var choices = string.Join("/", Choices.Select(choice => converter(choice)));
             var choicesStyle = ChoicesStyle?.ToMarkup() ?? "blue";
@@ -231,7 +231,7 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
 
         if (ShowDefaultValue && DefaultValue != null)
         {
-            appendSuffix = true;
+            hasPromptDetails = true;
             var converter = Converter ?? TypeConverterHelper.ConvertToString;
             var defaultValueStyle = DefaultValueStyle?.ToMarkup() ?? "green";
             var defaultValue = converter(DefaultValue.Value);
@@ -244,12 +244,29 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
         }
 
         var markup = builder.ToString().Trim();
-        if (appendSuffix)
+        if (ShouldAppendColon(markup, hasPromptDetails))
         {
             markup += ":";
         }
 
         console.Markup(markup + " ");
+    }
+
+    /// <summary>
+    /// A colon should be appended when prompt details are rendered, or when a plain prompt does not already end with punctuation.
+    /// </summary>
+    /// <param name="markup">The prompt markup.</param>
+    /// <param name="hasPromptDetails">Whether the prompt includes choices or a default value.</param>
+    /// <returns>Whether a colon should be appended.</returns>
+    private static bool ShouldAppendColon(string markup, bool hasPromptDetails)
+    {
+        if (hasPromptDetails)
+        {
+            return true;
+        }
+
+        var prompt = Markup.Remove(markup).TrimEnd();
+        return prompt.Length > 0 && char.IsLetterOrDigit(prompt[^1]);
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #1638

## Checklist
- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

## Changes
- Fixed `TextPrompt` so the suffix (default `:`) is consistently shown, even when no default value is provided.
- This resolves the visual inconsistency reported in #1638.

Tested on .NET 10.0 — relevant tests pass.

## AI Disclosure
I used **Cursor** and **Grok** to help generate the initial fix, then reviewed and made several manual tweaks.