### PR TITLE
fix(TextPrompt): prevent ArgumentOutOfRangeException for non-ASCII default values

### DIFF
--- a/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/TextPromptTests.cs
@@ -53,6 +53,23 @@ public sealed class TextPromptTests
     }
 
     [Fact]
+    public void Should_Not_Throw_When_Editable_Default_Value_Contains_Non_Ascii_Characters()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        // When
+        var result = console.Prompt(
+            new TextPrompt<string>("Language?")
+                .DefaultValue("日本語")
+                .EditableDefaultValue(true));
+
+        // Then
+        result.ShouldBe("日本語");
+    }
+
+    [Fact]
     [Expectation("InvalidChoice")]
     public Task Should_Return_Error_If_An_Invalid_Choice_Is_Made()
     {

--- a/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
+++ b/src/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
@@ -22,7 +22,8 @@ public static partial class AnsiConsoleExtensions
             foreach (var ch in initialInput)
             {
                 var control = char.IsUpper(ch);
-                injectedQueue.Enqueue(new ConsoleKeyInfo(ch, (ConsoleKey)ch, false, false, control));
+                var key = (int)ch <= 255 ? (ConsoleKey)ch : (ConsoleKey)0;
+                injectedQueue.Enqueue(new ConsoleKeyInfo(ch, key, false, false, control));
             }
         }
 


### PR DESCRIPTION
Fixes #2152

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

## Changes

### Problem
When using `TextPrompt` with `EditableDefaultValue(true)` containing non-ASCII or Unicode characters (e.g. `"日本語"` or `"ä"`), `AnsiConsoleExtensions.Input.cs` passed `(ConsoleKey)ch` to `ConsoleKeyInfo`, which throws `ArgumentOutOfRangeException` in .NET when `ConsoleKey > 255`.

### Solution
1. Updated `AnsiConsoleExtensions.Input.cs` to check `(int)ch <= 255 ? (ConsoleKey)ch : (ConsoleKey)0`, preventing out-of-range exceptions while maintaining full Unicode string processing.
2. Added unit test `Should_Not_Throw_When_Editable_Default_Value_Contains_Non_Ascii_Characters` in `TextPromptTests.cs`.