### PR TITLE
add prompt history on pressing up/down arrow

### DIFF
--- a/src/Spectre.Console.Testing/TestConsole.cs
+++ b/src/Spectre.Console.Testing/TestConsole.cs
@@ -29,6 +29,9 @@ public sealed class TestConsole : IAnsiConsole, IDisposable
     /// <inheritdoc/>
     IAnsiConsoleInput IAnsiConsole.Input => Input;
 
+    /// <inheritdoc/>
+    public List<string> InputHistory => _console.InputHistory;
+
     /// <summary>
     /// Gets the console output.
     /// </summary>

--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -2129,6 +2129,7 @@
         Spectre.Console.IAnsiConsoleCursor Cursor { get; }
         Spectre.Console.IExclusivityMode ExclusivityMode { get; }
         Spectre.Console.IAnsiConsoleInput Input { get; }
+        System.Collections.Generic.List<string> InputHistory { get; }
         Spectre.Console.Rendering.RenderPipeline Pipeline { get; }
         Spectre.Console.Profile Profile { get; }
         void Clear(bool home);
@@ -2643,6 +2644,7 @@
         public Spectre.Console.IAnsiConsoleCursor Cursor { get; }
         public Spectre.Console.IExclusivityMode ExclusivityMode { get; }
         public Spectre.Console.IAnsiConsoleInput Input { get; }
+        public System.Collections.Generic.List<string> InputHistory { get; }
         public Spectre.Console.Rendering.RenderPipeline Pipeline { get; }
         public Spectre.Console.Profile Profile { get; }
         public void Clear(bool home) { }

--- a/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -489,4 +489,94 @@ public sealed class TextPromptTests
         // Then
         result.ShouldBe("Yes");
     }
+
+    [Fact]
+    public void Should_Add_Entered_Text_To_Input_History()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Input.PushTextWithEnter("Hello World");
+
+        // When
+        var result = console.Prompt(new TextPrompt<string>("Enter text:"));
+
+        // Then
+        console.InputHistory.Count.ShouldBe(1);
+        console.InputHistory[0].ShouldBe("Hello World");
+    }
+
+    [Fact]
+    public void Should_Return_Correct_Input_After_Pressing_Pressing_Up_Arrow()
+    {
+        // Given
+        var console = new TestConsole { EmitAnsiSequences = true, };
+        console.Input.PushTextWithEnter("First input");
+
+        var firstPrompt = new TextPrompt<string>("First prompt");
+        console.Prompt(firstPrompt);
+
+        console.Input.PushKey(ConsoleKey.UpArrow);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        var secondPrompt = new TextPrompt<string>("Second prompt");
+
+        // When
+        var result = console.Prompt(secondPrompt);
+
+        // Then
+        result.ShouldBe("First input");
+    }
+
+    [Fact]
+    public void Should_Return_Correct_Input_After_Pressing_Pressing_Down_Arrow()
+    {
+        // Given
+        var console = new TestConsole { EmitAnsiSequences = true, };
+        console.Input.PushTextWithEnter("First input");
+
+        var firstPrompt = new TextPrompt<string>("First prompt");
+        console.Prompt(firstPrompt);
+
+        console.Input.PushTextWithEnter("Second input");
+
+        var secondPrompt = new TextPrompt<string>("Second prompt");
+        console.Prompt(secondPrompt);
+
+        console.Input.PushKey(ConsoleKey.UpArrow);
+        console.Input.PushKey(ConsoleKey.UpArrow);
+        console.Input.PushKey(ConsoleKey.DownArrow);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        var thirdPrompt = new TextPrompt<string>("Third prompt");
+
+        // When
+        var result = console.Prompt(thirdPrompt);
+
+        // Then
+        result.ShouldBe("Second input");
+    }
+
+    [Fact]
+    public void User_Input_Should_Persist_After_Pressing_Down_Arrow()
+    {
+        // Given
+        var console = new TestConsole { EmitAnsiSequences = true, };
+        console.Input.PushTextWithEnter("First input");
+
+        var firstPrompt = new TextPrompt<string>("First prompt");
+        console.Prompt(firstPrompt);
+
+        console.Input.PushText("User input");
+        console.Input.PushKey(ConsoleKey.UpArrow);
+        console.Input.PushKey(ConsoleKey.DownArrow);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        var secondPrompt = new TextPrompt<string>("Second prompt");
+
+        // When
+        var result = console.Prompt(secondPrompt);
+
+        // Then
+        result.ShouldBe("User input");
+    }
 }

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
@@ -5,6 +5,9 @@ namespace Spectre.Console;
 /// </summary>
 public static partial class AnsiConsoleExtensions
 {
+    private static int? _inputHistoryIndex;
+    private static string _inputReplacedByHistory = string.Empty;
+
     internal static async Task<string> ReadLine(this IAnsiConsole console, Style? style, bool secret, char? mask, IEnumerable<string>? items = null, CancellationToken cancellationToken = default, string? initialInput = null)
     {
         ArgumentNullException.ThrowIfNull(console);
@@ -47,6 +50,7 @@ public static partial class AnsiConsoleExtensions
             var key = rawKey.Value;
             if (key.Key == ConsoleKey.Enter)
             {
+                console.InputHistory.Add(text);
                 return text;
             }
 
@@ -87,6 +91,39 @@ public static partial class AnsiConsoleExtensions
                 }
 
                 continue;
+            }
+
+            if (key.Key == ConsoleKey.UpArrow && console.InputHistory.Count > 0)
+            {
+                if (_inputHistoryIndex.HasValue)
+                {
+                    _inputHistoryIndex = _inputHistoryIndex.Value != 0 ? _inputHistoryIndex - 1 : 0;
+                }
+                else
+                {
+                    _inputHistoryIndex = console.InputHistory.Count - 1;
+                    _inputReplacedByHistory = text;
+                }
+
+                var replace = console.InputHistory[_inputHistoryIndex.Value];
+                console.Write("\b \b".Repeat(text.Length), style);
+                console.Write(replace);
+                text = replace;
+                continue;
+            }
+
+            if (key.Key == ConsoleKey.DownArrow && console.InputHistory.Count > 0)
+            {
+                if (_inputHistoryIndex.HasValue)
+                {
+                    _inputHistoryIndex = _inputHistoryIndex.Value != console.InputHistory.Count - 1 ? _inputHistoryIndex + 1 : null;
+
+                    var replace = _inputHistoryIndex.HasValue ? console.InputHistory[_inputHistoryIndex.Value] : _inputReplacedByHistory;
+                    console.Write("\b \b".Repeat(text.Length), style);
+                    console.Write(replace);
+                    text = replace;
+                    continue;
+                }
             }
 
             if (!char.IsControl(key.KeyChar))

--- a/src/Spectre.Console/IAnsiConsole.cs
+++ b/src/Spectre.Console/IAnsiConsole.cs
@@ -31,6 +31,11 @@ public interface IAnsiConsole
     RenderPipeline Pipeline { get; }
 
     /// <summary>
+    /// Gets the input history
+    /// </summary>
+    List<string> InputHistory { get; }
+
+    /// <summary>
     /// Clears the console.
     /// </summary>
     /// <param name="home">If the cursor should be moved to the home position.</param>

--- a/src/Spectre.Console/Internal/Backends/AnsiConsoleFacade.cs
+++ b/src/Spectre.Console/Internal/Backends/AnsiConsoleFacade.cs
@@ -11,6 +11,7 @@ internal sealed class AnsiConsoleFacade : IAnsiConsole
     public IAnsiConsoleInput Input { get; }
     public IExclusivityMode ExclusivityMode { get; }
     public RenderPipeline Pipeline { get; }
+    public List<string> InputHistory { get; }
 
     public AnsiConsoleFacade(Profile profile, IExclusivityMode exclusivityMode)
     {
@@ -18,6 +19,7 @@ internal sealed class AnsiConsoleFacade : IAnsiConsole
         Input = new DefaultInput(Profile);
         ExclusivityMode = exclusivityMode ?? throw new ArgumentNullException(nameof(exclusivityMode));
         Pipeline = new RenderPipeline();
+        InputHistory = [];
 
         _renderLock = new object();
         _ansiBackend = new AnsiConsoleBackend(this);

--- a/src/Spectre.Console/Recorder.cs
+++ b/src/Spectre.Console/Recorder.cs
@@ -23,6 +23,9 @@ public class Recorder : IAnsiConsole, IDisposable
     /// <inheritdoc/>
     public RenderPipeline Pipeline => _console.Pipeline;
 
+    /// <inheritdoc/>
+    public List<string> InputHistory => _console.InputHistory;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Recorder"/> class.
     /// </summary>


### PR DESCRIPTION
Fixes #158 

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have checked that there isn't already another pull request that solves the above issue
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors

## Changes
Added InputHistory to AnsiConsole and retriving history input on up/down arrow in AnsiConsoleExtensions.Input