### PR TITLE
Allow wrapping of status text

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Live/Status/Render_LongText.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Live/Status/Render_LongText.Output.verified.txt
@@ -1,0 +1,9 @@
+﻿                                        
+* Building AppHost...                   
+  playground\HealthChecks\HealthChecksSa
+  ndbox.AppHost\AppHost.csproj          
+                                                                                
+* Building AppHost...                   
+  playground\HealthChecks\HealthChecksSa
+  ndbox.AppHost\AppHost.csproj          
+                                        

--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -3138,6 +3138,7 @@
         public TaskDescriptionColumn() { }
         public Spectre.Console.Justify Alignment { get; set; }
         protected override bool NoWrap { get; }
+        public bool Wrap { get; set; }
         public override Spectre.Console.Rendering.IRenderable Render(Spectre.Console.Rendering.RenderOptions options, Spectre.Console.ProgressTask task, System.TimeSpan deltaTime) { }
     }
     [System.Diagnostics.DebuggerDisplay("{_text,nq}")]

--- a/src/Spectre.Console.Tests/Unit/Live/StatusTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Live/StatusTests.cs
@@ -48,4 +48,29 @@ public sealed class StatusTests
         // Then
         return Verifier.Verify(console.Output);
     }
+
+    [Fact]
+    [Expectation("Render_LongText")]
+    [GitHubIssue("https://github.com/spectreconsole/spectre.console/issues/2152")]
+    public Task Should_Wrap_Status_Text_That_Exceeds_The_Console_Width()
+    {
+        // Given
+        var console = new TestConsole()
+            .Width(40)
+            .Interactive();
+
+        var status = new Status(console)
+        {
+            AutoRefresh = false,
+            Spinner = new DummySpinner1(),
+        };
+
+        // When
+        status.Start(
+            "Building AppHost... playground\\HealthChecks\\HealthChecksSandbox.AppHost\\AppHost.csproj",
+            ctx => ctx.Refresh());
+
+        // Then
+        return Verifier.Verify(console.Output);
+    }
 }

--- a/src/Spectre.Console/Live/Progress/Columns/TaskDescriptionColumn.cs
+++ b/src/Spectre.Console/Live/Progress/Columns/TaskDescriptionColumn.cs
@@ -6,7 +6,14 @@ namespace Spectre.Console;
 public sealed class TaskDescriptionColumn : ProgressColumn
 {
     /// <inheritdoc/>
-    protected internal override bool NoWrap => true;
+    protected internal override bool NoWrap => !Wrap;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the description should wrap
+    /// onto multiple lines when it's wider than the available space.
+    /// Defaults to <c>false</c>, which truncates the description with an ellipsis.
+    /// </summary>
+    public bool Wrap { get; set; }
 
     /// <summary>
     /// Gets or sets the alignment of the task description.
@@ -17,6 +24,8 @@ public sealed class TaskDescriptionColumn : ProgressColumn
     public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
     {
         var text = task.Description?.RemoveNewLines()?.Trim();
-        return new Markup(text ?? string.Empty).Overflow(Overflow.Ellipsis).Justify(Alignment);
+        return new Markup(text ?? string.Empty)
+            .Overflow(Wrap ? Overflow.Fold : Overflow.Ellipsis)
+            .Justify(Alignment);
     }
 }

--- a/src/Spectre.Console/Live/Status/Status.cs
+++ b/src/Spectre.Console/Live/Status/Status.cs
@@ -105,7 +105,11 @@ public sealed class Status
         progress.Columns(new ProgressColumn[]
         {
                 spinnerColumn,
-                new TaskDescriptionColumn(),
+                new TaskDescriptionColumn
+                {
+                    Wrap = true,
+                    Alignment = Justify.Left,
+                },
         });
 
         return await progress.StartAsync(async ctx =>


### PR DESCRIPTION
Fixes #2152

<!-- Formalities. These are not optional. -->

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have checked that there isn't already another pull request that solves the above issue
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors

## Changes

Wraps status text if text does not fit on a single line.