### PR TITLE
fix: IsFinished should return false when a task has not started

### DIFF
--- a/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
@@ -727,4 +727,100 @@ public sealed class ProgressTests
                 "          \n" + // Bottom padding
                 "\e[?25h"); // show cursor
     }
+
+    [Fact]
+    public void IsFinished_Should_Be_True_When_No_Tasks_Exist()
+    {
+        // Given
+        var console = new TestConsole().Interactive();
+        var progress = new Progress(console)
+            .Columns(new ProgressBarColumn())
+            .AutoRefresh(false)
+            .AutoClear(false);
+
+        var result = false;
+
+        // When
+        progress.Start(ctx =>
+        {
+            result = ctx.IsFinished;
+        });
+
+        // Then
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFinished_Should_Be_False_When_Task_Has_Not_Started()
+    {
+        // Given
+        var console = new TestConsole().Interactive();
+        var progress = new Progress(console)
+            .Columns(new ProgressBarColumn())
+            .AutoRefresh(false)
+            .AutoClear(false);
+
+        var result = false;
+
+        // When
+        progress.Start(ctx =>
+        {
+            ctx.AddTask("foo", autoStart: false);
+            result = ctx.IsFinished;
+        });
+
+        // Then
+        result.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void IsFinished_Should_Be_True_When_Task_Has_Started_And_Finished()
+    {
+        // Given
+        var console = new TestConsole().Interactive();
+        var progress = new Progress(console)
+            .Columns(new ProgressBarColumn())
+            .AutoRefresh(false)
+            .AutoClear(false);
+
+        var result = false;
+
+        // When
+        progress.Start(ctx =>
+        {
+            var task = ctx.AddTask("foo");
+            task.Value = task.MaxValue;
+            result = ctx.IsFinished;
+        });
+
+        // Then
+        result.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void IsFinished_Should_Be_False_When_One_Of_Multiple_Tasks_Has_Not_Started()
+    {
+        // Given
+        var console = new TestConsole().Interactive();
+        var progress = new Progress(console)
+            .Columns(new ProgressBarColumn())
+            .AutoRefresh(false)
+            .AutoClear(false);
+
+        var result = false;
+
+        // When
+        progress.Start(ctx =>
+        {
+            var started = ctx.AddTask("foo");
+            started.Value = started.MaxValue;
+
+            ctx.AddTask("bar", autoStart: false);
+
+            result = ctx.IsFinished;
+        });
+
+        // Then
+        result.ShouldBeFalse();
+    }
 }

--- a/src/Spectre.Console/Live/Progress/ProgressContext.cs
+++ b/src/Spectre.Console/Live/Progress/ProgressContext.cs
@@ -13,7 +13,8 @@ public sealed class ProgressContext
     private int _taskId;
 
     /// <summary>
-    /// Gets a value indicating whether or not all started tasks have completed.
+    /// Gets a value indicating whether or not all tasks have completed.
+    /// A task that has not been started yet is considered not finished.
     /// </summary>
     public bool IsFinished
     {
@@ -21,7 +22,12 @@ public sealed class ProgressContext
         {
             lock (_taskLock)
             {
-                return _tasks.Where(x => x.IsStarted).All(task => task.IsFinished);
+                if (_tasks.Count == 0)
+                {
+                    return true;
+                }
+
+                return _tasks.All(task => task.IsFinished);
             }
         }
     }


### PR DESCRIPTION
Fixes #2182

- [x] I have read the Contribution Guidelines
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

## Changes

`ProgressContext.IsFinished` previously used `_tasks.Where(x => x.IsStarted).All(task => task.IsFinished)`. When no task in the context had started yet (for example, tasks created with `autoStart: false`), `Where(...)` produced an empty sequence, and `.All()` on an empty sequence always returns `true` (vacuous truth). This caused `IsFinished` to report `true` even though no work had actually run, silently breaking the common `while (!ctx.IsFinished)` usage pattern.

- `ProgressContext.cs`: `IsFinished` now returns `true` only when there are no tasks in the context, or when every task's own `IsFinished` is `true`. Since `ProgressTask.IsFinished` is `false` for any task that hasn't reached its `MaxValue` (including one that hasn't started), this naturally treats "not started" as "not finished" without needing a separate `IsStarted` check.
- `ProgressTests.cs`: added four regression tests covering: no tasks in the context, a single task with `autoStart: false`, a task that has started and finished, and a mix of one finished task alongside one not-started task.

---

Please upvote 👍 this pull request if you are interested in it.