### PR TITLE
Support disabled items in SelectionPrompt<T>

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -2242,6 +2242,12 @@
         bool NoWrap { get; set; }
         int? Width { get; set; }
     }
+    public interface IDisableableSelectionItem<T> : Spectre.Console.ISelectionItem<T>
+        where T :  notnull
+    {
+        bool IsDisabled { get; }
+        Spectre.Console.IDisableableSelectionItem<T> Disable();
+    }
     public interface IExclusivityMode
     {
         T Run<T>(System.Func<T> func);
@@ -2769,6 +2775,11 @@
     {
         public static Spectre.Console.Rule RuleStyle(this Spectre.Console.Rule rule, Spectre.Console.Style style) { }
         public static Spectre.Console.Rule RuleTitle(this Spectre.Console.Rule rule, string title) { }
+    }
+    public static class SelectionItemExtensions
+    {
+        public static Spectre.Console.ISelectionItem<T> Disable<T>(this Spectre.Console.ISelectionItem<T> item)
+            where T :  notnull { }
     }
     public enum SelectionMode
     {

--- a/src/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Prompts/SelectionPromptTests.cs
@@ -642,6 +642,95 @@ public sealed class SelectionPromptTests
     }
 
     [Fact]
+    public void Should_Skip_Disabled_Item_When_Navigating_Down()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.DownArrow);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        var prompt = new SelectionPrompt<string>().Title("Select one");
+        prompt.AddChoice("First");
+        prompt.AddChoice("Second").Disable();
+        prompt.AddChoice("Third");
+
+        // When
+        var selection = prompt.Show(console);
+
+        // Then
+        selection.ShouldBe("Third");
+    }
+
+    [Fact]
+    public void Should_Skip_Disabled_Item_When_Navigating_Up_With_WrapAround()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.UpArrow);
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        var prompt = new SelectionPrompt<string>().Title("Select one").WrapAround();
+        prompt.AddChoice("First");
+        prompt.AddChoice("Second");
+        prompt.AddChoice("Third").Disable();
+
+        // When
+        var selection = prompt.Show(console);
+
+        // Then
+        selection.ShouldBe("Second");
+    }
+
+    [Fact]
+    public void Should_Not_Search_Match_A_Disabled_Item()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushText("Del");
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        var prompt = new SelectionPrompt<string>().Title("Select one").EnableSearch();
+        prompt.AddChoice("Zeta");
+        prompt.AddChoice("Delta").Disable();
+        prompt.AddChoice("Della");
+
+        // When
+        var selection = prompt.Show(console);
+
+        // Then
+        selection.ShouldBe("Della");
+    }
+
+    [Fact]
+    public void Should_Fall_Back_To_First_Enabled_Item_When_Default_Value_Is_Disabled()
+    {
+        // Given
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        console.Input.PushKey(ConsoleKey.Enter);
+
+        var prompt = new SelectionPrompt<string>().Title("Select one").DefaultValue("Second");
+        prompt.AddChoice("First");
+        prompt.AddChoice("Second").Disable();
+        prompt.AddChoice("Third");
+
+        // When
+        prompt.Show(console);
+
+        // Then
+        console.Lines.ShouldBe([
+            "Select one",
+            "          ",
+            "> First   ",
+            "  Second  ",
+            "  Third   ",
+        ]);
+    }
+
+    [Fact]
     public void Should_Initially_Select_The_First_Leaf_When_Skipping_Unselectable_Items_And_Default_Value_Is_Not_Leaf() {
         // Given
         var console = new TestConsole();

--- a/src/Spectre.Console/Prompts/IDisableableSelectionItem.cs
+++ b/src/Spectre.Console/Prompts/IDisableableSelectionItem.cs
@@ -1,0 +1,21 @@
+namespace Spectre.Console;
+
+/// <summary>
+/// Represents a selection item that can be disabled.
+/// A disabled item is rendered with the prompt's disabled style and cannot be navigated to or selected.
+/// </summary>
+/// <typeparam name="T">The data type.</typeparam>
+public interface IDisableableSelectionItem<T> : ISelectionItem<T>
+    where T : notnull
+{
+    /// <summary>
+    /// Gets a value indicating whether or not this item is disabled.
+    /// </summary>
+    bool IsDisabled { get; }
+
+    /// <summary>
+    /// Disables the item.
+    /// </summary>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    IDisableableSelectionItem<T> Disable();
+}

--- a/src/Spectre.Console/Prompts/List/ListPromptItem.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptItem.cs
@@ -1,6 +1,6 @@
 namespace Spectre.Console;
 
-internal sealed class ListPromptItem<T> : IMultiSelectionItem<T>
+internal sealed class ListPromptItem<T> : IMultiSelectionItem<T>, IDisableableSelectionItem<T>
     where T : notnull
 {
     public T Data { get; }
@@ -8,6 +8,7 @@ internal sealed class ListPromptItem<T> : IMultiSelectionItem<T>
     public List<ListPromptItem<T>> Children { get; }
     public int Depth { get; }
     public bool IsSelected { get; set; }
+    public bool IsDisabled { get; set; }
 
     public bool IsGroup => Children.Count > 0;
 
@@ -22,6 +23,12 @@ internal sealed class ListPromptItem<T> : IMultiSelectionItem<T>
     public IMultiSelectionItem<T> Select()
     {
         IsSelected = true;
+        return this;
+    }
+
+    public IDisableableSelectionItem<T> Disable()
+    {
+        IsDisabled = true;
         return this;
     }
 

--- a/src/Spectre.Console/Prompts/List/ListPromptState.cs
+++ b/src/Spectre.Console/Prompts/List/ListPromptState.cs
@@ -42,7 +42,7 @@ internal sealed class ListPromptState<T>
             _leafIndexes =
                 Items
                     .Select((item, index) => new { item, index })
-                    .Where(x => !x.item.IsGroup)
+                    .Where(x => !x.item.IsGroup && !x.item.IsDisabled)
                     .Select(x => x.index)
                     .ToList()
                     .AsReadOnly();
@@ -142,7 +142,8 @@ internal sealed class ListPromptState<T>
 
                 var item = Items.FirstOrDefault(x =>
                     _converter.Invoke(x.Data).Contains(search, StringComparison.OrdinalIgnoreCase)
-                    && (!x.IsGroup || Mode != SelectionMode.Leaf));
+                    && (!x.IsGroup || Mode != SelectionMode.Leaf)
+                    && !x.IsDisabled);
 
                 if (item != null)
                 {
@@ -159,7 +160,8 @@ internal sealed class ListPromptState<T>
 
                 var item = Items.FirstOrDefault(x =>
                     _converter.Invoke(x.Data).Contains(search, StringComparison.OrdinalIgnoreCase) &&
-                    (!x.IsGroup || Mode != SelectionMode.Leaf));
+                    (!x.IsGroup || Mode != SelectionMode.Leaf) &&
+                    !x.IsDisabled);
 
                 if (item != null)
                 {

--- a/src/Spectre.Console/Prompts/SelectionItemExtensions.cs
+++ b/src/Spectre.Console/Prompts/SelectionItemExtensions.cs
@@ -1,0 +1,24 @@
+namespace Spectre.Console;
+
+/// <summary>
+/// Contains extension methods for <see cref="ISelectionItem{T}"/>.
+/// </summary>
+public static class SelectionItemExtensions
+{
+    /// <summary>
+    /// Disables the item, if it supports being disabled.
+    /// </summary>
+    /// <typeparam name="T">The data type.</typeparam>
+    /// <param name="item">The item to disable.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static ISelectionItem<T> Disable<T>(this ISelectionItem<T> item)
+        where T : notnull
+    {
+        if (item is IDisableableSelectionItem<T> disableable)
+        {
+            disableable.Disable();
+        }
+
+        return item;
+    }
+}

--- a/src/Spectre.Console/Prompts/SelectionPrompt.cs
+++ b/src/Spectre.Console/Prompts/SelectionPrompt.cs
@@ -139,6 +139,11 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
                 return ListPromptInputResult.None;
             }
 
+            if (state.Current.IsDisabled)
+            {
+                return ListPromptInputResult.None;
+            }
+
             return ListPromptInputResult.Submit;
         }
 
@@ -211,7 +216,7 @@ public sealed class SelectionPrompt<T> : IPrompt<T>, IListPromptStrategy<T>
         {
             var current = item.Index == cursorIndex;
             var prompt = item.Index == cursorIndex ? ListPromptConstants.Arrow : new string(' ', ListPromptConstants.Arrow.Length);
-            var style = item.Node.IsGroup && Mode == SelectionMode.Leaf
+            var style = (item.Node.IsGroup && Mode == SelectionMode.Leaf) || item.Node.IsDisabled
                 ? disabledStyle
                 : current ? highlightStyle : Style.Plain;
 


### PR DESCRIPTION
Closes #2180.

Adds `IDisableableSelectionItem<T>`, a separate opt-in interface rather than new members on `ISelectionItem<T>` directly, so it stays additive on every target framework (including `netstandard2.0`, which can't represent default interface implementations). `ListPromptItem<T>` implements it alongside `IMultiSelectionItem<T>`, and a `SelectionItemExtensions.Disable()` extension keeps the call site unchanged:

```csharp
prompt.AddChoice("Fireball").Disable();
```

A disabled item is styled with `DisabledStyle` and skipped during arrow-key navigation, search, and default-value selection, the same way group headers already are in `Mode.Leaf`.

Opening as a draft since I haven't heard back on the issue write-up yet, happy to take feedback on the API shape before marking ready.

## Test plan
- [x] Builds clean across all four target frameworks (net8.0/net9.0/net10.0/netstandard2.0)
- [x] Existing test suite passes (756/756)
- [x] New tests added covering navigation skip, wrap-around skip, search exclusion, and default-value fallback for disabled items