### PR TITLE
Fix grid regression where expansion did not work

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Widgets/Grid/Render_Expanded.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Widgets/Grid/Render_Expanded.Output.verified.txt
@@ -1,0 +1,1 @@
+﻿Hello          World

--- a/src/Spectre.Console.Tests/Unit/Widgets/GridTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Widgets/GridTests.cs
@@ -133,6 +133,22 @@ public sealed class GridTests
     }
 
     [Fact]
+    [Expectation("Render_Expanded")]
+    public Task Should_Render_Grid_Expanded_If_Set()
+    {
+        var console = new TestConsole().Width(20);
+        var grid = new Grid().Expand();
+        grid.AddColumns(2);
+        grid.AddRow(new Text("Hello"), new Text("World").RightJustified());
+
+        // When
+        console.Write(grid);
+
+        // Then
+        return Verifier.Verify(console.Output);
+    }
+
+    [Fact]
     [Expectation("Render_Alignment")]
     public Task Should_Render_Grid_Column_Alignment_Correctly()
     {

--- a/src/Spectre.Console/Widgets/Grid.cs
+++ b/src/Spectre.Console/Widgets/Grid.cs
@@ -104,6 +104,7 @@ public sealed class Grid : JustInTimeRenderable, IExpandable
     {
         var table = new Table
         {
+            Expand = Expand,
             Border = TableBorder.None,
             ShowHeaders = false,
             IsGrid = true,
@@ -163,7 +164,6 @@ public static class GridExtensions
     public static Grid AddColumns(this Grid grid, params GridColumn[] columns)
     {
         ArgumentNullException.ThrowIfNull(grid);
-
         ArgumentNullException.ThrowIfNull(columns);
 
         foreach (var column in columns)
@@ -199,7 +199,6 @@ public static class GridExtensions
     public static Grid AddRow(this Grid grid, params string[] columns)
     {
         ArgumentNullException.ThrowIfNull(grid);
-
         ArgumentNullException.ThrowIfNull(columns);
 
         grid.AddRow(columns.Select(column => new Markup(column)).ToArray());


### PR DESCRIPTION
Fixes #2126

<!-- Formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have checked that there isn't already another pull request that solves the above issue
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors

## Changes

Expansion of grids should now work as expected.

---
Please upvote :+1: this pull request if you are interested in it.