### PR TITLE
GH2153: Fix async stack traces rendering as MoveNext() instead of source methods

### DIFF
--- a/src/Spectre.Console.Tests/Data/Exceptions.cs
+++ b/src/Spectre.Console.Tests/Data/Exceptions.cs
@@ -43,6 +43,15 @@ public static class TestExceptions
         MethodThatThrows(0);
         return ("key", []);
     }
+
+    public static async Task MethodThatThrowsAsync()
+    {
+        await Task.Yield();
+        throw new InvalidOperationException("Throwing async!");
+    }
+
+    public static void ThrowFromAsync() =>
+        MethodThatThrowsAsync().GetAwaiter().GetResult();
 }
 
 #pragma warning disable CS9113 // Parameter is unread.

--- a/src/Spectre.Console.Tests/Expectations/Exception/AsyncStackTrace.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Exception/AsyncStackTrace.Output.verified.txt
@@ -1,0 +1,4 @@
+InvalidOperationException: Throwing async!
+  at async Task MethodThatThrowsAsync() in Exceptions.cs:100       
+  at void ThrowFromAsync() in Exceptions.cs:200                    
+  at Exception GetException(Action action) in ExceptionTests.cs:300

--- a/src/Spectre.Console.Tests/Unit/ExceptionTests.cs
+++ b/src/Spectre.Console.Tests/Unit/ExceptionTests.cs
@@ -222,6 +222,25 @@ public sealed class ExceptionTests
         return Verifier.Verify(console.Output);
     }
 
+    [Fact]
+    [Expectation("AsyncStackTrace")]
+    public Task Should_Write_Async_Exception_With_Resolved_Method_Names()
+    {
+        // Given
+        var console = new TestConsole().Width(1024);
+        var dex = GetException(TestExceptions.ThrowFromAsync);
+
+        // When
+        console.WriteException(dex, new ExceptionSettings
+        {
+            Format = ExceptionFormats.ShortenEverything | ExceptionFormats.ShowLinks,
+            Resolver = new ExceptionScrubber(),
+        });
+
+        // Then
+        return Verifier.Verify(console.Output);
+    }
+
     private static Exception GetException(Action action)
     {
         try

--- a/src/Spectre.Console/Widgets/Exceptions/ExceptionRenderableBuilder.cs
+++ b/src/Spectre.Console/Widgets/Exceptions/ExceptionRenderableBuilder.cs
@@ -292,7 +292,7 @@ internal static class ExceptionRenderableBuilder
             isAsync = typeof(IAsyncStateMachine).IsAssignableFrom(declaringType);
             if (isAsync || typeof(IEnumerator).IsAssignableFrom(declaringType))
             {
-                TryResolveStateMachineMethod(method, out declaringType);
+                TryResolveStateMachineMethod(ref method, out declaringType);
             }
         }
         else
@@ -304,7 +304,7 @@ internal static class ExceptionRenderableBuilder
     }
 
     [RequiresDynamicCode(ExceptionRenderableBuilder.AotWarning)]
-    private static bool TryResolveStateMachineMethod(MethodBase method, out Type declaringType)
+    private static bool TryResolveStateMachineMethod(ref MethodBase method, out Type declaringType)
     {
         // https://github.com/dotnet/runtime/blob/v6.0.0/src/libraries/System.Private.CoreLib/src/System/Diagnostics/StackTrace.cs#L400-L455
         declaringType = method.DeclaringType ??


### PR DESCRIPTION
- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors


## Changes

Async exception stack frames were showing `async void MoveNext()` because `TryResolveStateMachineMethod` took `MethodBase` by value. The resolved method (e.g. `ExecuteAsync`) was assigned to a local copy and never propagated back to the caller, matching .NET StackTrace behavior only partially.

- Pass `MethodBase` by ref in `TryResolveStateMachineMethod` and at its call site in `GetMethodName`
- Add async throw helpers to `TestExceptions` for regression coverage
- Add verifier test and snapshot asserting resolved async method names
- Fixes #2153

### Example

```csharp
catch(Exception exception)
{
    AnsiConsole.WriteException(
        exception,
        ExceptionFormats.ShortenEverything | ExceptionFormats.ShowLinks
    );
}
```

#### Before fix (broken — MethodBase passed by value)

```
InvalidOperationException: Throwing async!
  at async void MoveNext() in Exceptions.cs:100
  at void ThrowFromAsync() in Exceptions.cs:200
  at Exception GetException(Action action) in ExceptionTests.cs:300
```

#### After fix (ref MethodBase — matches .NET StackTrace)

```
InvalidOperationException: Throwing async!
  at async Task MethodThatThrowsAsync() in Exceptions.cs:100
  at void ThrowFromAsync() in Exceptions.cs:200
  at Exception GetException(Action action) in ExceptionTests.cs:300
```


---
Please upvote :+1: this pull request if you are interested in it.