### PR TITLE
Fix infinite loop in TableMeasurer.CollapseWidths when wrappable columns have zero width (#2131)

### DIFF
--- a/src/Spectre.Console.Tests/Unit/Widgets/Table/TableTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Widgets/Table/TableTests.cs
@@ -1056,21 +1056,27 @@ public sealed class TableTests
 
     [Fact(Timeout = 3000)]
     [GitHubIssue("https://github.com/spectreconsole/spectre.console/issues/2131")]
-    public async Task CollapseWidths_Should_Terminate_When_Wrappable_Columns_Collapse_To_Zero()
+    public Task CollapseWidths_Should_Terminate_When_Wrappable_Columns_Collapse_To_Zero()
     {
-        // Given
-        var widths = new List<int> { 0, 0, 100 };
-        var wrappable = new List<bool> { true, true, false };
+        return Task.Run(() =>
+        {
+            // Given
+            var console = new TestConsole().Width(20);
+            var table = new Table().NoBorder();
 
-        var method = typeof(TableMeasurer).GetMethod(
-            "CollapseWidths",
-            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            var col1 = new TableColumn(string.Empty) { Padding = new Padding(0, 0, 0, 0) };
+            var col2 = new TableColumn(string.Empty) { Padding = new Padding(0, 0, 0, 0) };
+            var col3 = new TableColumn(string.Empty) { NoWrap = true, Width = 100, Padding = new Padding(0, 0, 0, 0) };
 
-        // When
-        var result = await Task.Run(() =>
-            (List<int>)method!.Invoke(null, new object[] { widths, wrappable, 5 })!);
+            table.AddColumn(col1);
+            table.AddColumn(col2);
+            table.AddColumn(col3);
 
-        // Then
-        result.ShouldAllBe(w => w >= 0);
+            // When
+            console.Write(table);
+
+            // Then
+            console.Output.ShouldNotBeNullOrEmpty();
+        });
     }
 }

--- a/src/Spectre.Console.Tests/Unit/Widgets/Table/TableTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Widgets/Table/TableTests.cs
@@ -1053,4 +1053,24 @@ public sealed class TableTests
         // Then
         return Verifier.Verify(console.Output);
     }
+
+    [Fact(Timeout = 3000)]
+    [GitHubIssue("https://github.com/spectreconsole/spectre.console/issues/2131")]
+    public async Task CollapseWidths_Should_Terminate_When_Wrappable_Columns_Collapse_To_Zero()
+    {
+        // Given
+        var widths = new List<int> { 0, 0, 100 };
+        var wrappable = new List<bool> { true, true, false };
+
+        var method = typeof(TableMeasurer).GetMethod(
+            "CollapseWidths",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        // When
+        var result = await Task.Run(() =>
+            (List<int>)method!.Invoke(null, new object[] { widths, wrappable, 5 })!);
+
+        // Then
+        result.ShouldAllBe(w => w >= 0);
+    }
 }

--- a/src/Spectre.Console/Widgets/Table/TableMeasurer.cs
+++ b/src/Spectre.Console/Widgets/Table/TableMeasurer.cs
@@ -183,11 +183,11 @@ internal sealed class TableMeasurer : TableAccessor
                     .Where(x => x.allowWrap)
                     .Max(x => x.width);
 
-                var secondMaxColumn = widths.Zip(wrappable, (width, allowWrap) => allowWrap && width != maxColumn ? width : 1).Max();
+                var secondMaxColumn = widths.Zip(wrappable, (width, allowWrap) => allowWrap && width != maxColumn ? width : 0).Max();
                 var columnDifference = maxColumn - secondMaxColumn;
 
                 var ratios = widths.Zip(wrappable, (width, allowWrap) => width == maxColumn && allowWrap ? 1 : 0).ToList();
-                if (!ratios.Any(x => x != 0) || columnDifference == 0)
+                if (!ratios.Any(x => x != 0) || columnDifference <= 0)
                 {
                     break;
                 }


### PR DESCRIPTION
This Pull Request resolves an infinite loop bug within TableMeasurer.CollapseWidths that occurs when one or more wrappable columns already have a width of 0 (e.g., via GetColumnWidth() returning 0 for hidden elements) while non-wrappable columns exceed the maximum console width. This edge case causes the layout engine to freeze, blocking the rendering thread indefinitely.
***

### Fixes #2131

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors
***
 
### Changes
The regression was rooted in the reduction loop calculation when maxColumn dropped to 0. The old logic fallback assigned a value of 1 to secondMaxColumn under certain conditions, yielding a negative columnDifference (0 - 1 = -1). Because the loop termination condition explicitly checked for columnDifference == 0, the negative value bypassed the check, keeping the while loop running forever since Ratio.Reduce cannot perform reductions with negative bounds.

To fully eliminate this lock vector, two changes were introduced to TableMeasurer.cs:
 1. Updated the loop break condition to columnDifference <= 0.
 2. Changed the conditional fallback value inside the secondMaxColumn selector from 1 to 0.
 ***

 Please upvote 👍 this pull request if you are interested in it.