### PR TITLE
Add IncrementMaxValue method to ProgressTask (fixes #1893)

### DIFF
--- a/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
+++ b/src/Spectre.Console.Tests/Expectations/Public_API.Output.verified.txt
@@ -2681,6 +2681,7 @@
         public object? Tag { get; set; }
         public double Value { get; set; }
         public void Increment(double value) { }
+        public void IncrementMaxValue(double value) { }
         public void StartTask() { }
         public void StopTask() { }
     }
@@ -2688,6 +2689,7 @@
     {
         public static Spectre.Console.ProgressTask Description(this Spectre.Console.ProgressTask task, string description) { }
         public static Spectre.Console.ProgressTask HideWhenCompleted(this Spectre.Console.ProgressTask task, bool hideWhenCompleted = true) { }
+        public static Spectre.Console.ProgressTask IncrementMaxValue(this Spectre.Console.ProgressTask task, double value) { }
         public static Spectre.Console.ProgressTask IsIndeterminate(this Spectre.Console.ProgressTask task, bool indeterminate = true) { }
         public static Spectre.Console.ProgressTask MaxValue(this Spectre.Console.ProgressTask task, double value) { }
         public static Spectre.Console.ProgressTask Tag(this Spectre.Console.ProgressTask task, object? tag) { }

--- a/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
+++ b/src/Spectre.Console.Tests/Unit/Live/Progress/ProgressTests.cs
@@ -727,4 +727,17 @@ public sealed class ProgressTests
                 "          \n" + // Bottom padding
                 "\e[?25h"); // show cursor
     }
+
+    [Fact]
+    public void Should_Increment_Max_Value()
+    {
+        // Given
+        var task = new ProgressTask(1, "Test", 100);
+
+        // When
+        task.IncrementMaxValue(50);
+
+        // Then
+        task.MaxValue.ShouldBe(150);
+    }
 }

--- a/src/Spectre.Console/Live/Progress/ProgressTask.cs
+++ b/src/Spectre.Console/Live/Progress/ProgressTask.cs
@@ -187,6 +187,15 @@ public sealed class ProgressTask : IProgress<double>
     }
 
     /// <summary>
+    /// Increments the task's max value in a thread-safe manner.
+    /// </summary>
+    /// <param name="value">The value to increment the max value with.</param>
+    public void IncrementMaxValue(double value)
+    {
+        Update(incrementMaxValue: value);
+    }
+
+    /// <summary>
     /// Gets or sets the maximum age of samples kept for calculating speed and estimated time remaining.
     /// Samples older than this value are discarded to more accurately reflect the current speed.
     /// </summary>
@@ -200,6 +209,7 @@ public sealed class ProgressTask : IProgress<double>
 
     private void Update(
         string? description = null,
+        double? incrementMaxValue = null,
         double? maxValue = null,
         double? increment = null,
         double? value = null)
@@ -217,6 +227,11 @@ public sealed class ProgressTask : IProgress<double>
                 }
 
                 _description = description;
+            }
+
+            if (incrementMaxValue != null)
+            {
+                _maxValue += incrementMaxValue.Value;
             }
 
             if (maxValue != null)
@@ -398,6 +413,20 @@ public static class ProgressTaskExtensions
         ArgumentNullException.ThrowIfNull(task);
 
         task.MaxValue = value;
+        return task;
+    }
+
+    /// <summary>
+    /// Increments the max value of the task.
+    /// </summary>
+    /// <param name="task">The task.</param>
+    /// <param name="value">The amount to increment the max value by.</param>
+    /// <returns>The same instance so that multiple calls can be chained.</returns>
+    public static ProgressTask IncrementMaxValue(this ProgressTask task, double value)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+
+        task.IncrementMaxValue(value);
         return task;
     }
 


### PR DESCRIPTION
Fixes #1893

<!-- Formalities. These are not optional. -->

- [x] I have read the [Contribution Guidelines](https://github.com/spectreconsole/spectre.console/blob/main/CONTRIBUTING.md)
- [x] I have checked that there isn't already another pull request that solves the above issue
- [x] All newly added code is adequately covered by tests
- [x] All existing tests are still running without errors

Assisted by AI (Gemini) for implementation guidance and unit test drafting.

## Changes

- Added `IncrementMaxValue` method to `ProgressTask` to allow thread-safe updates to the task's maximum value.
- Updated the internal `Update` method to safely modify `_maxValue` within the lock.
- Added fluent extension method `IncrementMaxValue` to `ProgressTaskExtensions`.
- Added unit tests in `ProgressTests.cs` verifying `IncrementMaxValue` behavior.