### PR TITLE
Fix indeterminate progress completion

### DIFF
--- a/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTaskTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTaskTests.cs
@@ -106,4 +106,36 @@ public sealed class ProgressTaskTests
         task.Speed.ShouldNotBeNull();
         task.Speed!.Value.ShouldBe(10.0, tolerance: 0.001);
     }
+
+    [Fact]
+    public void IsFinished_Should_Ignore_Value_When_Task_Is_Indeterminate()
+    {
+        // Given
+        var task = new ProgressTask(1, "Foo", 100)
+        {
+            IsIndeterminate = true,
+            Value = 100,
+        };
+
+        // Then
+        task.IsFinished.ShouldBeFalse();
+        task.Percentage.ShouldBe(0);
+    }
+
+    [Fact]
+    public void StopTask_Should_Finish_Indeterminate_Task()
+    {
+        // Given
+        var task = new ProgressTask(1, "Foo", 100)
+        {
+            IsIndeterminate = true,
+        };
+
+        // When
+        task.StopTask();
+
+        // Then
+        task.IsFinished.ShouldBeTrue();
+        task.Percentage.ShouldBe(100);
+    }
 }

--- a/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
@@ -258,6 +258,32 @@ public sealed class ProgressTests
     }
 
     [Fact]
+    public void Should_Not_Hide_Indeterminate_Task_When_Value_Reaches_MaxValue()
+    {
+        // Given
+        var console = new TestConsole()
+            .Interactive()
+            .EmitAnsiSequences();
+
+        var progress = new Progress(console)
+            .Columns(new TaskDescriptionColumn())
+            .AutoRefresh(false)
+            .AutoClear(false)
+            .HideCompleted(true);
+
+        // When
+        progress.Start(ctx =>
+        {
+            var task = ctx.AddTask("foo");
+            task.IsIndeterminate = true;
+            task.Value = task.MaxValue;
+        });
+
+        // Then
+        console.Output.ShouldContain("foo");
+    }
+
+    [Fact]
     public void Should_Report_Max_Remaining_Time_For_Extremely_Small_Progress()
     {
         // Given

--- a/src/Spectre.Console.Tests/Unit/Widgets/ProgressBarTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Widgets/ProgressBarTests.cs
@@ -47,4 +47,28 @@ public class ProgressBarTests
         // Then
         await Verifier.Verify(console.Output);
     }
+
+    [Fact]
+    public void Should_Render_Indeterminate_When_Value_Reaches_MaxValue()
+    {
+        // Given
+        var console = new TestConsole()
+            .SupportsUnicode(false)
+            .Colors(ColorSystem.NoColors);
+
+        var bar = new ProgressBar()
+        {
+            Width = 20,
+            Value = 100,
+            MaxValue = 100,
+            IsIndeterminate = true,
+        };
+
+        // When
+        console.Write(bar);
+
+        // Then
+        console.Output.ShouldContain(" ");
+        console.Output.ShouldNotBe(new string('-', 20));
+    }
 }

--- a/src/Spectre.Console/Live/Progress/Columns/ProgressBarColumn.cs
+++ b/src/Spectre.Console/Live/Progress/Columns/ProgressBarColumn.cs
@@ -43,6 +43,7 @@ public sealed class ProgressBarColumn : ProgressColumn
             RemainingStyle = RemainingStyle,
             IndeterminateStyle = IndeterminateStyle,
             IsIndeterminate = task.IsIndeterminate,
+            IsFinished = task.IsFinished,
         };
     }
 }

--- a/src/Spectre.Console/Live/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Live/Progress/ProgressTask.cs
@@ -84,7 +84,7 @@ public sealed class ProgressTask : IProgress<double>
     /// <summary>
     /// Gets a value indicating whether or not the task has finished.
     /// </summary>
-    public bool IsFinished => StopTime != null || Value >= MaxValue;
+    public bool IsFinished => StopTime != null || (!IsIndeterminate && Value >= MaxValue);
 
     /// <summary>
     /// Gets the percentage done of the task.
@@ -259,6 +259,11 @@ public sealed class ProgressTask : IProgress<double>
 
     private double GetPercentage()
     {
+        if (IsIndeterminate)
+        {
+            return IsFinished ? 100 : 0;
+        }
+
         if (MaxValue == 0)
         {
             return 100;

--- a/src/Spectre.Console/Widgets/ProgressBar.cs
+++ b/src/Spectre.Console/Widgets/ProgressBar.cs
@@ -14,6 +14,7 @@ internal sealed class ProgressBar : Renderable, IHasCulture
     public char AsciiBar { get; set; } = '-';
     public bool ShowValue { get; set; }
     public bool IsIndeterminate { get; set; }
+    public bool IsFinished { get; set; }
     public CultureInfo? Culture { get; set; }
     public Func<double, CultureInfo, string>? ValueFormatter { get; set; }
 
@@ -34,7 +35,7 @@ internal sealed class ProgressBar : Renderable, IHasCulture
     {
         var width = Math.Min(Width ?? maxWidth, maxWidth);
         var completedBarCount = Math.Min(MaxValue, Math.Max(0, Value));
-        var isCompleted = completedBarCount >= MaxValue;
+        var isCompleted = IsFinished || (!IsIndeterminate && completedBarCount >= MaxValue);
 
         if (IsIndeterminate && !isCompleted)
         {


### PR DESCRIPTION
## Summary

Fix indeterminate progress tasks so they do not become completed merely because `Value >= MaxValue`.

For indeterminate tasks, completion now depends on `StopTask()`, which prevents `HideCompleted` flicker and prevents the progress bar from rendering as a completed bar while the task is still active.

## Test plan

- `git show --check --oneline HEAD`
- `git diff --check HEAD~1 HEAD`

I could not run the focused `dotnet test` locally because the repo pins .NET SDK `10.0.300`, while this machine currently has `10.0.202`.

Fixes #1907.