### PR TITLE
Fix table width collapse hang

### DIFF
--- a/src/Spectre.Console.Tests/Unit/Widgets/Table/TableTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Widgets/Table/TableTests.cs
@@ -625,6 +625,27 @@ public sealed class TableTests
     }
 
     [Fact]
+    [GitHubIssue("https://github.com/spectreconsole/spectre.console/issues/2131")]
+    public void Should_Not_Hang_When_Wrappable_Column_Is_Already_Collapsed()
+    {
+        // Given
+        var console = new TestConsole().Width(20);
+        var table = new Table()
+            .HideHeaders()
+            .HideFooters();
+
+        table.AddColumn(new TableColumn("Hidden").Width(0));
+        table.AddColumn(new TableColumn("Description").NoWrap());
+        table.AddRow(string.Empty, new string('A', 80));
+
+        // When
+        console.Write(table);
+
+        // Then
+        console.Output.ShouldNotBeEmpty();
+    }
+
+    [Fact]
     [Expectation("Render_Multiline")]
     public Task Should_Render_Table_With_Multiple_Rows_In_Cell_Correctly()
     {

--- a/src/Spectre.Console/Widgets/Table/TableMeasurer.cs
+++ b/src/Spectre.Console/Widgets/Table/TableMeasurer.cs
@@ -187,7 +187,7 @@ internal sealed class TableMeasurer : TableAccessor
                 var columnDifference = maxColumn - secondMaxColumn;
 
                 var ratios = widths.Zip(wrappable, (width, allowWrap) => width == maxColumn && allowWrap ? 1 : 0).ToList();
-                if (!ratios.Any(x => x != 0) || columnDifference == 0)
+                if (!ratios.Any(x => x != 0) || columnDifference <= 0)
                 {
                     break;
                 }


### PR DESCRIPTION
## Summary

- Stop `TableMeasurer.CollapseWidths` when the largest wrappable column can no longer be reduced.
- This prevents the zero-width wrappable-column case from looping indefinitely when non-wrappable content still exceeds the available table width.
- Add a regression test that renders a narrow table with an already-collapsed wrappable column and long non-wrappable content.

Fixes #2131.

## Tests

- `C:\hades\.dotnet-10.0.300\dotnet.exe test src\Spectre.Console.Tests\Spectre.Console.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~Should_Not_Hang_When_Wrappable_Column_Is_Already_Collapsed" --no-restore`
- `C:\hades\.dotnet-10.0.300\dotnet.exe test src\Spectre.Console.Tests\Spectre.Console.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~Spectre.Console.Tests.Unit.TableTests" --no-restore`
- `git diff --check`

AI-assisted change, reviewed locally before submission.