### PR TITLE
ConfirmationPrompt: Allow submission without Enter key

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -379,6 +379,7 @@
         public Spectre.Console.Style? DefaultValueStyle { get; set; }
         public string InvalidChoiceMessage { get; set; }
         public char No { get; set; }
+        public bool RequireEnter { get; set; }
         public bool ShowChoices { get; set; }
         public bool ShowDefaultValue { get; set; }
         public char Yes { get; set; }
@@ -393,6 +394,7 @@
         public static Spectre.Console.ConfirmationPrompt HideDefaultValue(this Spectre.Console.ConfirmationPrompt obj) { }
         public static Spectre.Console.ConfirmationPrompt InvalidChoiceMessage(this Spectre.Console.ConfirmationPrompt obj, string message) { }
         public static Spectre.Console.ConfirmationPrompt No(this Spectre.Console.ConfirmationPrompt obj, char character) { }
+        public static Spectre.Console.ConfirmationPrompt RequireEnter(this Spectre.Console.ConfirmationPrompt obj, bool require = true) { }
         public static Spectre.Console.ConfirmationPrompt ShowChoices(this Spectre.Console.ConfirmationPrompt obj) { }
         public static Spectre.Console.ConfirmationPrompt ShowChoices(this Spectre.Console.ConfirmationPrompt obj, bool show) { }
         public static Spectre.Console.ConfirmationPrompt ShowDefaultValue(this Spectre.Console.ConfirmationPrompt obj) { }

--- a/src/Spectre.Console.Tests/Unit/Prompts/ConfirmationPromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/ConfirmationPromptTests.cs
@@ -1,0 +1,68 @@
+namespace Spectre.Console.Tests.Unit;
+
+public sealed class ConfirmationTextPromptTests
+{
+    [Theory]
+    [InlineData("y", true)]
+    [InlineData("n", false)]
+    public void Should_Require_Enter_By_Default(
+        string input, bool expected)
+    {
+        // Given
+        var console = new TestConsole();
+        console.Input.PushTextWithEnter(input);
+
+        // When
+        var result = console.Prompt(
+            new ConfirmationPrompt("Accept?")
+                .Yes('y')
+                .No('n'));
+
+        // Then
+        result.ShouldBe(expected);
+        console.Input.IsKeyAvailable().ShouldBeFalse();
+    }
+
+    [Theory]
+    [InlineData('y', true)]
+    [InlineData('n', false)]
+    public void Should_Not_Require_Enter_If_RequireEnter_Is_Set_To_False(
+        char input, bool expected)
+    {
+        // Given
+        var console = new TestConsole();
+        console.Input.PushCharacter(input);
+
+        // When
+        var result = console.Prompt(
+            new ConfirmationPrompt("Accept?")
+                .RequireEnter(false)
+                .Yes('y')
+                .No('n'));
+
+        // Then
+        result.ShouldBe(expected);
+    }
+
+    [Fact]
+    public void Should_Ignore_Invalid_Input()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Input.PushCharacter('a');
+        console.Input.PushCharacter('b');
+        console.Input.PushCharacter('c');
+        console.Input.PushCharacter('y');
+
+        // When
+        var result = console.Prompt(
+            new ConfirmationPrompt("Accept?")
+                .RequireEnter(false)
+                .Yes('y')
+                .No('n'));
+
+        // Then
+        result.ShouldBe(true);
+        console.Input.IsKeyAvailable().ShouldBeFalse();
+    }
+}

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
@@ -5,7 +5,8 @@ namespace Spectre.Console;
 /// </summary>
 public static partial class AnsiConsoleExtensions
 {
-    internal static async Task<string> ReadLine(this IAnsiConsole console, Style? style, bool secret, char? mask, IEnumerable<string>? items = null, CancellationToken cancellationToken = default, string? initialInput = null)
+    internal static async Task<string> ReadLine(this IAnsiConsole console, Style? style, bool secret, char? mask,
+        IEnumerable<string>? items = null, string? initialInput = null, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(console);
 
@@ -98,7 +99,8 @@ public static partial class AnsiConsoleExtensions
         }
     }
 
-    private static string AutoComplete(List<string> autocomplete, string text, AutoCompleteDirection autoCompleteDirection)
+    private static string AutoComplete(List<string> autocomplete, string text,
+        AutoCompleteDirection autoCompleteDirection)
     {
         var found = autocomplete.Find(i => i == text);
         var replace = string.Empty;
@@ -126,7 +128,8 @@ public static partial class AnsiConsoleExtensions
         return replace;
     }
 
-    private static string GetAutocompleteValue(AutoCompleteDirection autoCompleteDirection, IList<string> autocomplete, string found)
+    private static string GetAutocompleteValue(AutoCompleteDirection autoCompleteDirection, IList<string> autocomplete,
+        string found)
     {
         var foundAutocompleteIndex = autocomplete.IndexOf(found);
         var index = autoCompleteDirection switch

--- a/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
+++ b/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
@@ -40,14 +40,22 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
     public bool ShowDefaultValue { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets the style in which the default value is displayed. Defaults to green when <see langword="null"/>.
+    /// Gets or sets the style in which the default value is displayed.
+    /// Defaults to green when <see langword="null"/>.
     /// </summary>
     public Style? DefaultValueStyle { get; set; }
 
     /// <summary>
-    /// Gets or sets the style in which the list of choices is displayed. Defaults to blue when <see langword="null"/>.
+    /// Gets or sets the style in which the list of choices is displayed.
+    /// Defaults to blue when <see langword="null"/>.
     /// </summary>
     public Style? ChoicesStyle { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether or not the
+    /// enter key is required after input
+    /// </summary>
+    public bool RequireEnter { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the string comparer to use when comparing user input
@@ -86,12 +94,32 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
             .ShowDefaultValue(ShowDefaultValue)
             .DefaultValue(DefaultValue ? Yes : No)
             .DefaultValueStyle(DefaultValueStyle)
+            .UseInputHandler(RequireEnter ? null : SingleKeyInputHandler)
             .AddChoice(Yes)
             .AddChoice(No);
 
         var result = await prompt.ShowAsync(console, cancellationToken).ConfigureAwait(false);
 
         return comparer.Compare(Yes.ToString(), result.ToString()) == 0;
+    }
+
+    private static async Task<string> SingleKeyInputHandler(
+        IAnsiConsole console, Style? style, bool secret,
+        char? mask, IEnumerable<string>? items = null,
+        string? initialInput = null,
+        CancellationToken cancellationToken = default)
+    {
+        var key = await console.Input.ReadKeyAsync(true, cancellationToken);
+        if (key != null)
+        {
+            var character = key.Value.KeyChar;
+            if (char.IsLetter(character) || char.IsNumber(character))
+            {
+                return character.ToString();
+            }
+        }
+
+        return string.Empty;
     }
 }
 
@@ -235,6 +263,20 @@ public static class ConfirmationPromptExtensions
         ArgumentNullException.ThrowIfNull(obj);
 
         obj.No = character;
+        return obj;
+    }
+
+    /// <summary>
+    /// Sets whether or not the enter key is required after input.
+    /// </summary>
+    /// <param name="obj">The confirmation prompt.</param>
+    /// <param name="require">Whether or not the enter key is required after input.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static ConfirmationPrompt RequireEnter(this ConfirmationPrompt obj, bool require = true)
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+
+        obj.RequireEnter = require;
         return obj;
     }
 }

--- a/src/Spectre.Console/Prompts/TextPrompt.cs
+++ b/src/Spectre.Console/Prompts/TextPrompt.cs
@@ -96,10 +96,8 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
     /// </summary>
     public Style? ChoicesStyle { get; set; }
 
-    /// <summary>
-    /// Gets or sets the default value.
-    /// </summary>
     internal DefaultPromptValue<T>? DefaultValue { get; set; }
+    internal TextPromptInputHandler? InputHandler { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="TextPrompt{T}"/> class.
@@ -134,6 +132,7 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
             var converter = Converter ?? TypeConverterHelper.ConvertToString;
             var choices = Choices.Select(choice => converter(choice)).ToList();
             var choiceMap = Choices.ToDictionary(choice => converter(choice), choice => choice, _comparer);
+            var inputhandler = InputHandler ?? AnsiConsoleExtensions.ReadLine;
 
             WritePrompt(console);
 
@@ -142,14 +141,16 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
                 string input;
                 if (EditableDefaultValue && DefaultValue != null)
                 {
-                    input = await console.ReadLine(promptStyle, IsSecret, Mask, choices, cancellationToken, converter(DefaultValue.Value)).ConfigureAwait(false);
+                    input = await inputhandler(console, promptStyle, IsSecret, Mask, choices,
+                            converter(DefaultValue.Value), cancellationToken)
+                        .ConfigureAwait(false);
                 }
                 else
                 {
-                    input = await console.ReadLine(promptStyle, IsSecret, Mask, choices, cancellationToken).ConfigureAwait(false);
+                    input = await inputhandler(console, promptStyle, IsSecret, Mask, choices,
+                            null, cancellationToken)
+                        .ConfigureAwait(false);
                 }
-
-
 
                 // Nothing entered?
                 if (string.IsNullOrWhiteSpace(input))
@@ -187,7 +188,8 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
                         continue;
                     }
                 }
-                else if (!TypeConverterHelper.TryConvertFromStringWithCulture<T>(input, Culture, out result) || result == null)
+                else if (!TypeConverterHelper.TryConvertFromStringWithCulture<T>(input, Culture, out result) ||
+                         result == null)
                 {
                     console.MarkupLine(ValidationErrorMessage);
                     WritePrompt(console);

--- a/src/Spectre.Console/Prompts/TextPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/TextPromptExtensions.cs
@@ -333,4 +333,13 @@ public static class TextPromptExtensions
         obj.ClearOnFinish = clear;
         return obj;
     }
+
+    internal static TextPrompt<T> UseInputHandler<T>(
+        this TextPrompt<T> obj, TextPromptInputHandler? inputHandler)
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+
+        obj.InputHandler = inputHandler;
+        return obj;
+    }
 }

--- a/src/Spectre.Console/Prompts/TextPromptInputHandler.cs
+++ b/src/Spectre.Console/Prompts/TextPromptInputHandler.cs
@@ -1,0 +1,7 @@
+namespace Spectre.Console;
+
+internal delegate Task<string> TextPromptInputHandler(
+    IAnsiConsole console, Style? style, bool secret,
+    char? mask, IEnumerable<string>? items = null,
+    string? initialInput = null,
+    CancellationToken cancellationToken = default);


### PR DESCRIPTION
Fixes #2106

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have checked that there isn't already another pull request that solves the above issue
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors

## Changes

Add a new `RequireEnter` property to `ConfirmationPrompt` which defaults to `true`. Setting it to `false` makes the prompt accept input without the user pressing Enter.