### PR TITLE
Object based Input History of Text-based Prompts

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -393,6 +393,7 @@
         public static Spectre.Console.ConfirmationPrompt DefaultValueStyle(this Spectre.Console.ConfirmationPrompt obj, Spectre.Console.Style? style) { }
         public static Spectre.Console.ConfirmationPrompt HideChoices(this Spectre.Console.ConfirmationPrompt obj) { }
         public static Spectre.Console.ConfirmationPrompt HideDefaultValue(this Spectre.Console.ConfirmationPrompt obj) { }
+        public static Spectre.Console.ConfirmationPrompt History(this Spectre.Console.ConfirmationPrompt obj, Spectre.Console.PromptHistory? history) { }
         public static Spectre.Console.ConfirmationPrompt InvalidChoiceMessage(this Spectre.Console.ConfirmationPrompt obj, string message) { }
         public static Spectre.Console.ConfirmationPrompt No(this Spectre.Console.ConfirmationPrompt obj, char character) { }
         public static Spectre.Console.ConfirmationPrompt RequireEnter(this Spectre.Console.ConfirmationPrompt obj, bool require = true) { }

--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -377,6 +377,7 @@
         public System.StringComparer Comparer { get; set; }
         public bool DefaultValue { get; set; }
         public Spectre.Console.Style? DefaultValueStyle { get; set; }
+        public Spectre.Console.PromptHistory? History { get; set; }
         public string InvalidChoiceMessage { get; set; }
         public char No { get; set; }
         public bool RequireEnter { get; set; }
@@ -2639,6 +2640,17 @@
         public T Update<T>(string key, System.Func<T, T> func)
             where T :  struct { }
     }
+    public sealed class PromptHistory
+    {
+        public PromptHistory(int capacity = 32) { }
+        public bool Enabled { get; set; }
+        public System.Collections.Generic.IReadOnlyList<string> Entries { get; }
+        public bool IgnoreSecret { get; set; }
+        public static Spectre.Console.PromptHistory Default { get; }
+        public event System.EventHandler<string>? EntryAdded;
+        public void Add(string entry) { }
+        public void Clear() { }
+    }
     public class Recorder : Spectre.Console.IAnsiConsole, System.IDisposable
     {
         public Recorder(Spectre.Console.IAnsiConsole console) { }
@@ -3120,9 +3132,11 @@
         public static Spectre.Console.TextPrompt<T> ClearOnFinish<T>(this Spectre.Console.TextPrompt<T> obj, bool clear = true) { }
         public static Spectre.Console.TextPrompt<T> DefaultValue<T>(this Spectre.Console.TextPrompt<T> obj, T value) { }
         public static Spectre.Console.TextPrompt<T> DefaultValueStyle<T>(this Spectre.Console.TextPrompt<T> obj, Spectre.Console.Style? style) { }
+        public static Spectre.Console.TextPrompt<T> DisableHistory<T>(this Spectre.Console.TextPrompt<T> obj) { }
         public static Spectre.Console.TextPrompt<T> EditableDefaultValue<T>(this Spectre.Console.TextPrompt<T> obj, bool state) { }
         public static Spectre.Console.TextPrompt<T> HideChoices<T>(this Spectre.Console.TextPrompt<T> obj) { }
         public static Spectre.Console.TextPrompt<T> HideDefaultValue<T>(this Spectre.Console.TextPrompt<T> obj) { }
+        public static Spectre.Console.TextPrompt<T> History<T>(this Spectre.Console.TextPrompt<T> obj, Spectre.Console.PromptHistory? history) { }
         public static Spectre.Console.TextPrompt<T> InvalidChoiceMessage<T>(this Spectre.Console.TextPrompt<T> obj, string message) { }
         public static Spectre.Console.TextPrompt<T> PromptStyle<T>(this Spectre.Console.TextPrompt<T> obj, Spectre.Console.Style style) { }
         public static Spectre.Console.TextPrompt<T> Secret<T>(this Spectre.Console.TextPrompt<T> obj) { }
@@ -3147,6 +3161,7 @@
         public System.Globalization.CultureInfo? Culture { get; set; }
         public Spectre.Console.Style? DefaultValueStyle { get; set; }
         public bool EditableDefaultValue { get; set; }
+        public Spectre.Console.PromptHistory? History { get; set; }
         public string InvalidChoiceMessage { get; set; }
         public bool IsSecret { get; set; }
         public char? Mask { get; set; }

--- a/src/Spectre.Console.Tests/Unit/Prompts/ConfirmationPromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/ConfirmationPromptTests.cs
@@ -48,6 +48,7 @@ public sealed class ConfirmationTextPromptTests
     public void Should_Ignore_Invalid_Input()
     {
         // Given
+        var history = new PromptHistory();
         var console = new TestConsole();
         console.Input.PushCharacter('a');
         console.Input.PushCharacter('b');
@@ -64,5 +65,86 @@ public sealed class ConfirmationTextPromptTests
         // Then
         result.ShouldBe(true);
         console.Input.IsKeyAvailable().ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Should_Return_True_When_User_Answers_Yes()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Input.PushTextWithEnter("y");
+
+        // When
+        var result = console.Prompt(new ConfirmationPrompt("Continue?"));
+
+        // Then
+        result.ShouldBe(true);
+    }
+
+    [Fact]
+    public void Should_Return_False_When_User_Answers_No()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Input.PushTextWithEnter("n");
+
+        // When
+        var result = console.Prompt(new ConfirmationPrompt("Continue?"));
+
+        // Then
+        result.ShouldBe(false);
+    }
+
+    [Fact]
+    public void Should_Add_Confirmation_Input_To_History()
+    {
+        // Given
+        var history = new PromptHistory();
+        var console = new TestConsole();
+        console.Input.PushTextWithEnter("y");
+
+        // When
+        var result = console.Prompt(new ConfirmationPrompt("Continue?") { History = history });
+
+        // Then
+        result.ShouldBe(true);
+        history.Entries.ShouldBe(new[] { "y" });
+    }
+
+    [Fact]
+    public void Should_Share_History_Between_TextPrompt_And_ConfirmationPrompt()
+    {
+        // Given
+        var sharedHistory = new PromptHistory();
+        var console = new TestConsole();
+
+        // First, a text prompt
+        console.Input.PushTextWithEnter("hello");
+        console.Prompt(new TextPrompt<string>("Enter text:") { History = sharedHistory });
+
+        // Then, a confirmation prompt
+        console.Input.PushTextWithEnter("n");
+        var confirmResult = console.Prompt(new ConfirmationPrompt("Continue?") { History = sharedHistory });
+
+        // Then
+        confirmResult.ShouldBe(false);
+        sharedHistory.Entries.ShouldBe(new[] { "hello", "n" });
+    }
+
+    [Fact]
+    public void Should_Not_Add_Invalid_Confirmation_Input_To_History()
+    {
+        // Given
+        var history = new PromptHistory();
+        var console = new TestConsole();
+        console.Input.PushTextWithEnter("maybe");
+        console.Input.PushTextWithEnter("y");
+
+        // When
+        var result = console.Prompt(new ConfirmationPrompt("Continue?") { History = history });
+
+        // Then
+        result.ShouldBe(true);
+        history.Entries.ShouldBe(new[] { "y" }); // Only the valid "y" is stored
     }
 }

--- a/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -24,7 +24,6 @@ public sealed class TextPromptTests
         var history = new PromptHistory();
         var console = new TestConsole();
         console.Input.PushTextWithEnter("Hello World");
-
         // When
         var result = console.Prompt(new TextPrompt<string>("Enter text:") { History = history });
 

--- a/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -18,6 +18,91 @@ public sealed class TextPromptTests
     }
 
     [Fact]
+    public void Should_Add_Valid_Text_To_History()
+    {
+        // Given
+        var history = new PromptHistory();
+        var console = new TestConsole();
+        console.Input.PushTextWithEnter("Hello World");
+
+        // When
+        var result = console.Prompt(new TextPrompt<string>("Enter text:") { History = history });
+
+        // Then
+        result.ShouldBe("Hello World");
+        history.Entries.ShouldBe(new[] { "Hello World" });
+    }
+
+    [Fact]
+    public void Should_Not_Add_Invalid_Text_To_History()
+    {
+        // Given
+        var history = new PromptHistory();
+        var console = new TestConsole();
+        console.Input.PushTextWithEnter("bad");
+        console.Input.PushTextWithEnter("99");
+
+        // When
+        console.Prompt(new TextPrompt<int>("Age?") { History = history });
+
+        // Then
+        history.Entries.ShouldBe(new[] { "99" });
+    }
+
+    [Fact]
+    public void Should_Not_Add_Secret_Text_To_History_By_Default()
+    {
+        // Given
+        var history = new PromptHistory();
+        var console = new TestConsole();
+        console.Input.PushTextWithEnter("secret");
+
+        // When
+        var result = console.Prompt(new TextPrompt<string>("Password?") { History = history }.Secret());
+
+        // Then
+        result.ShouldBe("secret");
+        history.Entries.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void Should_Cycle_Through_History_With_Arrow_Keys()
+    {
+        // Given
+        var history = new PromptHistory();
+        history.Add("first");
+        history.Add("second");
+
+        var console = new TestConsole();
+        console.Input.PushKey(ConsoleKey.UpArrow);
+        console.Input.PushKey(ConsoleKey.UpArrow);
+        console.Input.PushKey(ConsoleKey.DownArrow);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var result = console.Prompt(new TextPrompt<string>("Enter text:") { History = history });
+
+        // Then
+        result.ShouldBe("second");
+    }
+
+    [Fact]
+    public void Should_Store_Confirmation_Input_In_History()
+    {
+        // Given
+        var history = new PromptHistory();
+        var console = new TestConsole();
+        console.Input.PushTextWithEnter("y");
+
+        // When
+        var result = console.Prompt(new ConfirmationPrompt("Continue?") { History = history });
+
+        // Then
+        result.ShouldBe(true);
+        history.Entries.ShouldBe(new[] { "y" });
+    }
+
+    [Fact]
     [Expectation("ConversionError")]
     public Task Should_Return_Validation_Error_If_Value_Cannot_Be_Converted()
     {

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
@@ -5,8 +5,7 @@ namespace Spectre.Console;
 /// </summary>
 public static partial class AnsiConsoleExtensions
 {
-    internal static async Task<string> ReadLine(this IAnsiConsole console, Style? style, bool secret, char? mask,
-        IEnumerable<string>? items = null, string? initialInput = null, CancellationToken cancellationToken = default)
+    internal static async Task<string> ReadLine(this IAnsiConsole console, Style? style, bool secret, char? mask, IEnumerable<string>? items = null, CancellationToken cancellationToken = default, string? initialInput = null, PromptHistory? history = null)
     {
         ArgumentNullException.ThrowIfNull(console);
 
@@ -14,6 +13,9 @@ public static partial class AnsiConsoleExtensions
         var text = string.Empty;
 
         var autocomplete = new List<string>(items ?? []);
+        var historyEntries = history?.Enabled == true ? history.Entries : Array.Empty<string>();
+        var historyIndex = -1;
+        string? pendingText = null;
 
         Queue<ConsoleKeyInfo>? injectedQueue = null;
         if (!string.IsNullOrEmpty(initialInput))
@@ -51,6 +53,48 @@ public static partial class AnsiConsoleExtensions
                 return text;
             }
 
+            if (key.Key == ConsoleKey.UpArrow && historyEntries.Count > 0)
+            {
+                if (historyIndex == -1)
+                {
+                    pendingText = text;
+                    historyIndex = historyEntries.Count - 1;
+                }
+                else if (historyIndex > 0)
+                {
+                    historyIndex--;
+                }
+
+                var replace = historyEntries[historyIndex];
+                ReplaceLine(console, style, text, replace, secret, mask);
+                text = replace;
+                continue;
+            }
+
+            if (key.Key == ConsoleKey.DownArrow && historyEntries.Count > 0)
+            {
+                if (historyIndex == -1)
+                {
+                    continue;
+                }
+
+                if (historyIndex < historyEntries.Count - 1)
+                {
+                    historyIndex++;
+                    var replace = historyEntries[historyIndex];
+                    ReplaceLine(console, style, text, replace, secret, mask);
+                    text = replace;
+                    continue;
+                }
+
+                var restore = pendingText ?? string.Empty;
+                ReplaceLine(console, style, text, restore, secret, mask);
+                text = restore;
+                pendingText = null;
+                historyIndex = -1;
+                continue;
+            }
+
             if (key.Key == ConsoleKey.Tab && autocomplete.Count > 0)
             {
                 var autoCompleteDirection = key.Modifiers.HasFlag(ConsoleModifiers.Shift)
@@ -69,6 +113,9 @@ public static partial class AnsiConsoleExtensions
 
             if (key.Key == ConsoleKey.Backspace)
             {
+                historyIndex = -1;
+                pendingText = null;
+
                 if (text.Length > 0)
                 {
                     var lastChar = text.Last();
@@ -92,6 +139,8 @@ public static partial class AnsiConsoleExtensions
 
             if (!char.IsControl(key.KeyChar))
             {
+                historyIndex = -1;
+                pendingText = null;
                 text += key.KeyChar.ToString();
                 var output = key.KeyChar.ToString();
                 console.Write(secret ? output.Mask(mask) : output, style);
@@ -99,8 +148,7 @@ public static partial class AnsiConsoleExtensions
         }
     }
 
-    private static string AutoComplete(List<string> autocomplete, string text,
-        AutoCompleteDirection autoCompleteDirection)
+    private static string AutoComplete(List<string> autocomplete, string text, AutoCompleteDirection autoCompleteDirection)
     {
         var found = autocomplete.Find(i => i == text);
         var replace = string.Empty;
@@ -128,8 +176,37 @@ public static partial class AnsiConsoleExtensions
         return replace;
     }
 
-    private static string GetAutocompleteValue(AutoCompleteDirection autoCompleteDirection, IList<string> autocomplete,
-        string found)
+    private static void ReplaceLine(IAnsiConsole console, Style? style, string currentText, string replace, bool secret, char? mask)
+    {
+        if (!string.IsNullOrEmpty(currentText) && !(secret && mask is null))
+        {
+            if (mask is null)
+            {
+                console.Write("\b \b".Repeat(currentText.Length), style);
+            }
+            else
+            {
+                foreach (var c in currentText)
+                {
+                    if (UnicodeCalculator.GetWidth(c) == 1)
+                    {
+                        console.Write("\b \b", style);
+                    }
+                    else if (UnicodeCalculator.GetWidth(c) == 2)
+                    {
+                        console.Write("\b \b\b \b", style);
+                    }
+                }
+            }
+        }
+
+        if (!string.IsNullOrEmpty(replace) && !(secret && mask is null))
+        {
+            console.Write(secret ? replace.Mask(mask) : replace, style);
+        }
+    }
+
+    private static string GetAutocompleteValue(AutoCompleteDirection autoCompleteDirection, IList<string> autocomplete, string found)
     {
         var foundAutocompleteIndex = autocomplete.IndexOf(found);
         var index = autoCompleteDirection switch

--- a/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
+++ b/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
@@ -284,4 +284,18 @@ public static class ConfirmationPromptExtensions
         obj.RequireEnter = require;
         return obj;
     }
+
+    /// <summary>
+    /// Uses the provided prompt history for this prompt.
+    /// </summary>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="history">The prompt history instance.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static ConfirmationPrompt History(this ConfirmationPrompt obj, PromptHistory? history)
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+
+        obj.History = history;
+        return obj;
+    }
 }

--- a/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
+++ b/src/Spectre.Console/Prompts/ConfirmationPrompt.cs
@@ -40,14 +40,12 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
     public bool ShowDefaultValue { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets the style in which the default value is displayed.
-    /// Defaults to green when <see langword="null"/>.
+    /// Gets or sets the style in which the default value is displayed. Defaults to green when <see langword="null"/>.
     /// </summary>
     public Style? DefaultValueStyle { get; set; }
 
     /// <summary>
-    /// Gets or sets the style in which the list of choices is displayed.
-    /// Defaults to blue when <see langword="null"/>.
+    /// Gets or sets the style in which the list of choices is displayed. Defaults to blue when <see langword="null"/>.
     /// </summary>
     public Style? ChoicesStyle { get; set; }
 
@@ -56,6 +54,11 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
     /// enter key is required after input
     /// </summary>
     public bool RequireEnter { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the prompt history.
+    /// </summary>
+    public PromptHistory? History { get; set; } = PromptHistory.Default;
 
     /// <summary>
     /// Gets or sets the string comparer to use when comparing user input
@@ -95,6 +98,7 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
             .DefaultValue(DefaultValue ? Yes : No)
             .DefaultValueStyle(DefaultValueStyle)
             .UseInputHandler(RequireEnter ? null : SingleKeyInputHandler)
+            .History(History)
             .AddChoice(Yes)
             .AddChoice(No);
 
@@ -106,8 +110,9 @@ public sealed class ConfirmationPrompt : IPrompt<bool>
     private static async Task<string> SingleKeyInputHandler(
         IAnsiConsole console, Style? style, bool secret,
         char? mask, IEnumerable<string>? items = null,
-        string? initialInput = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        string? initialInput = null, PromptHistory? history = null
+        )
     {
         var key = await console.Input.ReadKeyAsync(true, cancellationToken);
         if (key != null)

--- a/src/Spectre.Console/Prompts/PromptHistory.cs
+++ b/src/Spectre.Console/Prompts/PromptHistory.cs
@@ -1,0 +1,68 @@
+namespace Spectre.Console;
+
+/// <summary>
+/// Stores the history of valid prompt input entries.
+/// </summary>
+public sealed class PromptHistory
+{
+    private readonly List<string> _entries;
+
+    /// <summary>
+    /// Gets the default shared prompt history instance.
+    /// </summary>
+    public static PromptHistory Default { get; } = new PromptHistory();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether history is enabled.
+    /// </summary>
+    public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether secret input should be ignored.
+    /// </summary>
+    public bool IgnoreSecret { get; set; } = true;
+
+    /// <summary>
+    /// Occurs when a new entry is added to history.
+    /// </summary>
+    public event EventHandler<string>? EntryAdded;
+
+    /// <summary>
+    /// Gets the history entries.
+    /// </summary>
+    public IReadOnlyList<string> Entries => _entries.AsReadOnly();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PromptHistory"/> class.
+    /// </summary>
+    /// <param name="capacity">The initial capacity of the history list.</param>
+    public PromptHistory(int capacity = 32)
+    {
+        _entries = new List<string>(capacity);
+    }
+
+    /// <summary>
+    /// Adds a new entry to the prompt history.
+    /// </summary>
+    /// <param name="entry">The user input entry.</param>
+    public void Add(string entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+
+        if (string.IsNullOrWhiteSpace(entry))
+        {
+            return;
+        }
+
+        _entries.Add(entry);
+        EntryAdded?.Invoke(this, entry);
+    }
+
+    /// <summary>
+    /// Clears the prompt history.
+    /// </summary>
+    public void Clear()
+    {
+        _entries.Clear();
+    }
+}

--- a/src/Spectre.Console/Prompts/TextPrompt.cs
+++ b/src/Spectre.Console/Prompts/TextPrompt.cs
@@ -30,6 +30,11 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
     public string InvalidChoiceMessage { get; set; } = "[red]Please select one of the available options[/]";
 
     /// <summary>
+    /// Gets or sets the prompt history.
+    /// </summary>
+    public PromptHistory? History { get; set; } = PromptHistory.Default;
+
+    /// <summary>
     /// Gets or sets a value indicating whether input should
     /// be hidden in the console.
     /// </summary>
@@ -96,6 +101,9 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
     /// </summary>
     public Style? ChoicesStyle { get; set; }
 
+    /// <summary>
+    /// Gets or sets the default value.
+    /// </summary>
     internal DefaultPromptValue<T>? DefaultValue { get; set; }
     internal TextPromptInputHandler? InputHandler { get; set; }
 
@@ -136,21 +144,38 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
 
             WritePrompt(console);
 
+            void AddToHistory(string entry)
+            {
+                if (string.IsNullOrEmpty(entry))
+                {
+                    return;
+                }
+
+                if (History?.Enabled != true || (IsSecret && History.IgnoreSecret))
+                {
+                    return;
+                }
+
+                History.Add(entry);
+            }
+
             while (true)
             {
                 string input;
                 if (EditableDefaultValue && DefaultValue != null)
                 {
-                    input = await inputhandler(console, promptStyle, IsSecret, Mask, choices,
-                            converter(DefaultValue.Value), cancellationToken)
+                    input = await inputhandler(console, promptStyle, IsSecret, Mask, choices,cancellationToken,
+                            converter(DefaultValue.Value), History)
                         .ConfigureAwait(false);
                 }
                 else
                 {
-                    input = await inputhandler(console, promptStyle, IsSecret, Mask, choices,
-                            null, cancellationToken)
+                    input = await inputhandler(console, promptStyle, IsSecret, Mask, choices, cancellationToken,
+                            null, History)
                         .ConfigureAwait(false);
                 }
+
+
 
                 // Nothing entered?
                 if (string.IsNullOrWhiteSpace(input))
@@ -161,6 +186,7 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
                         console.Write(IsSecret ? defaultValue.Mask(Mask) : defaultValue, promptStyle);
                         console.WriteLine();
 
+                        AddToHistory(defaultValue);
                         ClearPromptLine(console);
                         return DefaultValue.Value;
                     }
@@ -178,6 +204,7 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
                 {
                     if (choiceMap.TryGetValue(input, out result) && result != null)
                     {
+                        AddToHistory(input);
                         ClearPromptLine(console);
                         return result;
                     }
@@ -204,6 +231,7 @@ public sealed class TextPrompt<T> : IPrompt<T>, IHasCulture
                     continue;
                 }
 
+                AddToHistory(input);
                 ClearPromptLine(console);
                 return result;
             }

--- a/src/Spectre.Console/Prompts/TextPromptExtensions.cs
+++ b/src/Spectre.Console/Prompts/TextPromptExtensions.cs
@@ -153,6 +153,35 @@ public static class TextPromptExtensions
     }
 
     /// <summary>
+    /// Uses the provided prompt history for this prompt.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <param name="history">The prompt history instance.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static TextPrompt<T> History<T>(this TextPrompt<T> obj, PromptHistory? history)
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+
+        obj.History = history;
+        return obj;
+    }
+
+    /// <summary>
+    /// Disables prompt history for this prompt.
+    /// </summary>
+    /// <typeparam name="T">The prompt result type.</typeparam>
+    /// <param name="obj">The prompt.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static TextPrompt<T> DisableHistory<T>(this TextPrompt<T> obj)
+    {
+        ArgumentNullException.ThrowIfNull(obj);
+
+        obj.History = null;
+        return obj;
+    }
+
+    /// <summary>
     /// Sets the default value of the prompt.
     /// </summary>
     /// <typeparam name="T">The prompt result type.</typeparam>

--- a/src/Spectre.Console/Prompts/TextPromptInputHandler.cs
+++ b/src/Spectre.Console/Prompts/TextPromptInputHandler.cs
@@ -3,5 +3,5 @@ namespace Spectre.Console;
 internal delegate Task<string> TextPromptInputHandler(
     IAnsiConsole console, Style? style, bool secret,
     char? mask, IEnumerable<string>? items = null,
-    string? initialInput = null,
-    CancellationToken cancellationToken = default);
+    CancellationToken cancellationToken = default,
+    string? initialInput = null, PromptHistory? history = null);


### PR DESCRIPTION
## Features
This pull requests allow users to go back and forth in time with their previous validated prompt answers.
Users can use the **up** and **down** arrows to go back to previous answers to answer again.
When Flags such as `.IsSecret()` are set, that prompt's history will not be remembered due to privacy.
Since this new PromptHistory is an object you can have multiple histories within the same program and can communicate between prompt types (such as confirmationprompt and textprompt). History can be reset and can be listed out if need be.
<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
Fixes #158

<!-- Formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [ ] I have checked that there isn't already another pull request that solves the above issue **(sorry my PR is a duplicate by 1 day)**
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

<!-- 
If you have used generative AI to create this pull request, you will need to disclose this here,
i.e. What AI agent you used and to what extent.
-->
AI Agents used:
- Copilot Raptor mini 1x : in-line code completion

## Changes

<!-- Describe the changes you made. -->
Added PromptHistory.cs
Added extensions such as `.DisableHistory()` and `.History(PromptHistory obj)` to valid text-based prompt types.
Multiple History object support. Initialises a default history when no valid is set.
Added EventHandler to notify when a new entry is submited to the history.

Ran tests and all was in working order.

---
Please upvote :+1: this pull request if you are interested in it.