### PR TITLE
add remove calendar event to CalendarExtensions

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -341,6 +341,10 @@
         public static Spectre.Console.Calendar HeaderStyle(this Spectre.Console.Calendar calendar, Spectre.Console.Style? style) { }
         public static Spectre.Console.Calendar HideHeader(this Spectre.Console.Calendar calendar) { }
         public static Spectre.Console.Calendar HighlightStyle(this Spectre.Console.Calendar calendar, Spectre.Console.Style? style) { }
+        public static Spectre.Console.Calendar RemoveCalendarEvent(this Spectre.Console.Calendar calendar, System.DateTime date) { }
+        public static Spectre.Console.Calendar RemoveCalendarEvent(this Spectre.Console.Calendar calendar, string description, System.DateTime date) { }
+        public static Spectre.Console.Calendar RemoveCalendarEvent(this Spectre.Console.Calendar calendar, int year, int month, int day) { }
+        public static Spectre.Console.Calendar RemoveCalendarEvent(this Spectre.Console.Calendar calendar, string description, int year, int month, int day) { }
         public static Spectre.Console.Calendar ShowHeader(this Spectre.Console.Calendar calendar) { }
     }
     public sealed class Canvas : Spectre.Console.Rendering.Renderable

--- a/src/Spectre.Console.Tests/Unit/Widgets/CalendarTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Widgets/CalendarTests.cs
@@ -97,4 +97,66 @@ public sealed class CalendarTests
         // Then
         return Verifier.Verify(console.Output);
     }
+
+    [Fact]
+    public void Should_Remove_Calendar_Event_By_Date()
+    {
+        // Given
+        var calendar = new Calendar(2020, 10)
+            .AddCalendarEvent(new DateTime(2020, 10, 3))
+            .AddCalendarEvent(new DateTime(2020, 10, 12));
+
+        // When
+        calendar.RemoveCalendarEvent(new DateTime(2020, 10, 3));
+
+        // Then
+        Assert.Single(calendar.CalendarEvents);
+        Assert.Equal(12, calendar.CalendarEvents[0].Day);
+    }
+
+    [Fact]
+    public void Should_Remove_Calendar_Event_By_Year_Month_Day()
+    {
+        // Given
+        var calendar = new Calendar(2020, 10)
+            .AddCalendarEvent(new DateTime(2020, 10, 3))
+            .AddCalendarEvent(new DateTime(2020, 10, 12));
+
+        // When
+        calendar.RemoveCalendarEvent(2020, 10, 3);
+
+        // Then
+        Assert.Single(calendar.CalendarEvents);
+        Assert.Equal(12, calendar.CalendarEvents[0].Day);
+    }
+
+    [Fact]
+    public void Should_Remove_Calendar_Event_By_Description_And_Date()
+    {
+        // Given
+        var calendar = new Calendar(2020, 10)
+            .AddCalendarEvent("Meeting", new DateTime(2020, 10, 3))
+            .AddCalendarEvent("Holiday", new DateTime(2020, 10, 12));
+
+        // When
+        calendar.RemoveCalendarEvent("Meeting", new DateTime(2020, 10, 3));
+
+        // Then
+        Assert.Single(calendar.CalendarEvents);
+        Assert.Equal(12, calendar.CalendarEvents[0].Day);
+    }
+
+    [Fact]
+    public void Should_Do_Nothing_When_Removing_Nonexistent_Calendar_Event()
+    {
+        // Given
+        var calendar = new Calendar(2020, 10)
+            .AddCalendarEvent(new DateTime(2020, 10, 3));
+
+        // When
+        calendar.RemoveCalendarEvent(new DateTime(2020, 11, 5));
+
+        // Then
+        Assert.Single(calendar.CalendarEvents);
+    }
 }

--- a/src/Spectre.Console/Widgets/Calendar.cs
+++ b/src/Spectre.Console/Widgets/Calendar.cs
@@ -378,4 +378,67 @@ public static class CalendarExtensions
         calendar.ShowHeader = false;
         return calendar;
     }
+
+    /// <summary>
+    /// Removes a calendar event.
+    /// </summary>
+    /// <param name="calendar">The calendar to remove the calendar event from.</param>
+    /// <param name="date">The calendar event date.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Calendar RemoveCalendarEvent(this Calendar calendar, DateTime date)
+    {
+        return RemoveCalendarEvent(calendar, string.Empty, date.Year, date.Month, date.Day);
+    }
+
+    /// <summary>
+    /// Removes a calendar event.
+    /// </summary>
+    /// <param name="calendar">The calendar to remove the calendar event from.</param>
+    /// <param name="description">The calendar event description.</param>
+    /// <param name="date">The calendar event date.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Calendar RemoveCalendarEvent(this Calendar calendar, string description, DateTime date)
+    {
+        return RemoveCalendarEvent(calendar, description, date.Year, date.Month, date.Day);
+    }
+
+    /// <summary>
+    /// Removes a calendar event.
+    /// </summary>
+    /// <param name="calendar">The calendar to remove the calendar event from.</param>
+    /// <param name="year">The year of the calendar event.</param>
+    /// <param name="month">The month of the calendar event.</param>
+    /// <param name="day">The day of the calendar event.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Calendar RemoveCalendarEvent(this Calendar calendar, int year, int month, int day)
+    {
+        return RemoveCalendarEvent(calendar, string.Empty, year, month, day);
+    }
+
+    /// <summary>
+    /// Removes a calendar event.
+    /// </summary>
+    /// <param name="calendar">The calendar.</param>
+    /// <param name="description">The calendar event description.</param>
+    /// <param name="year">The year of the calendar event.</param>
+    /// <param name="month">The month of the calendar event.</param>
+    /// <param name="day">The day of the calendar event.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static Calendar RemoveCalendarEvent(this Calendar calendar, string description, int year, int month, int day)
+    {
+        ArgumentNullException.ThrowIfNull(calendar);
+
+        var calendarEvent = calendar.CalendarEvents
+            .FirstOrDefault(e => e.Description == description
+                                 && e.Year == year
+                                 && e.Month == month
+                                 && e.Day == day);
+
+        if (calendarEvent != null)
+        {
+            calendar.CalendarEvents.Remove(calendarEvent);
+        }
+
+        return calendar;
+    }
 }


### PR DESCRIPTION
Fixes #1962 

- [X] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [X] I have checked that there isn't already another pull request that solves the above issue
- [X] All newly added code is adequately covered by tests
- [X] All existing tests are still running without errors

## Changes
This change was previously proposed in https://github.com/spectreconsole/spectre.console/pull/2062 but was closed without merging because of formality reasons (original PR didn't use PR template).
This PR reintroduces the same feature on top of the current codebase.

 - Added 4 overloads of RemoveCalendarEvent to CalendarExtensions in Calendar.cs:
   1. RemoveCalendarEvent(DateTime date)
   2. RemoveCalendarEvent(string description, DateTime date)
   3. RemoveCalendarEvent(int year, int month, int day)
   4. RemoveCalendarEvent(string description, int year, int month, int day)
- Added 4 unit tests covering removal by date, by year/month/day, by description, and no-op when event doesn't exist
---
Please upvote :+1: this pull request if you are interested in it.