### PR TITLE
Don't move up zero steps

### DIFF
--- a/src/Spectre.Console.Ansi.Tests/AnsiWriterTests.cs
+++ b/src/Spectre.Console.Ansi.Tests/AnsiWriterTests.cs
@@ -77,6 +77,19 @@ public sealed class AnsiWriterTests
             // Then
             fixture.Output.ShouldBe("\e[4D");
         }
+
+        [Fact]
+        public void Should_Not_Write_Ansi_For_Zero_Steps()
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Writer.CursorLeft(0);
+
+            // Then
+            fixture.Output.ShouldBeEmpty();
+        }
     }
 
     public sealed class CursorBackward
@@ -92,6 +105,19 @@ public sealed class AnsiWriterTests
 
             // Then
             fixture.Output.ShouldBe("\e[4D");
+        }
+
+        [Fact]
+        public void Should_Not_Write_Ansi_For_Zero_Steps()
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Writer.CursorBackward(0);
+
+            // Then
+            fixture.Output.ShouldBeEmpty();
         }
     }
 
@@ -109,6 +135,19 @@ public sealed class AnsiWriterTests
             // Then
             fixture.Output.ShouldBe("\e[4C");
         }
+
+        [Fact]
+        public void Should_Not_Write_Ansi_For_Zero_Steps()
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Writer.CursorRight(0);
+
+            // Then
+            fixture.Output.ShouldBeEmpty();
+        }
     }
 
     public sealed class CursorForward
@@ -124,6 +163,19 @@ public sealed class AnsiWriterTests
 
             // Then
             fixture.Output.ShouldBe("\e[4C");
+        }
+
+        [Fact]
+        public void Should_Not_Write_Ansi_For_Zero_Steps()
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Writer.CursorForward(0);
+
+            // Then
+            fixture.Output.ShouldBeEmpty();
         }
     }
 
@@ -141,6 +193,19 @@ public sealed class AnsiWriterTests
             // Then
             fixture.Output.ShouldBe("\e[4B");
         }
+
+        [Fact]
+        public void Should_Not_Write_Ansi_For_Zero_Steps()
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Writer.CursorDown(0);
+
+            // Then
+            fixture.Output.ShouldBeEmpty();
+        }
     }
 
     public sealed class CursorUp
@@ -156,6 +221,19 @@ public sealed class AnsiWriterTests
 
             // Then
             fixture.Output.ShouldBe("\e[4A");
+        }
+
+        [Fact]
+        public void Should_Not_Write_Ansi_For_Zero_Steps()
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Writer.CursorUp(0);
+
+            // Then
+            fixture.Output.ShouldBeEmpty();
         }
     }
 
@@ -391,6 +469,19 @@ public sealed class AnsiWriterTests
             // Then
             fixture.Output.ShouldBe("\e[4Z");
         }
+
+        [Fact]
+        public void Should_Not_Write_Ansi_For_Zero_Tabs()
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Writer.CursorBackwardTabulation(0);
+
+            // Then
+            fixture.Output.ShouldBeEmpty();
+        }
     }
 
     public sealed class CursorHorizontalTabulation
@@ -406,6 +497,19 @@ public sealed class AnsiWriterTests
 
             // Then
             fixture.Output.ShouldBe("\e[4I");
+        }
+
+        [Fact]
+        public void Should_Not_Write_Ansi_For_Zero_Tabs()
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Writer.CursorHorizontalTabulation(0);
+
+            // Then
+            fixture.Output.ShouldBeEmpty();
         }
     }
 
@@ -423,6 +527,19 @@ public sealed class AnsiWriterTests
             // Then
             fixture.Output.ShouldBe("\e[4E");
         }
+
+        [Fact]
+        public void Should_Not_Write_Ansi_For_Zero_Lines()
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Writer.CursorNextLine(0);
+
+            // Then
+            fixture.Output.ShouldBeEmpty();
+        }
     }
 
     public sealed class CursorPreviousLine
@@ -438,6 +555,19 @@ public sealed class AnsiWriterTests
 
             // Then
             fixture.Output.ShouldBe("\e[4F");
+        }
+
+        [Fact]
+        public void Should_Not_Write_Ansi_For_Zero_Lines()
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Writer.CursorPreviousLine(0);
+
+            // Then
+            fixture.Output.ShouldBeEmpty();
         }
     }
 

--- a/src/Spectre.Console.Ansi.Tests/AnsiWriterTests.cs
+++ b/src/Spectre.Console.Ansi.Tests/AnsiWriterTests.cs
@@ -157,6 +157,19 @@ public sealed class AnsiWriterTests
             // Then
             fixture.Output.ShouldBe("\e[4A");
         }
+
+        [Fact]
+        public void Should_Not_Write_Ansi_For_Zero_Steps()
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Writer.CursorUp(0);
+
+            // Then
+            fixture.Output.ShouldBeEmpty();
+        }
     }
 
     public sealed class CursorPosition

--- a/src/Spectre.Console.Ansi/AnsiWriter.cs
+++ b/src/Spectre.Console.Ansi/AnsiWriter.cs
@@ -351,6 +351,11 @@ public sealed class AnsiWriter
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public AnsiWriter CursorUp(int steps)
     {
+        if (steps == 0)
+        {
+            return this;
+        }
+
         return WriteCsi(steps, 'A');
     }
 
@@ -367,6 +372,11 @@ public sealed class AnsiWriter
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public AnsiWriter CursorDown(int steps)
     {
+        if (steps == 0)
+        {
+            return this;
+        }
+
         return WriteCsi(steps, 'B');
     }
 
@@ -397,6 +407,11 @@ public sealed class AnsiWriter
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public AnsiWriter CursorForward(int steps)
     {
+        if (steps == 0)
+        {
+            return this;
+        }
+
         return WriteCsi(steps, 'C');
     }
 
@@ -427,6 +442,11 @@ public sealed class AnsiWriter
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public AnsiWriter CursorBackward(int steps)
     {
+        if (steps == 0)
+        {
+            return this;
+        }
+
         return WriteCsi(steps, 'D');
     }
 
@@ -607,6 +627,11 @@ public sealed class AnsiWriter
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public AnsiWriter CursorBackwardTabulation(int tabs = 1)
     {
+        if (tabs == 0)
+        {
+            return this;
+        }
+
         return WriteCsi(tabs, 'Z');
     }
 
@@ -621,6 +646,11 @@ public sealed class AnsiWriter
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public AnsiWriter CursorHorizontalTabulation(int tabs = 1)
     {
+        if (tabs == 0)
+        {
+            return this;
+        }
+
         return WriteCsi(tabs, 'I');
     }
 
@@ -635,6 +665,11 @@ public sealed class AnsiWriter
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public AnsiWriter CursorNextLine(int lines = 1)
     {
+        if (lines == 0)
+        {
+            return this;
+        }
+
         return WriteCsi(lines, 'E');
     }
 
@@ -649,6 +684,11 @@ public sealed class AnsiWriter
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public AnsiWriter CursorPreviousLine(int lines = 1)
     {
+        if (lines == 0)
+        {
+            return this;
+        }
+
         return WriteCsi(lines, 'F');
     }
 

--- a/src/Spectre.Console.Ansi/AnsiWriter.cs
+++ b/src/Spectre.Console.Ansi/AnsiWriter.cs
@@ -351,6 +351,11 @@ public sealed class AnsiWriter
     /// <returns>The same instance so that multiple calls can be chained.</returns>
     public AnsiWriter CursorUp(int steps)
     {
+        if (steps == 0)
+        {
+            return this;
+        }
+
         return WriteCsi(steps, 'A');
     }
 


### PR DESCRIPTION
Fixes #2076

## Checklist
- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

## Changes
When AnsiWriter.CursorUp(0) is called, I changed it to treat that as a no-op.
Different ANSI terminals are inconsistent about handle \x1b[0A (move up 0 lines)
<https://unix.stackexchange.com/questions/559308/what-ansi-escape-0x1b0a-and-other-0-value-codes-should-do>
(Most treat the zero as meaning move up the default number of lines and one line is the default.)

This resolves the Live display bug reported in #2076.

Tested on .NET 10.0 — relevant Live tests pass.

## AI Disclosure
I used Cursor and Grok for assistance.