### PR TITLE
fix: Validate max value in ProgressTask to ensure it is zero or greater

### DIFF
--- a/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
@@ -139,6 +139,57 @@ public sealed class ProgressTests
     }
 
     [Fact]
+    public void Adding_Task_With_Negative_Max_Value_Should_Throw()
+    {
+        // Given
+        var console = new TestConsole()
+            .Interactive();
+
+        var progress = new Progress(console)
+            .Columns(new ProgressBarColumn())
+            .AutoRefresh(false)
+            .AutoClear(false);
+
+        // When
+        var exception = Record.Exception(() =>
+        {
+            progress.Start(ctx =>
+            {
+                ctx.AddTask("foo", maxValue: -1);
+            });
+        });
+
+        // Then
+        exception.ShouldBeOfType<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void Setting_Max_Value_To_Negative_Value_Should_Throw()
+    {
+        // Given
+        var console = new TestConsole()
+            .Interactive();
+
+        var progress = new Progress(console)
+            .Columns(new ProgressBarColumn())
+            .AutoRefresh(false)
+            .AutoClear(false);
+
+        // When
+        var exception = Record.Exception(() =>
+        {
+            progress.Start(ctx =>
+            {
+                var task = ctx.AddTask("foo");
+                task.MaxValue = -1;
+            });
+        });
+
+        // Then
+        exception.ShouldBeOfType<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
     public void Setting_Value_Should_Override_Incremented_Value()
     {
         // Given

--- a/src/Spectre.Console/Live/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Live/Progress/ProgressTask.cs
@@ -137,6 +137,11 @@ public sealed class ProgressTask : IProgress<double>
         _description = description?.RemoveNewLines()?.Trim() ??
                        throw new ArgumentNullException(nameof(description));
 
+        if (_maxValue < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxValue), "Max value must be zero or greater.");
+        }
+
         if (string.IsNullOrWhiteSpace(_description))
         {
             throw new ArgumentException("Task name cannot be empty", nameof(description));
@@ -221,6 +226,11 @@ public sealed class ProgressTask : IProgress<double>
 
             if (maxValue != null)
             {
+                if (maxValue.Value < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(maxValue), "Max value must be zero or greater.");
+                }
+
                 _maxValue = maxValue.Value;
             }
 


### PR DESCRIPTION
Fixes #2167 

<!-- Formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

<!-- 
If you have used generative AI to create this pull request, you will need to disclose this here,
i.e. What AI agent you used and to what extent.
-->

## Changes
This change puts maxValue validation in ProgressTask at the exact points where invalid values can enter task state, so the invariant is enforced centrally instead of at call sites.

Constructor guard in ProgressTask.cs:142: validates initial maxValue when a task is created. This covers all AddTask overloads because they all flow into ProgressTask construction through ProgressContext internals.
Update-path guard in ProgressTask.cs:231: validates later changes via task.MaxValue setter, which routes through Update(maxValue: ...). This prevents a task from becoming invalid after successful creation.
Regression tests in ProgressTests.cs:142 and ProgressTests.cs:167: one test verifies creation-time rejection (ctx.AddTask(..., maxValue: -1)), and one verifies mutation-time rejection (task.MaxValue = -1), so both entry points are locked down.
Putting validation in these two locations ensures consistent runtime behavior for every API path without duplicating checks across ProgressContext overloads or user call sites.

---
Please upvote :+1: this pull request if you are interested in it.