### PR TITLE
Fix AnsiConsole.Write string literal handling

### DIFF
--- a/src/Spectre.Console.Tests/Unit/AnsiConsoleTests.cs
+++ b/src/Spectre.Console.Tests/Unit/AnsiConsoleTests.cs
@@ -26,6 +26,33 @@ public partial class AnsiConsoleTests
 
     public sealed class Write
     {
+        [Theory]
+        [InlineData("{Pt.1} (TEST ~ 855D)")]
+        [InlineData("{")]
+        [InlineData("test {0}")]
+        [InlineData("test {0} {1}")]
+        public void Should_Treat_String_Value_As_Literal_Text(string value)
+        {
+            // Given
+            var previous = AnsiConsole.Console;
+            var console = new TestConsole();
+
+            try
+            {
+                AnsiConsole.Console = console;
+
+                // When
+                AnsiConsole.Write(value);
+            }
+            finally
+            {
+                AnsiConsole.Console = previous;
+            }
+
+            // Then
+            console.Output.ShouldBe(value);
+        }
+
         [Fact]
         public void Should_Combine_Decoration_And_Colors()
         {

--- a/src/Spectre.Console/AnsiConsole.Write.cs
+++ b/src/Spectre.Console/AnsiConsole.Write.cs
@@ -22,7 +22,7 @@ public static partial class AnsiConsole
     /// <param name="value">The value to write.</param>
     public static void Write(string value)
     {
-        Write(value, CurrentStyle);
+        Console.Write(value, CurrentStyle);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- make `AnsiConsole.Write(string)` write the supplied string literally instead of dispatching to the composite-format overload
- match `AnsiConsole.WriteLine(string)`, which already writes directly with `CurrentStyle`
- add regression coverage for literal braces and composite-format-looking strings

Fixes spectreconsole/spectre.console#1387.
Fixes spectreconsole/spectre.console#1495.

## Tests
- red regression reproduced before the fix: literal brace inputs threw `FormatException`, and `test {0}` formatted `CurrentStyle`
- `dotnet test src\Spectre.Console.Tests\Spectre.Console.Tests.csproj --framework net10.0 --filter "FullyQualifiedName~Should_Treat_String_Value_As_Literal_Text"`
- `dotnet test src\Spectre.Console.Tests\Spectre.Console.Tests.csproj --framework net10.0 --no-build --filter "FullyQualifiedName~Spectre.Console.Tests.Unit.AnsiConsoleTests"`
- `dotnet test src\Spectre.Console.Tests\Spectre.Console.Tests.csproj --framework net10.0 --no-build`
- `git diff --check`

---
Written by an agent (OpenAI Codex, GPT-5).