### PR TITLE
Added Markup clearing options and Cursor movement

### DIFF
--- a/src/Spectre.Console.Ansi.Tests/AnsiMarkupTests.cs
+++ b/src/Spectre.Console.Ansi.Tests/AnsiMarkupTests.cs
@@ -254,6 +254,108 @@ public sealed class AnsiMarkupTests
                 .ShouldBe(expected);
         }
 
+        [Theory]
+        [InlineData("[clear:to eol]", "\x1B[K")]
+        [InlineData("[clear:eol]", "\x1B[K")]
+        [InlineData("[clear:screen]", "\x1B[H\x1B[2J")]
+        [InlineData("[clear:to eos]", "\x1B[0J")]
+        [InlineData("[clear:#23]", "\x1B[23;1H")]
+        public void Should_Output_Expected_Ansi_For_Clear_Directives(string text, string expected)
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Markup.Write(text);
+
+            // Then
+            fixture.Output
+                .ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("[move:to 10]", "\x1B[10;1H")]
+        [InlineData("[move:10;20]", "\x1B[10;20H")]
+        [InlineData("[move:up 3]", "\x1B[3A")]
+        [InlineData("[move:down 4]", "\x1B[4B")]
+        [InlineData("[move:right 5]", "\x1B[5C")]
+        [InlineData("[move:left 2]", "\x1B[2D")]
+        [InlineData("[move:home]", "\x1B[H")]
+        public void Should_Output_Expected_Ansi_For_Move_Directives(string text, string expected)
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Markup.Write(text);
+
+            // Then
+            fixture.Output
+                .ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("[move:up blue]")]
+        [InlineData("[move:down abc]")]
+        [InlineData("[move:left -5]")]
+        [InlineData("[move:to]")]
+        [InlineData("[move:to -1]")]
+        [InlineData("[move:to 0]")]
+        [InlineData("[move:a;b]")]
+        [InlineData("[move:10;0]")]
+        [InlineData("[move:0;10]")]
+        [InlineData("[move:-1;5]")]
+        [InlineData("[move:1;-5]")]
+        [InlineData("[move:]]")]
+        [InlineData("[move:unknown]")]
+        public void Should_Throw_For_Invalid_Move_Directives(string text)
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            var exception = Record.Exception(() => fixture.Markup.Write(text));
+
+            // Then
+            exception.ShouldNotBeNull();
+            exception.ShouldBeOfType<InvalidOperationException>();
+            exception.Message.ShouldContain("Could not parse move directive");
+        }
+
+        [Theory]
+        [InlineData("[escnext][clear:to eol]", "")]
+        [InlineData("[escnext][move:up 2]", "")]
+        [InlineData("[escnext][escnext]", "[escnext]")]
+        public void Should_Skip_Self_Closing_Markup_When_Escaped(string text, string expected)
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Markup.Write(text);
+
+            // Then
+            fixture.Output
+                .ShouldBe(expected);
+        }
+
+        [Theory]
+        [InlineData("[wnext][clear:to eol]", "[clear:to eol]")]
+        [InlineData("[wnext][move:up 2]", "[move:up 2]")]
+        [InlineData("[wnext][wnext]", "[wnext]")]
+        public void Should_Write_Next_Markup_As_Raw_Text_When_Wnext(string text, string expected)
+        {
+            // Given
+            var fixture = new AnsiFixture();
+
+            // When
+            fixture.Markup.Write(text);
+
+            // Then
+            fixture.Output
+                .ShouldBe(expected);
+        }
+
         [Fact]
         public void Should_Output_Expected_Ansi_For_Link_With_Url_And_Text()
         {

--- a/src/Spectre.Console.Ansi/AnsiMarkup.cs
+++ b/src/Spectre.Console.Ansi/AnsiMarkup.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Spectre.Console;
 
 /// <summary>
@@ -25,7 +27,14 @@ public sealed class AnsiMarkup
     {
         foreach (var segment in Parse(markup, style))
         {
-            _writer.Write(segment.Text, segment.Style, segment.Link);
+            if (segment.IsControlCode)
+            {
+                _writer.Write(segment.Text);
+            }
+            else
+            {
+                _writer.Write(segment.Text, segment.Style, segment.Link);
+            }
         }
     }
 
@@ -64,6 +73,12 @@ public sealed class AnsiMarkup
 
             if (token.Kind == MarkupTokenKind.Open)
             {
+                if (token.Value.StartsWith("clear:", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Add(AnsiMarkupSegment.Control(ParseClearDirective(token.Value)));
+                    continue;
+                }
+
                 var parsed = AnsiMarkupTagParser.Parse(token.Value);
                 linkStack.Push(link);
                 link = parsed.Link ?? link;
@@ -83,7 +98,7 @@ public sealed class AnsiMarkup
             }
             else if (token.Kind == MarkupTokenKind.Text)
             {
-                if (result.Count > 0 && result[^1].Style.Equals(style) && Equals(result[^1].Link, link))
+                if (result.Count > 0 && !result[^1].IsControlCode && result[^1].Style.Equals(style) && Equals(result[^1].Link, link))
                 {
                     // Merge segments with same style and link
                     result[^1].Text += token.Value;
@@ -107,6 +122,44 @@ public sealed class AnsiMarkup
         }
 
         return result;
+    }
+
+    private static string ParseClearDirective(string text)
+    {
+        if (!text.StartsWith("clear:", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Could not parse clear directive '{text}'.");
+        }
+
+        var value = text[6..].Trim();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Could not parse clear directive '{text}'.");
+        }
+
+        var normalized = value.ToLowerInvariant();
+        return normalized switch
+        {
+            "to eol" or "eol" => "\x1B[K",
+            "line" or "entire line" or "entireline" => "\x1B[2K",
+            "to eos" or "eos" => "\x1B[0J",
+            "screen" or "entire screen" or "entirescreen" or "full screen" => "\x1B[H\x1B[2J",
+            _ => ParseClearRowDirective(value),
+        };
+    }
+
+    private static string ParseClearRowDirective(string value)
+    {
+        if (value.Length > 0 && value[0] == '#')
+        {
+            var rowText = value[1..].Trim();
+            if (int.TryParse(rowText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var row) && row > 0)
+            {
+                return $"\x1B[{row};1H";
+            }
+        }
+
+        throw new InvalidOperationException($"Could not parse clear directive 'clear:{value}'.");
     }
 
     /// <summary>
@@ -186,16 +239,33 @@ public sealed class AnsiMarkupSegment
     public Link? Link { get; }
 
     /// <summary>
+    /// Gets a value indicating whether the segment contains control codes.
+    /// </summary>
+    public bool IsControlCode { get; }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="AnsiMarkupSegment"/> class.
     /// </summary>
     /// <param name="text">The text.</param>
     /// <param name="style">The style.</param>
     /// <param name="link">The link.</param>
-    public AnsiMarkupSegment(string text, Style style, Link? link)
+    /// <param name="isControlCode">Whether this segment represents control codes.</param>
+    public AnsiMarkupSegment(string text, Style style, Link? link, bool isControlCode = false)
     {
         Text = text;
         Style = style;
         Link = link;
+        IsControlCode = isControlCode;
+    }
+
+    /// <summary>
+    /// Creates a new segment for raw control codes.
+    /// </summary>
+    /// <param name="control">The control code text.</param>
+    /// <returns>The control segment.</returns>
+    public static AnsiMarkupSegment Control(string control)
+    {
+        return new AnsiMarkupSegment(control, Style.Plain, null, true);
     }
 
     /// <inheritdoc />
@@ -328,6 +398,7 @@ file sealed class MarkupTokenizer : IDisposable
         // Read the "content" of the markup until we find the end-of-markup
         var builder = new StringBuilder();
         var currentStylePartCanContainMarkup = false;
+        var closed = false;
         while (!_reader.Eof)
         {
             var current = _reader.Read();
@@ -337,6 +408,7 @@ file sealed class MarkupTokenizer : IDisposable
                 if (!currentStylePartCanContainMarkup || _reader.Peek() != ']')
                 {
                     // Not parsing a link or not escaped. Markup closed
+                    closed = true;
                     break;
                 }
 
@@ -370,7 +442,7 @@ file sealed class MarkupTokenizer : IDisposable
             }
         }
 
-        if (_reader.Eof)
+        if (!closed)
         {
             ThrowMalformed(_reader.Position);
         }

--- a/src/Spectre.Console.Ansi/AnsiMarkup.cs
+++ b/src/Spectre.Console.Ansi/AnsiMarkup.cs
@@ -66,6 +66,8 @@ public sealed class AnsiMarkup
         var styleStack = new Stack<Style>();
         var linkStack = new Stack<Link?>();
         var link = default(Link?);
+        var skipNextSelfClosingMarkup = false;
+        var writeNextAsRaw = false;
 
         while (tokenizer.MoveNext())
         {
@@ -73,9 +75,46 @@ public sealed class AnsiMarkup
 
             if (token.Kind == MarkupTokenKind.Open)
             {
+                if (writeNextAsRaw)
+                {
+                    result.Add(new AnsiMarkupSegment($"[{token.Value}]", style.Value, null));
+                    writeNextAsRaw = false;
+                    continue;
+                }
+
+                if (token.Value.Equals("escnext", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (skipNextSelfClosingMarkup)
+                    {
+                        result.Add(new AnsiMarkupSegment("[escnext]", style.Value, null));
+                        skipNextSelfClosingMarkup = false;
+                        continue;
+                    }
+                    skipNextSelfClosingMarkup = true;
+                    continue;
+                }
+
+                if (token.Value.Equals("wnext", StringComparison.OrdinalIgnoreCase))
+                {
+                    writeNextAsRaw = true;
+                    continue;
+                }
+
+                if (skipNextSelfClosingMarkup)
+                {
+                    skipNextSelfClosingMarkup = false;
+                    continue;
+                }
+
                 if (token.Value.StartsWith("clear:", StringComparison.OrdinalIgnoreCase))
                 {
                     result.Add(AnsiMarkupSegment.Control(ParseClearDirective(token.Value)));
+                    continue;
+                }
+
+                if (token.Value.StartsWith("move:", StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Add(AnsiMarkupSegment.Control(ParseMoveDirective(token.Value)));
                     continue;
                 }
 
@@ -160,6 +199,72 @@ public sealed class AnsiMarkup
         }
 
         throw new InvalidOperationException($"Could not parse clear directive 'clear:{value}'.");
+    }
+
+    private static string ParseMoveDirective(string text)
+    {
+        if (!text.StartsWith("move:", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException($"Could not parse move directive '{text}'.");
+        }
+
+        var value = text[5..].Trim();
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"Could not parse move directive '{text}'.");
+        }
+
+        var normalized = value.ToLowerInvariant();
+        return normalized switch
+        {
+            "home" or "origin" => "\x1B[H",
+            _ when normalized.StartsWith("to ") => ParseMoveToDirective(normalized[3..].Trim()),
+            _ when normalized.StartsWith("up ") => ParseMoveRelativeDirective(normalized[3..].Trim(), 'A'),
+            _ when normalized.StartsWith("down ") => ParseMoveRelativeDirective(normalized[5..].Trim(), 'B'),
+            _ when normalized.StartsWith("left ") => ParseMoveRelativeDirective(normalized[5..].Trim(), 'D'),
+            _ when normalized.StartsWith("right ") => ParseMoveRelativeDirective(normalized[6..].Trim(), 'C'),
+            _ when normalized.StartsWith("forward ") => ParseMoveRelativeDirective(normalized[8..].Trim(), 'C'),
+            _ when normalized.StartsWith("backward ") => ParseMoveRelativeDirective(normalized[9..].Trim(), 'D'),
+            _ when normalized.Contains(';') => ParseMoveToDirective(normalized),
+            _ when int.TryParse(normalized, NumberStyles.Integer, CultureInfo.InvariantCulture, out var row) && row > 0 => $"\x1B[{row};1H",
+            _ => throw new InvalidOperationException($"Could not parse move directive 'move:{value}'."),
+        };
+    }
+
+    private static string ParseMoveToDirective(string value)
+    {
+        if (value.Contains(';'))
+        {
+            var parts = value.Split(';', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 2 &&
+                int.TryParse(parts[0].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var row) && row > 0 &&
+                int.TryParse(parts[1].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var column) && column > 0)
+            {
+                return $"\x1B[{row};{column}H";
+            }
+        }
+
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var singleRow) && singleRow > 0)
+        {
+            return $"\x1B[{singleRow};1H";
+        }
+
+        throw new InvalidOperationException($"Could not parse move directive 'move:{value}'.");
+    }
+
+    private static string ParseMoveRelativeDirective(string value, char direction)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return $"\x1B[1{direction}";
+        }
+
+        if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var steps) && steps >= 0)
+        {
+            return $"\x1B[{steps}{direction}";
+        }
+
+        throw new InvalidOperationException($"Could not parse move directive 'move:{value}'.");
     }
 
     /// <summary>

--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -2495,6 +2495,7 @@
         public int Lines { get; }
         public Spectre.Console.Overflow? Overflow { get; set; }
         public Spectre.Console.Paragraph Append(string text, Spectre.Console.Style? style = default, Spectre.Console.Link? link = null) { }
+        public Spectre.Console.Paragraph AppendControl(string control) { }
         protected override Spectre.Console.Rendering.Measurement Measure(Spectre.Console.Rendering.RenderOptions options, int maxWidth) { }
         protected override System.Collections.Generic.IEnumerable<Spectre.Console.Rendering.Segment> Render(Spectre.Console.Rendering.RenderOptions options, int maxWidth) { }
     }

--- a/src/Spectre.Console/Widgets/Markup.cs
+++ b/src/Spectre.Console/Widgets/Markup.cs
@@ -42,7 +42,14 @@ public sealed class Markup : Renderable, IHasJustification, IOverflowable
         _paragraph = new Paragraph();
         foreach (var segment in AnsiMarkup.Parse(text, style))
         {
-            _paragraph.Append(Emoji.Replace(segment.Text), segment.Style, segment.Link);
+            if (segment.IsControlCode)
+            {
+                _paragraph.AppendControl(segment.Text);
+            }
+            else
+            {
+                _paragraph.Append(Emoji.Replace(segment.Text), segment.Style, segment.Link);
+            }
         }
     }
 

--- a/src/Spectre.Console/Widgets/Paragraph.cs
+++ b/src/Spectre.Console/Widgets/Paragraph.cs
@@ -95,6 +95,24 @@ public sealed class Paragraph : Renderable, IHasJustification, IOverflowable
         return this;
     }
 
+    /// <summary>
+    /// Appends raw control codes to the paragraph.
+    /// </summary>
+    /// <param name="control">The control code text.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public Paragraph AppendControl(string control)
+    {
+        ArgumentNullException.ThrowIfNull(control);
+
+        if (_lines.Count == 0)
+        {
+            _lines.Add(new SegmentLine());
+        }
+
+        _lines[^1].Add(Segment.Control(control));
+        return this;
+    }
+
     /// <inheritdoc/>
     protected override Measurement Measure(RenderOptions options, int maxWidth)
     {


### PR DESCRIPTION
This Pull Request Adds new markup token to manipulated the console cursor, as well as clear parts of the console, such as lines, entire screen or to and from areas. These markup tokens are all being self-closing so no need to encapsulate it.


<!--
Do NOT open a PR without discussing the changes on an open issue, first.

Add the issue number here. e.g. #123
-->
Fixes #1570 

<!-- Formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

<!-- 
If you have used generative AI to create this pull request, you will need to disclose this here,
i.e. What AI agent you used and to what extent.
-->
AI Agent used:
- Copilot Raptor mini 1x : in-line code completion

## Changes

<!-- Describe the changes you made. -->

Added These new self-closing markup tokens:
1. [escnext]         Escape the next self-closing token (does not write any output to the console)
2. [wnext]            Escapes and Writes the next self-closing token as raw text
3. [move:to #]     Move cursor to position
4. [clear:to #]     Clear line/area of console 

[Move:] and [Clear:] support these formats:
'to (tag)' such as end of screen (eos), end of line (eol), numeric line number
'x;y', 'home', 'origin' (valid only for move for now) (home and origin are aliases for coordinate 1;1)
Relative tags: 'right', 'forward', 'backward', 'left', 'up', 'down' (valid only for move for now) (home and origin are aliases for coordinate 1;1)
'screen' (clear only, clears the entire screen)

---
Please upvote :+1: this pull request if you are interested in it.